### PR TITLE
chore: rename npm package to @agent-wiki/mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Instead of retrieving raw fragments every query (RAG), your agent compiles, refi
 
 Works with Claude Code, Cursor, Windsurf, and any MCP client. Also installable as a native skill for Claude Code. No LLM built in — your agent IS the intelligence.
 
-[![npm](https://img.shields.io/npm/v/@agent-wiki/mcp-server?label=%40agent-wiki%2Fmcp-server)](https://www.npmjs.com/package/@agent-wiki/mcp-server)
+[![npm](https://img.shields.io/npm/v/@agent-wiki/mcp?label=%40agent-wiki%2Fmcp)](https://www.npmjs.com/package/@agent-wiki/mcp)
 [![CI](https://github.com/xinhuagu/agent-wiki/actions/workflows/ci.yml/badge.svg)](https://github.com/xinhuagu/agent-wiki/actions/workflows/ci.yml)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-blue)](https://modelcontextprotocol.io)
@@ -31,7 +31,7 @@ Add to your MCP client config:
   "mcpServers": {
     "agent-wiki": {
       "command": "npx",
-      "args": ["-y", "@agent-wiki/mcp-server", "serve", "--wiki-path", "/path/to/knowledge"]
+      "args": ["-y", "@agent-wiki/mcp", "serve", "--wiki-path", "/path/to/knowledge"]
     }
   }
 }
@@ -40,7 +40,7 @@ Add to your MCP client config:
 ### Option B: Native Skill (Claude Code)
 
 ```bash
-npm install -g @agent-wiki/mcp-server
+npm install -g @agent-wiki/mcp
 
 # Install as Claude Code plugin
 agent-wiki install claude-code
@@ -49,7 +49,7 @@ agent-wiki install claude-code
 ### Option C: CLI only
 
 ```bash
-npx @agent-wiki/mcp-server call wiki_search '{"query": "deployment"}'
+npx @agent-wiki/mcp call wiki_search '{"query": "deployment"}'
 ```
 
 ### Option D: 3D Graph Viewer
@@ -57,7 +57,7 @@ npx @agent-wiki/mcp-server call wiki_search '{"query": "deployment"}'
 See your wiki as a realtime 3D knowledge graph — edits push live via SSE. Included in the main package, no separate install needed.
 
 ```bash
-npm install -g @agent-wiki/mcp-server
+npm install -g @agent-wiki/mcp
 agent-wiki web --wiki-path ./wiki --open
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Resolution priority: CLI `--workspace` > `AGENT_WIKI_WORKSPACE` env > config fil
 Code and data live in separate directories. The tool is stateless — all state lives in the workspace:
 
 ```
-npx @agent-wiki/mcp-server serve --wiki-path ./config --workspace ./data
+npx @agent-wiki/mcp serve --wiki-path ./config --workspace ./data
 ```
 
 This creates:

--- a/graph-viewer/README.md
+++ b/graph-viewer/README.md
@@ -6,7 +6,7 @@ Edit a `.md` file — the graph updates live.
 ## Zero coupling with core
 
 This package is **physically and functionally independent** from
-`@agent-wiki/mcp-server`:
+`@agent-wiki/mcp`:
 
 - Core `agent-wiki` does not import, require, or depend on this package.
 - This package reads a wiki directory as plain Markdown (frontmatter +
@@ -23,7 +23,7 @@ After publishing, three equivalent ways to launch:
 ```bash
 # 1. Through the core CLI (thin handoff — installs nothing in core, resolves
 #    and spawns this package at runtime). Needs both packages installed.
-npm install -g @agent-wiki/mcp-server @agent-wiki/graph-viewer
+npm install -g @agent-wiki/mcp @agent-wiki/graph-viewer
 agent-wiki web --wiki-path ./wiki --open
 
 # 2. Standalone binary, after installing this package:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-wiki/mcp-server",
+  "name": "@agent-wiki/mcp",
   "version": "0.17.6",
   "description": "Agent-driven knowledge base — immutable raw sources + mutable wiki + self-checking lint. MCP server, no LLM needed.",
   "type": "module",

--- a/skills/agent-wiki/SKILL.md
+++ b/skills/agent-wiki/SKILL.md
@@ -26,7 +26,7 @@ schemas/→ Entity templates (person, concept, event, artifact, ...)
 
 ## How to Call Tools
 
-Every tool is invoked via the CLI `call` command. The binary is `agent-wiki` (or `npx @agent-wiki/mcp-server` if not globally installed).
+Every tool is invoked via the CLI `call` command. The binary is `agent-wiki` (or `npx @agent-wiki/mcp` if not globally installed).
 
 ```bash
 agent-wiki call <tool_name> '<json_args>'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,9 +4,9 @@
  * CLI entry point for agent-wiki.
  *
  * Usage:
- *   npx @agent-wiki/mcp-server                  # start MCP server (stdio)
- *   npx @agent-wiki/mcp-server --wiki-path /kb  # custom wiki root
- *   npx @agent-wiki/mcp-server init ./my-kb     # initialize a new knowledge base
+ *   npx @agent-wiki/mcp                  # start MCP server (stdio)
+ *   npx @agent-wiki/mcp --wiki-path /kb  # custom wiki root
+ *   npx @agent-wiki/mcp init ./my-kb     # initialize a new knowledge base
  */
 
 import { Command } from "commander";
@@ -335,7 +335,7 @@ program
         const wikiPath = resolve(opts.wikiPath ?? ".");
         servers["agent-wiki"] = {
           command: "npx",
-          args: ["-y", "@agent-wiki/mcp-server", "serve", "--wiki-path", wikiPath],
+          args: ["-y", "@agent-wiki/mcp", "serve", "--wiki-path", wikiPath],
         };
         // Write back — use mcpServers key if it was already used, else top-level
         const output = mcpConfig.mcpServers ? mcpConfig : { mcpServers: servers };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,10 @@
  *   - MCP server interface
  *
  * Usage as MCP server:
- *   npx @agent-wiki/mcp-server
+ *   npx @agent-wiki/mcp
  *
  * Usage as library:
- *   import { Wiki } from "@agent-wiki/mcp-server";
+ *   import { Wiki } from "@agent-wiki/mcp";
  *   const wiki = new Wiki("/path/to/kb");
  *   wiki.rawAdd("paper.md", { content: "...", sourceUrl: "..." });
  *   wiki.write("concept-gil.md", content);


### PR DESCRIPTION
## Summary

graph-viewer is no longer published as a separate npm package — it lives in this repo as an internal sub-component. With only one npm artifact under the `@agent-wiki` scope, the `-server` suffix is no longer disambiguating against a hypothetical client / sdk. Drop it for the shorter name.

## Renames

`@agent-wiki/mcp-server` → `@agent-wiki/mcp`

### What stays put

- **GitHub Packages mirror** at `@xinhuagu/agent-wiki` — already has 0.17.4 / 0.17.5 / 0.17.6 published; renaming would orphan those versions on GH Packages.
- **Repo name** — `xinhuagu/agent-wiki` is unaffected; the rename is purely npm-side.

## Files touched (7)

- `package.json` — name field
- `README.md` — npm badge URL + label (URL-encoded form too) + 4 install examples
- `graph-viewer/README.md` — install example
- `docs/configuration.md` — install example
- `src/index.ts` — jsdoc usage example
- `src/cli.ts` — jsdoc usage examples + the `.mcp.json` scaffolding string emitted by `agent-wiki init`
- `skills/agent-wiki/SKILL.md` — npx fallback line

## After merge

Run `npm deprecate '@agent-wiki/mcp-server@*' "Renamed to @agent-wiki/mcp — install that instead."` so installers of the old name see a redirect notice. (Cannot be done in CI — needs interactive npm auth.)

`npm test` — 1471/1471, no regressions.