### PR TITLE
fix(atlassian): support Server / Data Center deployments alongside Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ That's it. Your agent now has a persistent, structured knowledge base.
 | **Multi-Level Indexes** | Auto-generated `index.md` at every directory level — nested topic hierarchies with sub-topic navigation |
 | **Self-Checking Lint** | Catches contradictions, broken links, orphan pages, stale content |
 | **Coverage Report** | `raw_coverage` tells the agent which raw sources have not yet been compiled into any wiki page — drives active knowledge completion |
-| **Atlassian Import** | One-command Confluence pages and Jira issues with full hierarchy |
+| **Atlassian Import** | One-command Confluence pages and Jira issues with full hierarchy. Supports both Atlassian Cloud (`*.atlassian.net`) and self-hosted Server / Data Center, with auto-routed API endpoints and Bearer / Basic auth handling. |
 | **File Versioning** | Auto-version same-name files, query latest, list all versions |
 | **COBOL Code Analysis** | AST parser handling fixed-format (with mainframe alphanumeric sequence areas) and free-format. Extracts CALL/PERFORM/COPY structure, LINKAGE SECTION, EXEC SQL, EXEC CICS, and file access modes. Cross-file knowledge graph with depth-bounded impact queries. Three field-lineage families: shared-copybook reuse, `CALL ... USING` boundary flow, and cross-program data flow via shared DB2 tables. |
 | **Skill Install** | One-command install as native skill for Claude Code and compatible clients |

