### PR TITLE
chore(release): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,15 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
 
-      # Publish to npm (npmjs.org)
+      # Publish to npm (npmjs.org) via Trusted Publishing.
+      # No NPM_TOKEN required — the workflow exchanges its short-lived
+      # GitHub Actions OIDC token (id-token: write permission) for an
+      # npm authentication via the Trusted Publisher configured on the
+      # @agent-wiki/mcp package settings (Add Trusted Publisher: this
+      # repo, this workflow file). `--provenance` is what triggers the
+      # OIDC handshake; it also ships build attestation to Sigstore.
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Publish a mirror copy to GitHub Packages under @xinhuagu/agent-wiki.
       # GitHub Packages requires the npm scope to match the GitHub user/org;


### PR DESCRIPTION
## Summary

Drop `NODE_AUTH_TOKEN` from the npm publish step. The workflow already has `id-token: write` permission, so `npm publish --provenance` exchanges the short-lived GitHub Actions OIDC token for npm authentication — provided `@agent-wiki/mcp` has a Trusted Publisher configured pointing at this repo + this workflow filename.

## Pre-merge setup (one-time, on npmjs.com)

```
@agent-wiki/mcp → Settings → Trusted Publishers → Add Trusted Publisher
  Type:               GitHub Actions
  Repository owner:   xinhuagu
  Repository name:    agent-wiki
  Workflow filename:  release.yml
  Environment:        (leave empty)
```

If this is configured before merge, the next release run will use OIDC end-to-end with no token involvement.

## Why

- No long-lived `NPM_TOKEN` to rotate or worry about leaking.
- Tokens can't be stolen — OIDC tokens last seconds and are scoped to the specific workflow run.
- Audit trail ties each publish to a specific workflow run + commit (npm shows it).
- npm itself recommends this over classic tokens for CI/CD.

## What's not changing

- **GitHub Packages step** is unaffected; it still uses `PACKAGES_TOKEN` because GH Packages doesn't yet support OIDC trusted publishing for user-scoped packages.
- **Release workflow shape** otherwise identical (build, test, version bump, tag, GitHub release page, then npm publish).

## After this lands

If the next release succeeds end-to-end, `NPM_TOKEN` can be removed from repo secrets:

```bash
gh secret delete NPM_TOKEN -R xinhuagu/agent-wiki
```

Hold off on deletion until at least one trusted-publish release verifies the path works — easy rollback if something is off.