### PR TITLE
chore(release): drop GitHub Packages publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
-      id-token: write
+      contents: write     # tag + create release
+      id-token: write     # npm provenance via OIDC
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,21 +63,3 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # Publish to GitHub Packages
-      - name: Setup GitHub Packages registry
-        run: |
-          echo "@xinhuagu:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
-
-      - name: Publish to GitHub Packages
-        run: |
-          # GitHub Packages requires scope to match owner
-          node -e "
-            const pkg = require('./package.json');
-            pkg.name = '@xinhuagu/mcp-server';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Workflow attempted to publish a renamed copy of the package (`@xinhuagu/mcp-server`) to GitHub Packages alongside the npmjs.org publish, but `GITHUB_TOKEN` doesn't have rights to write to user-scoped GH Packages — every release run failed at this step with `403 Forbidden`.

Nobody was actually consuming the GH Packages copy: real users install via `@agent-wiki/mcp-server` from npmjs.org, which works. Removing the step rather than wiring up a personal access token just to publish to a registry no one reads.

Also drops the now-unused `packages: write` permission from the release job.

## What's left in release.yml

- build / test / version bump (unchanged)
- Create GitHub Release (unchanged)
- Publish to npm (npmjs.org) — the only consumer-facing publish

## Tests

No code change beyond the workflow; no test impact.