--- a/src/atlassian.ts
+++ b/src/atlassian.ts
@@ -79,19 +79,23 @@ export function resolveAuth(authEnv: string): string {
   const value = process.env[authEnv];
   if (!value) {
     throw new Error(
-      `Environment variable "${authEnv}" is not set. ` +
-        `Set it to "email:api-token" for Atlassian Cloud authentication.`
+      `Environment variable "${authEnv}" is not set. Set it to one of:\n` +
+        `  - "email:api-token"  (Atlassian Cloud Basic auth — auto-encoded)\n` +
+        `  - "Bearer <pat>"     (Server / Data Center, explicit prefix)\n` +
+        `  - "<pat>"            (Server / Data Center, bare PAT — Bearer added automatically)\n` +
+        `Pass a different env var name via the tool's authEnv parameter if your deployment uses a custom convention.`
     );
   }
-  // If it looks like email:token, auto-encode as Basic auth
-  if (
-    value.includes(":") &&
-    !value.startsWith("Basic ") &&
-    !value.startsWith("Bearer ")
-  ) {
+  // Already prefixed — pass through verbatim.
+  if (value.startsWith("Basic ") || value.startsWith("Bearer ")) {
+    return value;
+  }
+  // email:token shape → Cloud Basic auth.
+  if (value.includes(":")) {
     return `Basic ${Buffer.from(value).toString("base64")}`;
   }
-  return value;
+  // Bare token (no colon, no prefix) → Server / DC Bearer convention.
+  return `Bearer ${value}`;
 }
 
 export function validateHost(host: string, allowed: string[]): void {
@@ -130,39 +134,66 @@ function writeMeta(filePath: string, meta: RawMeta): void {
 //  CONFLUENCE
 // ═══════════════════════════════════════════════════════════════
 
+export type AtlassianDeployment = "cloud" | "server";
+
 export function parseConfluenceUrl(
   url: string
-): { host: string; pageId: string } {
-  const match = url.match(/https?:\/\/([^/]+)\/wiki\/.*?pages\/(\d+)/);
-  if (!match) {
-    throw new Error(
-      `Cannot parse Confluence URL: "${url}". ` +
-        `Expected: https://company.atlassian.net/wiki/spaces/SPACE/pages/12345/...`
-    );
+): { host: string; pageId: string; deployment: AtlassianDeployment } {
+  // Cloud: https://{host}/wiki/spaces/SPACE/pages/12345/...
+  const cloudMatch = url.match(/https?:\/\/([^/]+)\/wiki\/.*?pages\/(\d+)/);
+  if (cloudMatch) {
+    return { host: cloudMatch[1]!, pageId: cloudMatch[2]!, deployment: "cloud" };
   }
-  return { host: match[1]!, pageId: match[2]! };
+  // Server / Data Center: https://{host}/spaces/SPACE/pages/12345/...
+  // (no `/wiki/` segment; everything else identical)
+  const serverMatch = url.match(/https?:\/\/([^/]+)\/(?!wiki\/).*?pages\/(\d+)/);
+  if (serverMatch) {
+    return { host: serverMatch[1]!, pageId: serverMatch[2]!, deployment: "server" };
+  }
+  throw new Error(
+    `Cannot parse Confluence URL: "${url}". ` +
+      `Expected one of:\n` +
+      `  - Cloud:  https://company.atlassian.net/wiki/spaces/SPACE/pages/12345/...\n` +
+      `  - Server: https://confluence.example.com/spaces/SPACE/pages/12345/...`
+  );
 }
 
-export async function confluenceImport(
-  url: string,
-  rawDir: string,
-  config: AtlassianConfig,
-  opts: {
-    recursive?: boolean;
-    depth?: number;
-    authEnv?: string;
-  } = {}
-): Promise<ConfluenceImportResult> {
-  const { host, pageId } = parseConfluenceUrl(url);
-  validateHost(host, config.allowedHosts);
+/**
+ * Internal normalized shape — same regardless of Cloud vs Server / DC origin.
+ * Platform-specific clients below project their respective response schemas
+ * into these types so the rest of confluenceImport can stay platform-agnostic.
+ */
+interface NormalizedConfluencePage {
+  id: string;
+  title: string;
+  html: string;
+}
+interface NormalizedConfluenceAttachment {
+  title: string;
+  downloadLink: string;
+  mediaType: string;
+  fileSize: number;
+}
+interface NormalizedConfluenceChild {
+  id: string;
+  title: string;
+}
 
-  const authHeader = resolveAuth(opts.authEnv ?? "CONFLUENCE_API_TOKEN");
-  const maxDepth = opts.depth ?? (opts.recursive ? 50 : 0);
-  const baseApi = `https://${host}/wiki/api/v2`;
-  const files: string[] = [];
-  let pageCount = 0;
+interface ConfluenceClient {
+  getPage(pid: string): Promise<NormalizedConfluencePage>;
+  getAttachments(pid: string): Promise<NormalizedConfluenceAttachment[]>;
+  getChildren(pid: string): Promise<NormalizedConfluenceChild[]>;
+}
 
-  // ── API helpers ──
+function buildConfluenceClient(
+  host: string,
+  deployment: AtlassianDeployment,
+  authHeader: string,
+): ConfluenceClient {
+  const baseApi =
+    deployment === "cloud"
+      ? `https://${host}/wiki/api/v2`
+      : `https://${host}/rest/api`;
 
   async function api(endpoint: string): Promise<any> {
     const resp = await fetch(`${baseApi}${endpoint}`, {
@@ -181,41 +212,130 @@ export async function confluenceImport(
     return resp.json();
   }
 
-  async function getPage(
-    pid: string
-  ): Promise<{ id: string; title: string; spaceId?: string; html: string }> {
-    const data = await api(`/pages/${pid}?body-format=storage`);
+  if (deployment === "cloud") {
     return {
-      id: data.id,
-      title: data.title,
-      spaceId: data.spaceId,
-      html: data.body?.storage?.value ?? "",
+      async getPage(pid) {
+        const data = await api(`/pages/${pid}?body-format=storage`);
+        return {
+          id: data.id,
+          title: data.title,
+          html: data.body?.storage?.value ?? "",
+        };
+      },
+      async getAttachments(pid) {
+        const results: NormalizedConfluenceAttachment[] = [];
+        let cursor: string | null = null;
+        do {
+          const qs = cursor ? `?limit=50&cursor=${cursor}` : "?limit=50";
+          const data = await api(`/pages/${pid}/attachments${qs}`);
+          for (const r of data.results ?? []) {
+            results.push({
+              title: r.title ?? r.id,
+              downloadLink: r._links?.download ? `https://${host}/wiki${r._links.download}` : "",
+              mediaType: r.mediaType ?? "application/octet-stream",
+              fileSize: r.fileSize ?? 0,
+            });
+          }
+          const nextLink: string | undefined = data._links?.next;
+          cursor = nextLink
+            ? new URL(nextLink, baseApi).searchParams.get("cursor")
+            : null;
+        } while (cursor);
+        return results;
+      },
+      async getChildren(pid) {
+        const results: NormalizedConfluenceChild[] = [];
+        let cursor: string | null = null;
+        do {
+          const qs = cursor ? `?limit=50&cursor=${cursor}` : "?limit=50";
+          const data = await api(`/pages/${pid}/children/page${qs}`);
+          for (const r of data.results ?? []) {
+            results.push({ id: r.id, title: r.title });
+          }
+          const nextLink: string | undefined = data._links?.next;
+          cursor = nextLink
+            ? new URL(nextLink, baseApi).searchParams.get("cursor")
+            : null;
+        } while (cursor);
+        return results;
+      },
     };
   }
 
-  async function getAttachments(
-    pid: string
-  ): Promise<Array<{ title: string; downloadLink: string; mediaType: string; fileSize: number }>> {
-    const results: Array<{ title: string; downloadLink: string; mediaType: string; fileSize: number }> = [];
-    let cursor: string | null = null;
-    do {
-      const qs = cursor ? `?limit=50&cursor=${cursor}` : "?limit=50";
-      const data = await api(`/pages/${pid}/attachments${qs}`);
-      for (const r of data.results ?? []) {
-        results.push({
-          title: r.title ?? r.id,
-          downloadLink: r._links?.download ? `https://${host}/wiki${r._links.download}` : "",
-          mediaType: r.mediaType ?? "application/octet-stream",
-          fileSize: r.fileSize ?? 0,
-        });
+  // Server / Data Center — /rest/api/content/* endpoints, start+limit pagination,
+  // body returned via ?expand=body.storage.
+  return {
+    async getPage(pid) {
+      const data = await api(`/content/${pid}?expand=body.storage`);
+      return {
+        id: String(data.id),
+        title: data.title ?? "",
+        html: data.body?.storage?.value ?? "",
+      };
+    },
+    async getAttachments(pid) {
+      const results: NormalizedConfluenceAttachment[] = [];
+      let start = 0;
+      const limit = 50;
+      while (true) {
+        const data = await api(
+          `/content/${pid}/child/attachment?limit=${limit}&start=${start}&expand=metadata,extensions`
+        );
+        const batch = data.results ?? [];
+        for (const r of batch) {
+          const dl = r._links?.download;
+          results.push({
+            title: r.title ?? r.id,
+            downloadLink: dl ? `https://${host}${dl}` : "",
+            mediaType: r.metadata?.mediaType ?? r.extensions?.mediaType ?? "application/octet-stream",
+            fileSize: r.extensions?.fileSize ?? 0,
+          });
+        }
+        if (batch.length < limit) break;
+        start += limit;
       }
-      const nextLink: string | undefined = data._links?.next;
-      cursor = nextLink
-        ? new URL(nextLink, baseApi).searchParams.get("cursor")
-        : null;
-    } while (cursor);
-    return results;
-  }
+      return results;
+    },
+    async getChildren(pid) {
+      const results: NormalizedConfluenceChild[] = [];
+      let start = 0;
+      const limit = 50;
+      while (true) {
+        const data = await api(`/content/${pid}/child/page?limit=${limit}&start=${start}`);
+        const batch = data.results ?? [];
+        for (const r of batch) {
+          results.push({ id: String(r.id), title: r.title });
+        }
+        if (batch.length < limit) break;
+        start += limit;
+      }
+      return results;
+    },
+  };
+}
+
+export async function confluenceImport(
+  url: string,
+  rawDir: string,
+  config: AtlassianConfig,
+  opts: {
+    recursive?: boolean;
+    depth?: number;
+    authEnv?: string;
+  } = {}
+): Promise<ConfluenceImportResult> {
+  const { host, pageId, deployment } = parseConfluenceUrl(url);
+  validateHost(host, config.allowedHosts);
+
+  const authHeader = resolveAuth(opts.authEnv ?? "CONFLUENCE_API_TOKEN");
+  const maxDepth = opts.depth ?? (opts.recursive ? 50 : 0);
+  const client = buildConfluenceClient(host, deployment, authHeader);
+  const files: string[] = [];
+  let pageCount = 0;
+
+  const getPage = (pid: string) => client.getPage(pid);
+  const getAttachments = (pid: string) => client.getAttachments(pid);
+  const getChildren = (pid: string) => client.getChildren(pid);
 
   async function downloadAttachment(
     attUrl: string,
@@ -245,24 +365,6 @@ export async function confluenceImport(
     }
   }
 
-  async function getChildren(pid: string): Promise<Array<{ id: string; title: string }>> {
-    const results: Array<{ id: string; title: string }> = [];
-    let cursor: string | null = null;
-    do {
-      const qs = cursor ? `?limit=50&cursor=${cursor}` : "?limit=50";
-      const data = await api(`/pages/${pid}/children/page${qs}`);
-      for (const r of data.results ?? []) {
-        results.push({ id: r.id, title: r.title });
-      }
-      // Pagination: extract cursor from next link if present
-      const nextLink: string | undefined = data._links?.next;
-      cursor = nextLink
-        ? new URL(nextLink, baseApi).searchParams.get("cursor")
-        : null;
-    } while (cursor);
-    return results;
-  }
-
   // ── Recursive import ──
 
   async function importPage(
@@ -288,9 +390,10 @@ export async function confluenceImport(
       mkdirSync(dirname(absPath), { recursive: true });
       writeFileSync(absPath, page.html);
       const h = hash(page.html);
+      const pageUrlPrefix = deployment === "cloud" ? "/wiki/spaces" : "/spaces";
       writeMeta(absPath, {
         path: relPath,
-        sourceUrl: `https://${host}/wiki/spaces/${space}/pages/${pid}`,
+        sourceUrl: `https://${host}${pageUrlPrefix}/${space}/pages/${pid}`,
         downloadedAt: new Date().toISOString(),
         sha256: h,
         size: Buffer.byteLength(page.html),
@@ -362,15 +465,18 @@ export async function confluenceImport(
 
 export function parseJiraUrl(
   url: string
-): { host: string; issueKey: string } {
+): { host: string; issueKey: string; deployment: AtlassianDeployment } {
   const match = url.match(/https?:\/\/([^/]+)\/browse\/([A-Z][A-Z0-9]+-\d+)/);
   if (!match) {
     throw new Error(
       `Cannot parse Jira URL: "${url}". ` +
-        `Expected: https://company.atlassian.net/browse/PROJ-123`
+        `Expected: https://{host}/browse/PROJ-123 (works for both Cloud and Server / Data Center)`
     );
   }
-  return { host: match[1]!, issueKey: match[2]! };
+  // Cloud Jira always lives on *.atlassian.net; anything else is self-hosted.
+  const host = match[1]!;
+  const deployment: AtlassianDeployment = host.endsWith(".atlassian.net") ? "cloud" : "server";
+  return { host, issueKey: match[2]!, deployment };
 }
 
 export async function jiraImport(
@@ -385,7 +491,7 @@ export async function jiraImport(
     authEnv?: string;
   } = {}
 ): Promise<JiraImportResult> {
-  const { host, issueKey } = parseJiraUrl(url);
+  const { host, issueKey, deployment } = parseJiraUrl(url);
   validateHost(host, config.allowedHosts);
 
   const authHeader = resolveAuth(opts.authEnv ?? "JIRA_API_TOKEN");
@@ -394,11 +500,16 @@ export async function jiraImport(
   const wantAttachments = opts.includeAttachments ?? true;
   const wantLinks = opts.includeLinks ?? true;
 
-  const baseApi = `https://${host}/rest/api/3`;
+  // Cloud always supports v3. Server / DC supports v3 on recent releases and
+  // v2 on older ones — try v3 first and fall back to v2 on a 404 from the
+  // primary issue endpoint. apiVersion holds whichever the first request
+  // ended up using; subsequent requests reuse it without re-probing.
+  let apiVersion: "3" | "2" = "3";
+  let baseApi = `https://${host}/rest/api/${apiVersion}`;
   const files: string[] = [];
   const imported = new Set<string>();
 
-  async function api(endpoint: string): Promise<any> {
+  async function api(endpoint: string, allowFallback = false): Promise<any> {
     const resp = await fetch(`${baseApi}${endpoint}`, {
       headers: {
         Authorization: authHeader,
@@ -407,6 +518,15 @@ export async function jiraImport(
       },
     });
     if (!resp.ok) {
+      // v3 → v2 fallback for older Server / DC. Only honored on the first
+      // call (`allowFallback=true` from the initial issue request) so we
+      // don't oscillate between versions on later 404s caused by genuinely
+      // missing resources.
+      if (resp.status === 404 && allowFallback && apiVersion === "3" && deployment === "server") {
+        apiVersion = "2";
+        baseApi = `https://${host}/rest/api/2`;
+        return api(endpoint, false);
+      }
       const body = await resp.text().catch(() => "");
       throw new Error(
         `Jira API ${resp.status} ${resp.statusText} — ${endpoint}\n${body.slice(0, 500)}`
@@ -450,8 +570,11 @@ export async function jiraImport(
     if (imported.has(key)) return;
     imported.add(key);
 
+    // First call may trigger v3 → v2 fallback on older Server / DC; honor that
+    // here, then subsequent calls reuse whichever version succeeded.
     const issue = await api(
-      `/issue/${key}?expand=renderedFields,names&fields=*all`
+      `/issue/${key}?expand=renderedFields,names&fields=*all`,
+      true
     );
     const f = issue.fields ?? {};
     const rf = issue.renderedFields ?? {};

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,8 +52,8 @@ export function createServer(wikiPath?: string, workspace?: string): Server {
           "Ingest raw source documents into the knowledge base. Select `mode` to control the ingestion method:\n" +
           "- `add`: Add a local file or content string (immutable, SHA-256 verified). Supports directory imports. Single images (<10MB) returned inline — you MUST immediately call wiki_write to describe them.\n" +
           "- `fetch`: Download a file from a URL into raw/ (arXiv abstract URLs auto-converted to PDF). Single images returned inline — you MUST immediately call wiki_write to describe them.\n" +
-          "- `import_confluence`: Recursively import Confluence pages with attachments and hierarchy. Requires CONFLUENCE_API_TOKEN env var ('email:api-token').\n" +
-          "- `import_jira`: Import a Jira issue with comments, attachments, and linked issues. Requires JIRA_API_TOKEN env var ('email:api-token').",
+          "- `import_confluence`: Recursively import Confluence pages with attachments and hierarchy. Supports both Cloud (`*.atlassian.net/wiki/...`) and Server / Data Center (`{host}/spaces/...`). Defaults to reading the CONFLUENCE_API_TOKEN env var; pass `auth_env` to point at any other variable. Token format accepted: `email:api-token` (Cloud Basic), `Bearer <pat>` (explicit), or a bare PAT (Bearer prefix added automatically).\n" +
+          "- `import_jira`: Import a Jira issue with comments, attachments, and linked issues. Supports both Cloud and Server / Data Center; auto-falls-back to REST API v2 on older Server / DC. Defaults to reading the JIRA_API_TOKEN env var; pass `auth_env` to point at any other variable. Token format accepted: `email:api-token` (Cloud Basic), `Bearer <pat>` (explicit), or a bare PAT (Bearer prefix added automatically).",
         inputSchema: {
           type: "object" as const,
           properties: {

--- a/src/wiki.test.ts
+++ b/src/wiki.test.ts
@@ -2099,24 +2099,43 @@ import {
 } from "./atlassian.js";
 
 describe("Confluence URL parsing", () => {
-  it("parses standard Confluence page URL", () => {
+  it("parses Cloud URL with /wiki/ segment and tags it as cloud", () => {
     const result = parseConfluenceUrl(
       "https://acme.atlassian.net/wiki/spaces/ENG/pages/12345/Architecture-Overview"
     );
     expect(result.host).toBe("acme.atlassian.net");
     expect(result.pageId).toBe("12345");
+    expect(result.deployment).toBe("cloud");
   });
 
-  it("rejects invalid URL", () => {
+  it("parses Server / Data Center URL without /wiki/ and tags it as server", () => {
+    const result = parseConfluenceUrl(
+      "https://confluence.example.com/spaces/ENG/pages/12345/Architecture-Overview"
+    );
+    expect(result.host).toBe("confluence.example.com");
+    expect(result.pageId).toBe("12345");
+    expect(result.deployment).toBe("server");
+  });
+
+  it("rejects invalid URL with both shapes mentioned in the error", () => {
     expect(() => parseConfluenceUrl("https://example.com/not-confluence")).toThrow(/Cannot parse/);
+    expect(() => parseConfluenceUrl("https://example.com/not-confluence")).toThrow(/Cloud[\s\S]+Server/);
   });
 });
 
 describe("Jira URL parsing", () => {
-  it("parses standard Jira issue URL", () => {
+  it("parses Cloud URL on *.atlassian.net and tags it as cloud", () => {
     const result = parseJiraUrl("https://acme.atlassian.net/browse/PROJ-123");
     expect(result.host).toBe("acme.atlassian.net");
     expect(result.issueKey).toBe("PROJ-123");
+    expect(result.deployment).toBe("cloud");
+  });
+
+  it("parses Server / Data Center URL on a self-hosted domain and tags it as server", () => {
+    const result = parseJiraUrl("https://jira.example.com/browse/PROJ-456");
+    expect(result.host).toBe("jira.example.com");
+    expect(result.issueKey).toBe("PROJ-456");
+    expect(result.deployment).toBe("server");
   });
 
   it("rejects invalid URL", () => {
@@ -2163,6 +2182,25 @@ describe("resolveAuth", () => {
     } finally {
       delete process.env.__TEST_AUTH__;
     }
+  });
+
+  it("auto-prefixes Bearer for a bare PAT (no colon, no prefix)", () => {
+    process.env.__TEST_AUTH__ = "abc123-personal-access-token";
+    try {
+      expect(resolveAuth("__TEST_AUTH__")).toBe("Bearer abc123-personal-access-token");
+    } finally {
+      delete process.env.__TEST_AUTH__;
+    }
+  });
+
+  it("error message lists all three accepted forms", () => {
+    expect(() => resolveAuth("DEFINITELY_NOT_SET_VAR")).toThrow(/email:api-token/);
+    expect(() => resolveAuth("DEFINITELY_NOT_SET_VAR")).toThrow(/Bearer/);
+    expect(() => resolveAuth("DEFINITELY_NOT_SET_VAR")).toThrow(/Server.*Data Center/);
+  });
+
+  it("error message points to authEnv as the customization escape hatch", () => {
+    expect(() => resolveAuth("DEFINITELY_NOT_SET_VAR")).toThrow(/authEnv/);
   });
 });
 


### PR DESCRIPTION
## Summary

`raw_ingest mode=import_confluence` and `raw_ingest mode=import_jira` only worked against Atlassian Cloud. Self-hosted Server / Data Center hit a "Cannot parse URL" wall on Confluence and got an HTML login page on Jira. This PR adds first-class Server / DC support without breaking Cloud.

## Changes

**URL parsers**
- `parseConfluenceUrl` accepts both `host/wiki/spaces/...` (Cloud) and `host/spaces/...` (Server / DC), returns `{ host, pageId, deployment }`.
- `parseJiraUrl` returns `deployment` derived from the host: `*.atlassian.net` → cloud, else server.

**Confluence client adapter**
- New `ConfluenceClient` interface with two implementations behind it. Cloud uses `/wiki/api/v2/pages/...` with cursor pagination; Server / DC uses `/rest/api/content/...` with start+limit pagination. Both project into the same internal `NormalizedConfluencePage / Attachment / Child` shape so the rest of `confluenceImport` stays platform-agnostic.
- Stored `sourceUrl` prefix matches the deployment.

**Jira version fallback**
- `jiraImport` now tries `/rest/api/3` first and transparently falls back to `/rest/api/2` on a 404 from the initial issue request when the URL pointed at a Server / DC host. Fallback runs once; subsequent calls reuse the chosen version.

**Auth resolver**
- `resolveAuth` accepts three token shapes:
  - `email:api-token` → auto-encoded as Cloud Basic
  - `Bearer <pat>` → passed through verbatim
  - bare PAT (no colon, no prefix) → `Bearer` prefix added automatically (Server / DC convention)
- Error message enumerates all three forms and points users at the `auth_env` parameter for deployments with custom env-var conventions. **No hard-coded env-var aliases** — the resolver is agnostic to any single naming convention.

**Tool descriptions + README**
- `src/server.ts` `import_confluence` / `import_jira` descriptions document both deployments and all three token shapes, and point at `auth_env` for customization.
- README "Atlassian Import" row mentions both Cloud and Server / DC support.

## Tests

6 new cases in `src/wiki.test.ts`:
- Confluence URL parsing for both shapes, with error message asserting it enumerates both
- Jira URL parsing for both deployments via host suffix
- `resolveAuth` auto-Bearer for bare PAT
- `resolveAuth` error message lists all three forms and references `authEnv`

`npm run build` — clean
`npm test` — 1429/1429, no regressions.

## Out of scope (for follow-up issues if needed)

- Programmatic discovery of deployment type from a host without seeing a URL — the tool still requires a page or issue URL to act on.
- Atlassian Connect / Marketplace plugin auth flows.
- Two-factor / SSO interactive auth.