### PR TITLE
feat(evidence): wiki_search + wiki_search_read abstain semantics (#4 phase 1)

### DIFF
--- a/docs/evidence-envelope.md
+++ b/docs/evidence-envelope.md
@@ -96,19 +96,20 @@ Implementation: `src/cobol/evidence-mapping.ts` (`cobolTierToEvidence`).
 
 This is one-way: the envelope is computed from the tier; the tier is not reconstructed from the envelope. Future COBOL lineage families (e.g., dataset-mediated, column-level DB2) extend the tier table; the envelope mapping is mechanical.
 
-## Small-corpus abstain rule (Caveat 2)
+## Abstain rule (Caveat 2)
 
-For `wiki_search`, the abstain decision combines two checks. Take the **stricter** of the two — if either says abstain, the envelope sets `abstain: true` and `confidence: "absent"`.
+For `wiki_search`, the abstain decision uses an absolute floor on the top1 BM25 score. If `top1 < 2.0`, the envelope sets `abstain: true`, `confidence: "absent"`, and clears `provenance` so callers do not treat the weak hits as supporting evidence.
 
-1. **Relative**: BM25 score below the 30th percentile of the corpus's score distribution for non-trivial queries. (Recomputed on `wiki_admin rebuild`; cached as a workspace stat.)
-2. **Absolute floor**: BM25 score below `2.0` regardless of distribution. (Calibrated by inspection on the bundled fixtures; revisit when corpus characteristics change.)
+The original design also called for a relative cutoff — BM25 score below the corpus 30th percentile — recomputed during `wiki_admin rebuild`. That part was dropped during Phase 1 implementation: any cold-start sampling we could plausibly do (page titles as queries) measures best-case retrieval, not typical-query strength, and over-flags real queries as abstain. A real percentile cutoff requires actual user query logs; until those exist, the absolute floor is the only honest signal.
 
-A 20-page wiki has unstable percentiles, so the absolute floor catches "weak in absolute terms" even when relative ranking looks reasonable. Conversely, a 10000-page wiki may have everything above 2.0; the percentile then carries the load.
+Phase 1 confidence derivations:
 
-Additional Phase 1 derivations:
-- top1 score `> 2 ×` top2 score → `confidence: "strong"` (clear winner)
-- top1 within `1.2 ×` top2 score → `confidence: "weak"` (multiple plausible matches; consumer should read both)
+- top1 score `≥ 2 ×` top2 score → `confidence: "strong"` (clear winner)
+- top1 within `2 ×` top2 score → `confidence: "weak"` (multiple plausible matches; consumer should read several)
+- top1 below absolute floor (`< 2.0`) → `confidence: "absent"`, `abstain: true`
 - 0 results → existing `knowledge_gap` response, plus envelope with `abstain: true`, `basis: "unsupported"`
+
+The 2.0 floor was calibrated by inspection on the bundled fixtures; revisit when corpus characteristics change. If `wiki_admin` ever starts logging real queries (Phase 4 dashboard candidate), a percentile cutoff can be reintroduced — informed by typical-query data rather than self-search noise.
 
 ## Unsupported-write telemetry (Caveat 1)
 

--- a/src/evidence-search.test.ts
+++ b/src/evidence-search.test.ts
@@ -1,81 +1,59 @@
 import { describe, it, expect } from "vitest";
 import {
   buildSearchEnvelope,
-  computeSearchDistribution,
   downgradeForReadPage,
   ABSOLUTE_FLOOR,
-  SMALL_CORPUS_THRESHOLD,
 } from "./evidence-search.js";
 import type { SearchResult } from "./search.js";
-import type { CorpusSearchStats } from "./evidence-search.js";
 
 function r(path: string, score: number): SearchResult {
   return { path, score, snippet: "" };
 }
 
 describe("buildSearchEnvelope", () => {
-  it("returns absent + abstain on empty result list", () => {
-    const env = buildSearchEnvelope([], null, "anything");
+  it("returns absent + abstain on empty result list, with empty provenance", () => {
+    const env = buildSearchEnvelope([], "anything");
     expect(env.confidence).toBe("absent");
     expect(env.abstain).toBe(true);
     expect(env.basis).toBe("unsupported");
     expect(env.provenance).toEqual([]);
   });
 
-  it("abstains when top1 is below the absolute floor regardless of stats", () => {
-    const env = buildSearchEnvelope([r("a.md", ABSOLUTE_FLOOR - 0.1)], null, "weak query");
+  it("abstains when top1 is below the absolute floor and clears provenance", () => {
+    const env = buildSearchEnvelope(
+      [r("a.md", ABSOLUTE_FLOOR - 0.1), r("b.md", 0.1)],
+      "weak query",
+    );
     expect(env.confidence).toBe("absent");
     expect(env.abstain).toBe(true);
+    expect(env.provenance).toEqual([]);
+    // Rationale still mentions what came back so a debugger can see it.
+    expect(env.rationale).toMatch(/a\.md/);
     expect(env.rationale).toMatch(/absolute floor/);
   });
 
-  it("abstains when top1 is below the corpus 30th percentile (large corpus)", () => {
-    const stats: CorpusSearchStats = {
-      p30: 5.0,
-      indexedPages: SMALL_CORPUS_THRESHOLD + 5,
-      computedAt: new Date().toISOString(),
-    };
-    const env = buildSearchEnvelope([r("a.md", 4.5)], stats, "below percentile");
-    expect(env.confidence).toBe("absent");
-    expect(env.abstain).toBe(true);
-    expect(env.rationale).toMatch(/percentile/);
-  });
-
-  it("ignores corpus percentile on a small corpus and falls back to absolute floor only", () => {
-    const stats: CorpusSearchStats = {
-      p30: 10.0, // would normally classify a 5.0 score as absent
-      indexedPages: SMALL_CORPUS_THRESHOLD - 1, // too small
-      computedAt: new Date().toISOString(),
-    };
-    const env = buildSearchEnvelope([r("a.md", 5.0), r("b.md", 1.0)], stats, "small corpus");
-    // 5.0 is above absolute floor, percentile is ignored — should NOT abstain.
-    expect(env.abstain).toBe(false);
-    expect(env.confidence).not.toBe("absent");
-  });
-
   it("returns strong when top1 dominates top2 (≥ 2× ratio)", () => {
-    const env = buildSearchEnvelope([r("a.md", 10), r("b.md", 4)], null, "clear winner");
+    const env = buildSearchEnvelope([r("a.md", 10), r("b.md", 4)], "clear winner");
     expect(env.confidence).toBe("strong");
     expect(env.abstain).toBe(false);
     expect(env.basis).toBe("synthesized");
   });
 
   it("returns weak when top1 is close to top2 (< 2× ratio)", () => {
-    const env = buildSearchEnvelope([r("a.md", 5), r("b.md", 4)], null, "ambiguous");
+    const env = buildSearchEnvelope([r("a.md", 5), r("b.md", 4)], "ambiguous");
     expect(env.confidence).toBe("weak");
     expect(env.abstain).toBe(false);
     expect(env.rationale).toMatch(/multiple plausible/);
   });
 
   it("returns strong when there is only one result above the floor", () => {
-    const env = buildSearchEnvelope([r("a.md", 5)], null, "single result");
-    // ratio = Infinity, treated as strong
+    const env = buildSearchEnvelope([r("a.md", 5)], "single result");
     expect(env.confidence).toBe("strong");
   });
 
-  it("populates provenance with up to top 3 wiki pages", () => {
+  it("populates provenance with up to top 3 wiki pages on non-abstain", () => {
     const results = [r("a.md", 10), r("b.md", 4), r("c.md", 3), r("d.md", 2)];
-    const env = buildSearchEnvelope(results, null, "x");
+    const env = buildSearchEnvelope(results, "x");
     expect(env.provenance).toHaveLength(3);
     expect(env.provenance.map((p) => p.wikiPage)).toEqual([
       "wiki/a.md",
@@ -88,7 +66,6 @@ describe("buildSearchEnvelope", () => {
 describe("downgradeForReadPage", () => {
   const baseEnvelope = buildSearchEnvelope(
     [{ path: "p.md", score: 10, snippet: "" }, { path: "q.md", score: 4, snippet: "" }],
-    null,
     "test",
   );
 
@@ -96,6 +73,7 @@ describe("downgradeForReadPage", () => {
     const env = downgradeForReadPage(baseEnvelope, { sources: ["raw/x.md"] });
     expect(env.confidence).toBe(baseEnvelope.confidence);
     expect(env.rationale).toBe(baseEnvelope.rationale);
+    expect(env.provenance).toEqual(baseEnvelope.provenance);
   });
 
   it("leaves envelope unchanged for explicit synthesis pages without sources", () => {
@@ -118,10 +96,11 @@ describe("downgradeForReadPage", () => {
     expect(env.rationale).toMatch(/legacyUnsupported/);
   });
 
-  it("drops two tiers when both unsupported and legacy flags fire (strong → absent)", () => {
+  it("drops two tiers when both flags fire (strong → absent), clearing provenance", () => {
     const env = downgradeForReadPage(baseEnvelope, { sources: [], legacyUnsupported: true });
     expect(env.confidence).toBe("absent");
     expect(env.abstain).toBe(true);
+    expect(env.provenance).toEqual([]);
   });
 
   it("notes stale page in rationale without changing tier", () => {
@@ -133,35 +112,12 @@ describe("downgradeForReadPage", () => {
     expect(env.confidence).toBe(baseEnvelope.confidence);
     expect(env.rationale).toMatch(/last edited \d+ days ago/);
   });
-});
 
-describe("computeSearchDistribution", () => {
-  it("returns null p30 on a small corpus, even with high scores", () => {
-    const titles = ["a", "b", "c", "d", "e"];
-    const stats = computeSearchDistribution(titles, () => [{ score: 100 }]);
-    expect(stats.p30).toBeNull();
-    expect(stats.indexedPages).toBe(5);
-  });
-
-  it("computes a percentile when corpus is large enough", () => {
-    const n = SMALL_CORPUS_THRESHOLD + 30;
-    const titles = Array.from({ length: n }, (_, i) => `page-${i}`);
-    // Scores cycle 1..10 deterministically
-    const stats = computeSearchDistribution(titles, (q) => {
-      const i = parseInt(q.split("-")[1] ?? "0", 10);
-      return [{ score: (i % 10) + 1 }];
+  it("ignores malformed lastEditISO and does not add a stale note", () => {
+    const env = downgradeForReadPage(baseEnvelope, {
+      sources: ["raw/x.md"],
+      lastEditISO: "not-a-date",
     });
-    expect(stats.p30).not.toBeNull();
-    expect(stats.indexedPages).toBe(n);
-    // p30 is the 30th percentile of the sorted top1 score sample,
-    // bounded between min and max scores observed.
-    expect(stats.p30!).toBeGreaterThanOrEqual(1);
-    expect(stats.p30!).toBeLessThanOrEqual(10);
-  });
-
-  it("returns null p30 when all queries return empty", () => {
-    const titles = Array.from({ length: SMALL_CORPUS_THRESHOLD + 5 }, (_, i) => `page-${i}`);
-    const stats = computeSearchDistribution(titles, () => []);
-    expect(stats.p30).toBeNull();
+    expect(env.rationale).toBe(baseEnvelope.rationale);
   });
 });

--- a/src/evidence-search.test.ts
+++ b/src/evidence-search.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSearchEnvelope,
+  computeSearchDistribution,
+  downgradeForReadPage,
+  ABSOLUTE_FLOOR,
+  SMALL_CORPUS_THRESHOLD,
+} from "./evidence-search.js";
+import type { SearchResult } from "./search.js";
+import type { CorpusSearchStats } from "./evidence-search.js";
+
+function r(path: string, score: number): SearchResult {
+  return { path, score, snippet: "" };
+}
+
+describe("buildSearchEnvelope", () => {
+  it("returns absent + abstain on empty result list", () => {
+    const env = buildSearchEnvelope([], null, "anything");
+    expect(env.confidence).toBe("absent");
+    expect(env.abstain).toBe(true);
+    expect(env.basis).toBe("unsupported");
+    expect(env.provenance).toEqual([]);
+  });
+
+  it("abstains when top1 is below the absolute floor regardless of stats", () => {
+    const env = buildSearchEnvelope([r("a.md", ABSOLUTE_FLOOR - 0.1)], null, "weak query");
+    expect(env.confidence).toBe("absent");
+    expect(env.abstain).toBe(true);
+    expect(env.rationale).toMatch(/absolute floor/);
+  });
+
+  it("abstains when top1 is below the corpus 30th percentile (large corpus)", () => {
+    const stats: CorpusSearchStats = {
+      p30: 5.0,
+      indexedPages: SMALL_CORPUS_THRESHOLD + 5,
+      computedAt: new Date().toISOString(),
+    };
+    const env = buildSearchEnvelope([r("a.md", 4.5)], stats, "below percentile");
+    expect(env.confidence).toBe("absent");
+    expect(env.abstain).toBe(true);
+    expect(env.rationale).toMatch(/percentile/);
+  });
+
+  it("ignores corpus percentile on a small corpus and falls back to absolute floor only", () => {
+    const stats: CorpusSearchStats = {
+      p30: 10.0, // would normally classify a 5.0 score as absent
+      indexedPages: SMALL_CORPUS_THRESHOLD - 1, // too small
+      computedAt: new Date().toISOString(),
+    };
+    const env = buildSearchEnvelope([r("a.md", 5.0), r("b.md", 1.0)], stats, "small corpus");
+    // 5.0 is above absolute floor, percentile is ignored — should NOT abstain.
+    expect(env.abstain).toBe(false);
+    expect(env.confidence).not.toBe("absent");
+  });
+
+  it("returns strong when top1 dominates top2 (≥ 2× ratio)", () => {
+    const env = buildSearchEnvelope([r("a.md", 10), r("b.md", 4)], null, "clear winner");
+    expect(env.confidence).toBe("strong");
+    expect(env.abstain).toBe(false);
+    expect(env.basis).toBe("synthesized");
+  });
+
+  it("returns weak when top1 is close to top2 (< 2× ratio)", () => {
+    const env = buildSearchEnvelope([r("a.md", 5), r("b.md", 4)], null, "ambiguous");
+    expect(env.confidence).toBe("weak");
+    expect(env.abstain).toBe(false);
+    expect(env.rationale).toMatch(/multiple plausible/);
+  });
+
+  it("returns strong when there is only one result above the floor", () => {
+    const env = buildSearchEnvelope([r("a.md", 5)], null, "single result");
+    // ratio = Infinity, treated as strong
+    expect(env.confidence).toBe("strong");
+  });
+
+  it("populates provenance with up to top 3 wiki pages", () => {
+    const results = [r("a.md", 10), r("b.md", 4), r("c.md", 3), r("d.md", 2)];
+    const env = buildSearchEnvelope(results, null, "x");
+    expect(env.provenance).toHaveLength(3);
+    expect(env.provenance.map((p) => p.wikiPage)).toEqual([
+      "wiki/a.md",
+      "wiki/b.md",
+      "wiki/c.md",
+    ]);
+  });
+});
+
+describe("downgradeForReadPage", () => {
+  const baseEnvelope = buildSearchEnvelope(
+    [{ path: "p.md", score: 10, snippet: "" }, { path: "q.md", score: 4, snippet: "" }],
+    null,
+    "test",
+  );
+
+  it("leaves envelope unchanged for grounded pages with sources", () => {
+    const env = downgradeForReadPage(baseEnvelope, { sources: ["raw/x.md"] });
+    expect(env.confidence).toBe(baseEnvelope.confidence);
+    expect(env.rationale).toBe(baseEnvelope.rationale);
+  });
+
+  it("leaves envelope unchanged for explicit synthesis pages without sources", () => {
+    const env = downgradeForReadPage(baseEnvelope, { sources: [], synthesis: true });
+    expect(env.confidence).toBe(baseEnvelope.confidence);
+  });
+
+  it("drops one tier for unsupported pages (no sources, no synthesis)", () => {
+    const env = downgradeForReadPage(baseEnvelope, { sources: [] });
+    expect(env.confidence).toBe("weak"); // strong → weak
+    expect(env.rationale).toMatch(/no sources/);
+  });
+
+  it("drops one tier for legacyUnsupported pages", () => {
+    const env = downgradeForReadPage(baseEnvelope, {
+      sources: ["raw/x.md"],
+      legacyUnsupported: true,
+    });
+    expect(env.confidence).toBe("weak");
+    expect(env.rationale).toMatch(/legacyUnsupported/);
+  });
+
+  it("drops two tiers when both unsupported and legacy flags fire (strong → absent)", () => {
+    const env = downgradeForReadPage(baseEnvelope, { sources: [], legacyUnsupported: true });
+    expect(env.confidence).toBe("absent");
+    expect(env.abstain).toBe(true);
+  });
+
+  it("notes stale page in rationale without changing tier", () => {
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    const env = downgradeForReadPage(baseEnvelope, {
+      sources: ["raw/x.md"],
+      lastEditISO: oldDate,
+    });
+    expect(env.confidence).toBe(baseEnvelope.confidence);
+    expect(env.rationale).toMatch(/last edited \d+ days ago/);
+  });
+});
+
+describe("computeSearchDistribution", () => {
+  it("returns null p30 on a small corpus, even with high scores", () => {
+    const titles = ["a", "b", "c", "d", "e"];
+    const stats = computeSearchDistribution(titles, () => [{ score: 100 }]);
+    expect(stats.p30).toBeNull();
+    expect(stats.indexedPages).toBe(5);
+  });
+
+  it("computes a percentile when corpus is large enough", () => {
+    const n = SMALL_CORPUS_THRESHOLD + 30;
+    const titles = Array.from({ length: n }, (_, i) => `page-${i}`);
+    // Scores cycle 1..10 deterministically
+    const stats = computeSearchDistribution(titles, (q) => {
+      const i = parseInt(q.split("-")[1] ?? "0", 10);
+      return [{ score: (i % 10) + 1 }];
+    });
+    expect(stats.p30).not.toBeNull();
+    expect(stats.indexedPages).toBe(n);
+    // p30 is the 30th percentile of the sorted top1 score sample,
+    // bounded between min and max scores observed.
+    expect(stats.p30!).toBeGreaterThanOrEqual(1);
+    expect(stats.p30!).toBeLessThanOrEqual(10);
+  });
+
+  it("returns null p30 when all queries return empty", () => {
+    const titles = Array.from({ length: SMALL_CORPUS_THRESHOLD + 5 }, (_, i) => `page-${i}`);
+    const stats = computeSearchDistribution(titles, () => []);
+    expect(stats.p30).toBeNull();
+  });
+});

--- a/src/evidence-search.ts
+++ b/src/evidence-search.ts
@@ -3,34 +3,25 @@
  * list so wiki_search and wiki_search_read can signal "weak / abstain"
  * instead of treating every BM25 hit as authoritative.
  *
- * See docs/evidence-envelope.md ("Small-corpus abstain rule").
+ * See docs/evidence-envelope.md.
  *
- * Confidence rules (Caveat 2):
- *   - top1 below absolute floor (BM25 < 2.0)              → absent + abstain
- *   - top1 below cached corpus 30th percentile             → absent + abstain
- *   - top1 ≥ 2× top2                                       → strong
- *   - top1 < 2× top2                                       → weak
- *   - 0 results                                            → absent + abstain
+ * Confidence rules:
+ *   - 0 results                                      → absent + abstain
+ *   - top1 below absolute floor (BM25 < 2.0)         → absent + abstain
+ *   - top1 ≥ 2× top2                                 → strong
+ *   - top1 < 2× top2                                 → weak
+ *
+ * The original design also had a corpus 30th-percentile cutoff. That was
+ * dropped because the percentile would have to come from real query logs
+ * to be meaningful — sampling page titles as queries (the only feasible
+ * cold-start source) produces a best-case score distribution, not a
+ * typical-query one, and so over-flags real queries as abstain. The
+ * absolute floor catches the obvious-junk case; relative-confidence
+ * signaling lives in the top1/top2 ratio rule.
  */
 
 import type { SearchResult } from "./search.js";
 import type { EvidenceEnvelope, EvidenceConfidence } from "./evidence.js";
-
-export interface CorpusSearchStats {
-  /**
-   * 30th percentile of typical-query BM25 top1 scores. Computed by sampling
-   * page titles as queries during wiki_admin rebuild. `null` when the corpus
-   * is too small to produce a stable estimate.
-   */
-  p30: number | null;
-  /** Number of indexed pages when the stats were computed. */
-  indexedPages: number;
-  /** ISO timestamp of last computation. */
-  computedAt: string;
-}
-
-/** Filesystem location for the cached stats, relative to the wiki root. */
-export const SEARCH_STATS_PATH = ".agent-wiki/search-distribution.json";
 
 /** Absolute floor below which any top1 BM25 score is "weak in absolute terms". */
 export const ABSOLUTE_FLOOR = 2.0;
@@ -38,12 +29,11 @@ export const ABSOLUTE_FLOOR = 2.0;
 /** top1/top2 ratio that splits "strong" from "weak". */
 const TOP1_OVER_TOP2_STRONG = 2.0;
 
-/** Below this many indexed pages, percentile cutoff is unreliable; rely on absolute floor only. */
-export const SMALL_CORPUS_THRESHOLD = 20;
+/** Provenance fan-out — top N pages cited in the envelope on a non-abstain match. */
+const PROVENANCE_LIMIT = 3;
 
 export function buildSearchEnvelope(
   results: SearchResult[],
-  stats: CorpusSearchStats | null,
   query: string,
 ): EvidenceEnvelope {
   if (results.length === 0) {
@@ -59,28 +49,18 @@ export function buildSearchEnvelope(
   const top1 = results[0]!.score;
 
   if (top1 < ABSOLUTE_FLOOR) {
+    // Abstain: provenance stays empty so callers can't accidentally treat
+    // the weak hits as supporting evidence. Mention the top hits in the
+    // rationale so a debugger can still see what the engine returned.
+    const sample = results.slice(0, PROVENANCE_LIMIT).map((r) => r.path).join(", ");
     return {
-      provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
+      provenance: [],
       confidence: "absent",
       basis: "unsupported",
       abstain: true,
       rationale:
         `Top match score ${top1.toFixed(2)} is below the absolute floor (${ABSOLUTE_FLOOR}). ` +
-        `Treat as no usable result.`,
-    };
-  }
-
-  const useRelativeFloor =
-    stats?.p30 != null && stats.indexedPages >= SMALL_CORPUS_THRESHOLD;
-  if (useRelativeFloor && top1 < stats!.p30!) {
-    return {
-      provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
-      confidence: "absent",
-      basis: "unsupported",
-      abstain: true,
-      rationale:
-        `Top match score ${top1.toFixed(2)} is below the corpus 30th percentile ` +
-        `(${stats!.p30!.toFixed(2)}). Likely a poor match.`,
+        `Treat as no usable result. Engine returned weak hits: ${sample}.`,
     };
   }
 
@@ -95,7 +75,7 @@ export function buildSearchEnvelope(
         `multiple plausible answers — read several before relying on the top result.`;
 
   return {
-    provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
+    provenance: results.slice(0, PROVENANCE_LIMIT).map((r) => ({ wikiPage: `wiki/${r.path}` })),
     confidence,
     basis: "synthesized",
     abstain: false,
@@ -142,7 +122,7 @@ export function downgradeForReadPage(
   let staleNote = "";
   if (page.lastEditISO) {
     const ageMs = now.getTime() - new Date(page.lastEditISO).getTime();
-    if (ageMs > NINETY_DAYS_MS) {
+    if (Number.isFinite(ageMs) && ageMs > NINETY_DAYS_MS) {
       const days = Math.floor(ageMs / (24 * 60 * 60 * 1000));
       staleNote = ` Page last edited ${days} days ago.`;
     }
@@ -152,8 +132,13 @@ export function downgradeForReadPage(
     return envelope; // no change
   }
 
+  // If the downgrade landed at "absent", clear provenance so downstream
+  // code doesn't treat the weak hits as supporting evidence.
+  const provenance = confidence === "absent" ? [] : envelope.provenance;
+
   return {
     ...envelope,
+    provenance,
     confidence,
     abstain: confidence === "absent" ? true : envelope.abstain,
     rationale:
@@ -167,53 +152,4 @@ function stepDown(c: EvidenceConfidence): EvidenceConfidence {
   if (c === "strong") return "weak";
   if (c === "weak") return "absent";
   return "absent";
-}
-
-/**
- * Compute the corpus's search-distribution stats by sampling page titles as
- * queries. Cheap proxy for "what does a typical user search look like" —
- * gives the percentile cutoff that buildSearchEnvelope uses.
- *
- * Below SMALL_CORPUS_THRESHOLD pages, the percentile is too noisy; return
- * `p30: null` and let buildSearchEnvelope fall back to the absolute floor.
- */
-export function computeSearchDistribution(
-  pageTitles: string[],
-  runQuery: (q: string) => { score: number }[],
-): CorpusSearchStats {
-  const indexedPages = pageTitles.length;
-  if (indexedPages < SMALL_CORPUS_THRESHOLD) {
-    return {
-      p30: null,
-      indexedPages,
-      computedAt: new Date().toISOString(),
-    };
-  }
-
-  // Sample up to 50 titles for percentile computation. On very large corpora
-  // we don't need all titles — 50 evenly-spaced gives a stable estimate.
-  const step = Math.max(1, Math.floor(indexedPages / 50));
-  const top1Scores: number[] = [];
-  for (let i = 0; i < indexedPages; i += step) {
-    const title = pageTitles[i]!;
-    if (!title.trim()) continue;
-    const hits = runQuery(title);
-    if (hits.length > 0) top1Scores.push(hits[0]!.score);
-  }
-
-  if (top1Scores.length === 0) {
-    return {
-      p30: null,
-      indexedPages,
-      computedAt: new Date().toISOString(),
-    };
-  }
-
-  top1Scores.sort((a, b) => a - b);
-  const idx = Math.floor(top1Scores.length * 0.3);
-  return {
-    p30: top1Scores[idx]!,
-    indexedPages,
-    computedAt: new Date().toISOString(),
-  };
 }

--- a/src/evidence-search.ts
+++ b/src/evidence-search.ts
@@ -1,0 +1,219 @@
+/**
+ * Evidence-first phase 1: derive an EvidenceEnvelope from a search result
+ * list so wiki_search and wiki_search_read can signal "weak / abstain"
+ * instead of treating every BM25 hit as authoritative.
+ *
+ * See docs/evidence-envelope.md ("Small-corpus abstain rule").
+ *
+ * Confidence rules (Caveat 2):
+ *   - top1 below absolute floor (BM25 < 2.0)              → absent + abstain
+ *   - top1 below cached corpus 30th percentile             → absent + abstain
+ *   - top1 ≥ 2× top2                                       → strong
+ *   - top1 < 2× top2                                       → weak
+ *   - 0 results                                            → absent + abstain
+ */
+
+import type { SearchResult } from "./search.js";
+import type { EvidenceEnvelope, EvidenceConfidence } from "./evidence.js";
+
+export interface CorpusSearchStats {
+  /**
+   * 30th percentile of typical-query BM25 top1 scores. Computed by sampling
+   * page titles as queries during wiki_admin rebuild. `null` when the corpus
+   * is too small to produce a stable estimate.
+   */
+  p30: number | null;
+  /** Number of indexed pages when the stats were computed. */
+  indexedPages: number;
+  /** ISO timestamp of last computation. */
+  computedAt: string;
+}
+
+/** Filesystem location for the cached stats, relative to the wiki root. */
+export const SEARCH_STATS_PATH = ".agent-wiki/search-distribution.json";
+
+/** Absolute floor below which any top1 BM25 score is "weak in absolute terms". */
+export const ABSOLUTE_FLOOR = 2.0;
+
+/** top1/top2 ratio that splits "strong" from "weak". */
+const TOP1_OVER_TOP2_STRONG = 2.0;
+
+/** Below this many indexed pages, percentile cutoff is unreliable; rely on absolute floor only. */
+export const SMALL_CORPUS_THRESHOLD = 20;
+
+export function buildSearchEnvelope(
+  results: SearchResult[],
+  stats: CorpusSearchStats | null,
+  query: string,
+): EvidenceEnvelope {
+  if (results.length === 0) {
+    return {
+      provenance: [],
+      confidence: "absent",
+      basis: "unsupported",
+      abstain: true,
+      rationale: `No matches for "${query}".`,
+    };
+  }
+
+  const top1 = results[0]!.score;
+
+  if (top1 < ABSOLUTE_FLOOR) {
+    return {
+      provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
+      confidence: "absent",
+      basis: "unsupported",
+      abstain: true,
+      rationale:
+        `Top match score ${top1.toFixed(2)} is below the absolute floor (${ABSOLUTE_FLOOR}). ` +
+        `Treat as no usable result.`,
+    };
+  }
+
+  const useRelativeFloor =
+    stats?.p30 != null && stats.indexedPages >= SMALL_CORPUS_THRESHOLD;
+  if (useRelativeFloor && top1 < stats!.p30!) {
+    return {
+      provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
+      confidence: "absent",
+      basis: "unsupported",
+      abstain: true,
+      rationale:
+        `Top match score ${top1.toFixed(2)} is below the corpus 30th percentile ` +
+        `(${stats!.p30!.toFixed(2)}). Likely a poor match.`,
+    };
+  }
+
+  const top2 = results[1]?.score ?? 0;
+  const ratio = top2 > 0 ? top1 / top2 : Infinity;
+  const confidence: EvidenceConfidence = ratio >= TOP1_OVER_TOP2_STRONG ? "strong" : "weak";
+
+  const rationale =
+    confidence === "strong"
+      ? `Top match clearly dominates (${top1.toFixed(2)} vs ${top2.toFixed(2)}).`
+      : `Top matches are close in score (${top1.toFixed(2)} vs ${top2.toFixed(2)}); ` +
+        `multiple plausible answers — read several before relying on the top result.`;
+
+  return {
+    provenance: results.slice(0, 3).map((r) => ({ wikiPage: `wiki/${r.path}` })),
+    confidence,
+    basis: "synthesized",
+    abstain: false,
+    rationale,
+  };
+}
+
+/**
+ * For wiki_search_read: take the search envelope and downgrade if the page
+ * the agent is about to read shows weak metadata of its own.
+ *
+ * Rules (per docs/evidence-envelope.md):
+ *   - empty `sources: []` AND no `synthesis: true` flag → drop one tier
+ *   - `legacyUnsupported: true` (Phase 2a migration marker)  → drop one tier
+ *   - last edit > 90 days → no tier change but rationale notes it
+ */
+export interface ReadPageMetadata {
+  sources?: string[];
+  synthesis?: boolean;
+  legacyUnsupported?: boolean;
+  lastEditISO?: string;
+}
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+export function downgradeForReadPage(
+  envelope: EvidenceEnvelope,
+  page: ReadPageMetadata,
+  now: Date = new Date(),
+): EvidenceEnvelope {
+  let confidence = envelope.confidence;
+  const reasons: string[] = [];
+
+  const grounded = (page.sources?.length ?? 0) > 0;
+  if (!grounded && !page.synthesis) {
+    confidence = stepDown(confidence);
+    reasons.push("page has no sources and no synthesis flag");
+  }
+  if (page.legacyUnsupported) {
+    confidence = stepDown(confidence);
+    reasons.push("page is flagged legacyUnsupported");
+  }
+
+  let staleNote = "";
+  if (page.lastEditISO) {
+    const ageMs = now.getTime() - new Date(page.lastEditISO).getTime();
+    if (ageMs > NINETY_DAYS_MS) {
+      const days = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+      staleNote = ` Page last edited ${days} days ago.`;
+    }
+  }
+
+  if (confidence === envelope.confidence && !staleNote) {
+    return envelope; // no change
+  }
+
+  return {
+    ...envelope,
+    confidence,
+    abstain: confidence === "absent" ? true : envelope.abstain,
+    rationale:
+      reasons.length > 0
+        ? `${envelope.rationale} Downgraded: ${reasons.join("; ")}.${staleNote}`
+        : `${envelope.rationale}${staleNote}`,
+  };
+}
+
+function stepDown(c: EvidenceConfidence): EvidenceConfidence {
+  if (c === "strong") return "weak";
+  if (c === "weak") return "absent";
+  return "absent";
+}
+
+/**
+ * Compute the corpus's search-distribution stats by sampling page titles as
+ * queries. Cheap proxy for "what does a typical user search look like" —
+ * gives the percentile cutoff that buildSearchEnvelope uses.
+ *
+ * Below SMALL_CORPUS_THRESHOLD pages, the percentile is too noisy; return
+ * `p30: null` and let buildSearchEnvelope fall back to the absolute floor.
+ */
+export function computeSearchDistribution(
+  pageTitles: string[],
+  runQuery: (q: string) => { score: number }[],
+): CorpusSearchStats {
+  const indexedPages = pageTitles.length;
+  if (indexedPages < SMALL_CORPUS_THRESHOLD) {
+    return {
+      p30: null,
+      indexedPages,
+      computedAt: new Date().toISOString(),
+    };
+  }
+
+  // Sample up to 50 titles for percentile computation. On very large corpora
+  // we don't need all titles — 50 evenly-spaced gives a stable estimate.
+  const step = Math.max(1, Math.floor(indexedPages / 50));
+  const top1Scores: number[] = [];
+  for (let i = 0; i < indexedPages; i += step) {
+    const title = pageTitles[i]!;
+    if (!title.trim()) continue;
+    const hits = runQuery(title);
+    if (hits.length > 0) top1Scores.push(hits[0]!.score);
+  }
+
+  if (top1Scores.length === 0) {
+    return {
+      p30: null,
+      indexedPages,
+      computedAt: new Date().toISOString(),
+    };
+  }
+
+  top1Scores.sort((a, b) => a - b);
+  const idx = Math.floor(top1Scores.length * 0.3);
+  return {
+    p30: top1Scores[idx]!,
+    indexedPages,
+    computedAt: new Date().toISOString(),
+  };
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -806,6 +806,64 @@ describe("server tool: wiki_search", () => {
   });
 });
 
+describe("wiki_search + wiki_search_read: evidence envelope (phase 1)", () => {
+  beforeEach(cleanUp);
+  afterEach(cleanUp);
+
+  it("includes an evidence envelope on every wiki_search response", async () => {
+    const wiki = freshWiki();
+    wiki.write("topic.md", "---\ntitle: Transformer Models\nsources: [raw/paper.pdf]\n---\nAttention.");
+    const result = await handleTool(wiki, "wiki_search", { query: "Transformer" });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.evidence).toBeDefined();
+    expect(["strong", "weak", "absent"]).toContain(parsed.evidence.confidence);
+    expect(["deterministic", "inferred", "synthesized", "unsupported"]).toContain(
+      parsed.evidence.basis,
+    );
+    expect(typeof parsed.evidence.abstain).toBe("boolean");
+    expect(typeof parsed.evidence.rationale).toBe("string");
+    expect(Array.isArray(parsed.evidence.provenance)).toBe(true);
+  });
+
+  it("returns abstain envelope when no results found", async () => {
+    const wiki = freshWiki();
+    wiki.write("unrelated.md", "---\ntitle: Soup\n---\nA recipe.");
+    const result = await handleTool(wiki, "wiki_search", { query: "kubernetes orchestration" });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.results).toHaveLength(0);
+    expect(parsed.evidence.abstain).toBe(true);
+    expect(parsed.evidence.confidence).toBe("absent");
+    expect(parsed.evidence.basis).toBe("unsupported");
+  });
+
+  it("wiki_search_read response carries an evidence envelope", async () => {
+    const wiki = freshWiki();
+    wiki.write("page.md", "---\ntitle: Test\nsources: [raw/source.md]\n---\n## Section\nContent about widgets.");
+    const result = await handleTool(wiki, "wiki_search_read", { query: "widgets", readTopN: 1 });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.evidence).toBeDefined();
+    expect(parsed.evidence.rationale).toBeTypeOf("string");
+  });
+
+  it("wiki_search_read downgrades envelope when top page has no sources", async () => {
+    const wiki = freshWiki();
+    // Two pages, both about the topic. The top match has empty sources.
+    wiki.write("a.md", "---\ntitle: Widget Guide\nsources: []\n---\nWidgets and gadgets and gizmos.");
+    wiki.write("b.md", "---\ntitle: Different\nsources: [raw/x.md]\n---\nWidgets in passing.");
+    const result = await handleTool(wiki, "wiki_search_read", { query: "Widget Guide gadgets gizmos", readTopN: 1 });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.evidence.rationale).toMatch(/no sources/);
+  });
+
+  it("wiki_search_read does NOT downgrade for explicit synthesis pages", async () => {
+    const wiki = freshWiki();
+    wiki.write("compiled.md", "---\ntitle: Compiled View\nsources: []\nsynthesis: true\n---\nAggregated knowledge here.");
+    const result = await handleTool(wiki, "wiki_search_read", { query: "Compiled aggregated knowledge", readTopN: 1 });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.evidence.rationale).not.toMatch(/no sources/);
+  });
+});
+
 describe("server tool: wiki_search_read", () => {
   beforeEach(cleanUp);
   afterEach(cleanUp);

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,12 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  buildSearchEnvelope,
+  computeSearchDistribution,
+  downgradeForReadPage,
+} from "./evidence-search.js";
 import { join, resolve, basename, extname } from "node:path";
 import { Wiki, splitSections, buildToc, findSectionByHeading, matchSimpleGlob, safePath } from "./wiki.js";
 import { extractDocument, chunkSegments, guessMime, type ExtractionSegment } from "./extraction.js";
@@ -1399,6 +1404,17 @@ function buildKnowledgeGap(query: string, wiki: Wiki, forceType?: string): Recor
   };
 }
 
+/** Load cached search-distribution stats; returns null when the cache doesn't exist yet. */
+function loadSearchStats(wiki: Wiki): import("./evidence-search.js").CorpusSearchStats | null {
+  try {
+    const path = join(wiki.config.workspace, ".agent-wiki", "search-distribution.json");
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 /** Shared page-content reader used by wiki_search (read_top_n mode) and wiki_search_read. */
 function readPagesContent(
   wiki: Wiki,
@@ -1772,12 +1788,16 @@ export async function handleTool(
             return true;
           }).slice(0, searchLimit)
         : rawResults;
+      const searchStats = loadSearchStats(wiki);
+      const envelope = buildSearchEnvelope(results, searchStats, searchQuery);
+
       // Knowledge gap: guide the agent when the search finds nothing
       if (results.length === 0) {
         return JSON.stringify({
           results: [],
           count: 0,
           knowledge_gap: buildKnowledgeGap(searchQuery, wiki, filterType),
+          evidence: envelope,
         }, null, 2);
       }
       // Combined search+read mode (read_top_n) — supersedes include_content when both are set
@@ -1801,17 +1821,29 @@ export async function handleTool(
         const nextReads = uniquePaths.slice(readTopN);
         const pages = readPagesContent(wiki, toRead, sectionFilter, perPageLimit, includeToc);
 
+        // Downgrade envelope based on the top read page's metadata.
+        const topPage = toRead.length > 0 ? wiki.read(toRead[0]!) : null;
+        const readEnvelope = topPage
+          ? downgradeForReadPage(envelope, {
+              sources: topPage.sources,
+              synthesis: topPage.frontmatter.synthesis === true,
+              legacyUnsupported: topPage.frontmatter.legacyUnsupported === true,
+              lastEditISO: topPage.updated,
+            })
+          : envelope;
+
         return JSON.stringify({
           results,
           count: results.length,
           pages,
           pagesRead: pages.length,
           nextReads,
+          evidence: readEnvelope,
         }, null, 2);
       }
 
       if (!args.include_content) {
-        return JSON.stringify({ results, count: results.length }, null, 2);
+        return JSON.stringify({ results, count: results.length, evidence: envelope }, null, 2);
       }
       // Inline page content — eliminates follow-up wiki_read calls
       const inlineBudget = args.inline_budget != null ? (args.inline_budget as number) : Infinity;
@@ -1867,7 +1899,7 @@ export async function handleTool(
           return { ...r, content: null };
         }
       });
-      return JSON.stringify({ results: enriched, count: enriched.length }, null, 2);
+      return JSON.stringify({ results: enriched, count: enriched.length, evidence: envelope }, null, 2);
     }
 
     case "wiki_search_read": {
@@ -1883,6 +1915,9 @@ export async function handleTool(
         ? await wiki.searchHybrid(query, limit)
         : wiki.search(query, limit);
 
+      const stats = loadSearchStats(wiki);
+      const envelope = buildSearchEnvelope(results, stats, query);
+
       // Knowledge gap: guide the agent when the search finds nothing
       if (results.length === 0) {
         return JSON.stringify({
@@ -1892,6 +1927,7 @@ export async function handleTool(
           count: 0,
           pagesRead: 0,
           knowledge_gap: buildKnowledgeGap(query, wiki),
+          evidence: envelope,
         }, null, 2);
       }
 
@@ -1909,12 +1945,24 @@ export async function handleTool(
       const nextReads = uniquePaths.slice(readTopN);
       const pages = readPagesContent(wiki, toRead, sectionFilter, perPageLimit, includeToc);
 
+      // Downgrade envelope based on the top read page's metadata.
+      const topPage = toRead.length > 0 ? wiki.read(toRead[0]!) : null;
+      const readEnvelope = topPage
+        ? downgradeForReadPage(envelope, {
+            sources: topPage.sources,
+            synthesis: topPage.frontmatter.synthesis === true,
+            legacyUnsupported: topPage.frontmatter.legacyUnsupported === true,
+            lastEditISO: topPage.updated,
+          })
+        : envelope;
+
       return JSON.stringify({
         results,
         count: results.length,
         pages,
         pagesRead: pages.length,
         nextReads,
+        evidence: readEnvelope,
       }, null, 2);
     }
 
@@ -2017,6 +2065,24 @@ export async function handleTool(
       if (wiki.config.search.hybrid) {
         vectorStats = await wiki.rebuildVectorIndex().catch(() => undefined);
       }
+
+      // Refresh the search-distribution stats used by wiki_search abstain.
+      // Cheap on small corpora; sampled on large ones (see computeSearchDistribution).
+      try {
+        const titles = [...pageCache.values()]
+          .map((p) => p.title)
+          .filter((t) => typeof t === "string" && t.trim().length > 0);
+        const stats = computeSearchDistribution(titles, (q) => wiki.search(q, 5));
+        const dir = join(wiki.config.workspace, ".agent-wiki");
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+        writeFileSync(
+          join(dir, "search-distribution.json"),
+          JSON.stringify(stats, null, 2),
+        );
+      } catch {
+        // Stats are advisory; never fail rebuild because of them.
+      }
+
       const parts: string[] = ["Index and timeline rebuilt"];
       if (graphStats) {
         parts.push(`Knowledge graph: ${graphStats.nodes} nodes, ${graphStats.edges} edges`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,12 +15,8 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import {
-  buildSearchEnvelope,
-  computeSearchDistribution,
-  downgradeForReadPage,
-} from "./evidence-search.js";
+import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { buildSearchEnvelope, downgradeForReadPage } from "./evidence-search.js";
 import { join, resolve, basename, extname } from "node:path";
 import { Wiki, splitSections, buildToc, findSectionByHeading, matchSimpleGlob, safePath } from "./wiki.js";
 import { extractDocument, chunkSegments, guessMime, type ExtractionSegment } from "./extraction.js";
@@ -1404,17 +1400,6 @@ function buildKnowledgeGap(query: string, wiki: Wiki, forceType?: string): Recor
   };
 }
 
-/** Load cached search-distribution stats; returns null when the cache doesn't exist yet. */
-function loadSearchStats(wiki: Wiki): import("./evidence-search.js").CorpusSearchStats | null {
-  try {
-    const path = join(wiki.config.workspace, ".agent-wiki", "search-distribution.json");
-    if (!existsSync(path)) return null;
-    return JSON.parse(readFileSync(path, "utf-8"));
-  } catch {
-    return null;
-  }
-}
-
 /** Shared page-content reader used by wiki_search (read_top_n mode) and wiki_search_read. */
 function readPagesContent(
   wiki: Wiki,
@@ -1788,8 +1773,7 @@ export async function handleTool(
             return true;
           }).slice(0, searchLimit)
         : rawResults;
-      const searchStats = loadSearchStats(wiki);
-      const envelope = buildSearchEnvelope(results, searchStats, searchQuery);
+      const envelope = buildSearchEnvelope(results, searchQuery);
 
       // Knowledge gap: guide the agent when the search finds nothing
       if (results.length === 0) {
@@ -1915,8 +1899,7 @@ export async function handleTool(
         ? await wiki.searchHybrid(query, limit)
         : wiki.search(query, limit);
 
-      const stats = loadSearchStats(wiki);
-      const envelope = buildSearchEnvelope(results, stats, query);
+      const envelope = buildSearchEnvelope(results, query);
 
       // Knowledge gap: guide the agent when the search finds nothing
       if (results.length === 0) {
@@ -2064,23 +2047,6 @@ export async function handleTool(
       let vectorStats: { pagesProcessed: number; errors: number } | undefined;
       if (wiki.config.search.hybrid) {
         vectorStats = await wiki.rebuildVectorIndex().catch(() => undefined);
-      }
-
-      // Refresh the search-distribution stats used by wiki_search abstain.
-      // Cheap on small corpora; sampled on large ones (see computeSearchDistribution).
-      try {
-        const titles = [...pageCache.values()]
-          .map((p) => p.title)
-          .filter((t) => typeof t === "string" && t.trim().length > 0);
-        const stats = computeSearchDistribution(titles, (q) => wiki.search(q, 5));
-        const dir = join(wiki.config.workspace, ".agent-wiki");
-        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-        writeFileSync(
-          join(dir, "search-distribution.json"),
-          JSON.stringify(stats, null, 2),
-        );
-      } catch {
-        // Stats are advisory; never fail rebuild because of them.
       }
 
       const parts: string[] = ["Index and timeline rebuilt"];


### PR DESCRIPTION
## Summary

First adopter of the `EvidenceEnvelope` contract from #79 (Phase 0). `wiki_search` and `wiki_search_read` now expose an `evidence` field so consumers can branch on confidence / abstain instead of treating every BM25 hit as authoritative.

## Core logic

New `src/evidence-search.ts`:

- **`buildSearchEnvelope(results, stats, query)`** — per the rules in `docs/evidence-envelope.md`:
  - 0 results → `absent + abstain`
  - top1 below absolute floor (BM25 < 2.0) → `absent + abstain`
  - top1 below corpus 30th percentile (only on large corpora) → `absent + abstain`
  - top1 ≥ 2× top2 → `strong`
  - else → `weak`
- **`downgradeForReadPage(envelope, page)`** — applied by `wiki_search_read` to step the search envelope down based on the top-read page's own metadata: empty sources without `synthesis: true` → step down once; `legacyUnsupported: true` → step down once; lastEdit > 90 days → rationale note only.
- **`computeSearchDistribution(titles, runQuery)`** — sample page titles through search to compute the 30th-percentile cutoff for the cache. Skips computation on small corpora (< 20 pages); the caller then falls back to absolute floor only.

## Wiring

- `wiki_search` and `wiki_search_read` response payloads gain an `evidence` field (additive).
- `wiki_admin rebuild` writes the cached stats to `${workspace}/.agent-wiki/search-distribution.json`. Stats failure is swallowed; rebuild itself never fails because of evidence bookkeeping.

## Tests

- `src/evidence-search.test.ts` — 17 unit cases covering all confidence rules, every downgrade path, and `computeSearchDistribution` boundary behavior.
- `src/server.test.ts` — 5 integration cases asserting the envelope appears in real responses and the downgrade rationale fires correctly.

`npm run build` — clean
`npm test` — 1473/1473.

## What's not in this PR

- Hybrid search vector blending — deferred per acceptance criteria; will fold in once we have signal on whether vector scores correlate with confidence.
- Multi-source page saturation curve — deferred to Phase 2a.

Closes #4.