### PR TITLE
chore(release): restore NPM_TOKEN fallback for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,19 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true
 
-      # Publish to npm (npmjs.org) via Trusted Publishing.
-      # No NPM_TOKEN required — the workflow exchanges its short-lived
-      # GitHub Actions OIDC token (id-token: write permission) for an
-      # npm authentication via the Trusted Publisher configured on the
-      # @agent-wiki/mcp package settings (Add Trusted Publisher: this
-      # repo, this workflow file). `--provenance` is what triggers the
-      # OIDC handshake; it also ships build attestation to Sigstore.
+      # Publish to npm (npmjs.org).
+      #
+      # We tried Trusted Publishing (OIDC) earlier; provenance signing
+      # via OIDC works (Sigstore transparency entry is created), but
+      # the actual publish kept returning 404 even with the trusted
+      # publisher configured to match the workflow filename / repo.
+      # Falling back to the classic NPM_TOKEN path until that's
+      # diagnosed. `--provenance` is kept on either path so users still
+      # get the Sigstore attestation.
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Publish a mirror copy to GitHub Packages under @xinhuagu/agent-wiki.
       # GitHub Packages requires the npm scope to match the GitHub user/org;


### PR DESCRIPTION
## Summary

PR #12 switched to Trusted Publishing (OIDC). Provenance signing succeeded (Sigstore transparency entry was created during the failed run), so the OIDC handshake works — but the actual `npm publish` endpoint returned 404 even with the trusted publisher configured to match repo + workflow filename + `release.yml`.

Falling back to the classic `NPM_TOKEN` env to unblock releases. `--provenance` stays — users still get the Sigstore attestation either way.

## What's restored

```yaml
- name: Publish to npm
  run: npm publish --provenance --access public
  env:
    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## What stays

- Trusted publisher config on `@agent-wiki/mcp` on npmjs.com — leave it; does no harm with token also present.
- `NPM_TOKEN` secret — required again for this path.
- `id-token: write` permission on the job — needed for `--provenance` OIDC signing regardless of auth path.

## Diagnosing OIDC later (out of scope here)

Possible follow-ups:
- Add explicit `scope: '@agent-wiki'` to `actions/setup-node` so the registry config matches what npm expects.
- Pin npm to a known-good version (npm 11.x is where trusted publishing landed; setup-node@v4 with node 22 should be fine).
- Wait for any npm-side propagation delay (some users report 5-10 minute lag after configuring trusted publisher).
- Confirm trusted publisher is on `@agent-wiki/mcp`, not the deprecated `@agent-wiki/mcp-server`.

After this lands and a release succeeds (will be 0.17.11 since v0.17.10 tag was created in the failed run but never published to npm), we can re-attempt OIDC in a follow-up PR.