### PR TITLE
chore(release): mirror to GitHub Packages as @xinhuagu/agent-wiki

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write     # tag + create release
       id-token: write     # npm provenance via OIDC
+      packages: write     # GitHub Packages publish (uses PACKAGES_TOKEN, not GITHUB_TOKEN)
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,3 +64,27 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Publish a mirror copy to GitHub Packages under @xinhuagu/agent-wiki.
+      # GitHub Packages requires the npm scope to match the GitHub user/org;
+      # we rewrite package.json in-place before publishing. PACKAGES_TOKEN
+      # is a personal access token with `write:packages` scope (the default
+      # GITHUB_TOKEN cannot publish to user-scoped GH Packages). If the
+      # secret is unset the step exits early so first-time releases without
+      # the secret still succeed.
+      - name: Publish to GitHub Packages
+        env:
+          PACKAGES_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
+        run: |
+          if [ -z "$PACKAGES_TOKEN" ]; then
+            echo "PACKAGES_TOKEN secret is unset — skipping GitHub Packages publish."
+            exit 0
+          fi
+          echo "@xinhuagu:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${PACKAGES_TOKEN}" >> .npmrc
+          node -e "
+            const pkg = require('./package.json');
+            pkg.name = '@xinhuagu/agent-wiki';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish --access public


### PR DESCRIPTION
## Summary

Restore the GitHub Packages publish step that was dropped in #2 (which had been failing because `GITHUB_TOKEN` cannot publish to user-scoped packages). This time use a `PACKAGES_TOKEN` secret — a personal access token with `write:packages` scope — that has the right permission.

## Changes vs the original implementation

- **Package name** is rewritten to `@xinhuagu/agent-wiki` (was `@xinhuagu/mcp-server`). Matches the GitHub repo name and leaves room for future packages under the same scope.
- **Graceful skip** when `PACKAGES_TOKEN` is unset — the step prints a notice and exits 0 instead of failing the whole release. So this PR can land before the secret is configured.

## Setup checklist (one-time, on the repo owner side)

1. Create a Personal Access Token at https://github.com/settings/tokens — Classic, with the `write:packages` scope checked.
2. Add as repo secret:
   ```
   gh secret set PACKAGES_TOKEN -R xinhuagu/agent-wiki
   ```
3. Trigger the next release (e.g. `gh workflow run release.yml -f bump=patch`). The `Publish to GitHub Packages` step now goes from "skipped (no secret)" to actually publishing.

## Notes

- npmjs.org publish (`@agent-wiki/mcp-server`) is unaffected.
- GitHub Packages mirror lives at `@xinhuagu/agent-wiki` — install via `npm install @xinhuagu/agent-wiki --registry=https://npm.pkg.github.com`.