### PR TITLE
fix(cobol): strip quotes from PROGRAM-ID quoted-literal values

### DIFF
--- a/src/cobol/__tests__/parser.test.ts
+++ b/src/cobol/__tests__/parser.test.ts
@@ -167,4 +167,45 @@ describe("COBOL parser", () => {
       expect(conditions[1].name).toBe("DATE-INVALID");
     });
   });
+
+  describe("PROGRAM-ID quoted-literal handling", () => {
+    it("strips single quotes around the program name", () => {
+      const src = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. 'MY-PROG'.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STOP RUN.
+`;
+      const ast = parse(src, "quoted.cbl");
+      expect(ast.programId).toBe("MY-PROG");
+    });
+
+    it("strips double quotes around the program name", () => {
+      const src = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. "MY-PROG".
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STOP RUN.
+`;
+      const ast = parse(src, "dq.cbl");
+      expect(ast.programId).toBe("MY-PROG");
+    });
+
+    it("leaves unquoted PROGRAM-ID identifiers untouched", () => {
+      const src = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PLAIN-PROG.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STOP RUN.
+`;
+      const ast = parse(src, "plain.cbl");
+      expect(ast.programId).toBe("PLAIN-PROG");
+    });
+  });
 });

--- a/src/cobol/parser.ts
+++ b/src/cobol/parser.ts
@@ -593,6 +593,12 @@ class Parser {
     // Look through the raw tokens we already parsed.
     // The PROGRAM-ID is stored as tokens: PROGRAM_ID PERIOD? IDENTIFIER PERIOD?
     // We need to scan the tokens in the IDENTIFICATION division region.
+    //
+    // The COBOL spec accepts both `PROGRAM-ID. NAME.` (IDENTIFIER) and
+    // `PROGRAM-ID. 'NAME'.` / `PROGRAM-ID. "NAME".` (quoted LITERAL). The
+    // lexer keeps the surrounding quotes on LITERAL tokens; strip them
+    // here so downstream consumers (filenames, graph node IDs, lineage
+    // entries) get a clean program name.
     for (let i = 0; i < this.tokens.length - 1; i++) {
       if (this.tokens[i].type === "PROGRAM_ID") {
         // Skip period and IS
@@ -601,7 +607,7 @@ class Parser {
           j++;
         }
         if (j < this.tokens.length && (this.tokens[j].type === "IDENTIFIER" || this.tokens[j].type === "LITERAL")) {
-          return this.tokens[j].value;
+          return stripQuotes(this.tokens[j].value);
         }
       }
     }
@@ -612,6 +618,17 @@ class Parser {
 // ---------------------------------------------------------------------------
 // Data item hierarchy builder
 // ---------------------------------------------------------------------------
+
+/** Strip a single matched pair of surrounding ASCII quote characters. */
+function stripQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === "'" || first === '"') && first === last) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
 
 /**
  * Flat list of data items with level numbers → nested tree.


### PR DESCRIPTION
## Summary

The COBOL spec accepts both `PROGRAM-ID. NAME.` (IDENTIFIER token) and `PROGRAM-ID. 'NAME'.` / `"NAME".` (LITERAL token, quotes preserved by the lexer). `extractProgramId` returned the raw token value, so quoted-literal program names leaked the quote characters into every downstream consumer:

- Wiki page filenames became `'name'.md` instead of `name.md` — broken links, invalid filesystem paths.
- Knowledge graph node IDs included the quotes.
- Lineage entries (call-bound, DB2 table) keyed off the quoted form, so `CALL "OTHER"` from one program never resolved to a callee whose own `PROGRAM-ID` was a quoted literal.

## Fix

Small `stripQuotes` helper that removes a matched pair of surrounding single or double ASCII quotes; applied to the value returned by `extractProgramId`. Idempotent on already-clean identifiers.

## Tests

Three new cases in `src/cobol/__tests__/parser.test.ts`:

- single-quoted PROGRAM-ID is stripped
- double-quoted PROGRAM-ID is stripped
- unquoted PROGRAM-ID identifier is left untouched (regression guard against accidentally stripping legitimate characters)

`npm run build` — clean
`npm test` — 1471/1471, no other regressions.