### PR TITLE
feat(evidence): lineage diagnostics + envelope wrapping (#6 phase 3)

### DIFF
--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -276,6 +276,47 @@ describe("buildCallBoundLineage", () => {
     expect(lineage!.diagnostics[0]!.target).toBe("WS-PROG-NAME");
   });
 
+  it("attaches a weak/inferred envelope to high-confidence entries (name divergence)", () => {
+    // Top-level group pair matches deterministically; descended children
+    // have divergent names → child entries are confidence: "high" → envelope
+    // should be weak/inferred.
+    const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-REC.
+           05  WS-FOO         PIC X(5).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-REC.
+           STOP RUN.
+`;
+    const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-REC.
+           05  LK-COMPLETELY-OTHER-NAME PIC X(5).
+       PROCEDURE DIVISION USING LK-REC.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    const lineage = buildCallBoundLineage([
+      model(callerSrc, "CALLER.cbl"),
+      model(calleeSrc, "CALLEE.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    const child = lineage!.entries.find((e) => e.confidence === "high");
+    expect(child).toBeDefined();
+    expect(child!.envelope.confidence).toBe("weak");
+    expect(child!.envelope.basis).toBe("inferred");
+    expect(child!.envelope.abstain).toBe(false);
+  });
+
   it("attaches an EvidenceEnvelope to each entry derived from confidence tier", () => {
     const callerSrc = `
        IDENTIFICATION DIVISION.

--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -136,7 +136,7 @@ describe("buildCallBoundLineage", () => {
     ]);
   });
 
-  it("does not emit entries when USING arity differs from LINKAGE arity", () => {
+  it("emits arity-mismatch diagnostic when USING arity differs from LINKAGE arity", () => {
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -166,10 +166,14 @@ describe("buildCallBoundLineage", () => {
       model(callee, "CALLEE.cbl"),
     ]);
 
-    expect(lineage).toBeNull();
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    expect(lineage!.diagnostics).toHaveLength(1);
+    expect(lineage!.diagnostics[0]!.kind).toBe("arity-mismatch");
+    expect(lineage!.diagnostics[0]!.target).toBe("CALLEE");
   });
 
-  it("does not emit entries when scalar PICs differ", () => {
+  it("emits shape-mismatch diagnostic when scalar PICs differ", () => {
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -198,10 +202,12 @@ describe("buildCallBoundLineage", () => {
       model(callee, "CALLEE.cbl"),
     ]);
 
-    expect(lineage).toBeNull();
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    expect(lineage!.diagnostics.map((d) => d.kind)).toEqual(["shape-mismatch"]);
   });
 
-  it("does not emit entries when one side is a group and the other is a scalar", () => {
+  it("emits shape-mismatch diagnostic when one side is a group and the other is a scalar", () => {
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -231,7 +237,9 @@ describe("buildCallBoundLineage", () => {
       model(callee, "CALLEE.cbl"),
     ]);
 
-    expect(lineage).toBeNull();
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    expect(lineage!.diagnostics.map((d) => d.kind)).toEqual(["shape-mismatch"]);
   });
 
   it("does not emit entries when callee is unresolved (no parsed program with that name)", () => {
@@ -242,7 +250,7 @@ describe("buildCallBoundLineage", () => {
     expect(lineage).toBeNull();
   });
 
-  it("does not emit entries for dynamic CALL where target is a variable", () => {
+  it("emits dynamic-call diagnostic when CALL target is a variable identifier", () => {
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -262,10 +270,52 @@ describe("buildCallBoundLineage", () => {
       model(calleeWithLinkageGroup, "CALLEE.cbl"),
     ]);
 
-    expect(lineage).toBeNull();
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    expect(lineage!.diagnostics.map((d) => d.kind)).toEqual(["dynamic-call"]);
+    expect(lineage!.diagnostics[0]!.target).toBe("WS-PROG-NAME");
   });
 
-  it("does not emit entries when caller's USING arg is not a top-level data item", () => {
+  it("attaches an EvidenceEnvelope to each entry derived from confidence tier", () => {
+    const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-A               PIC X(5).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-A.
+           STOP RUN.
+`;
+    const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-A               PIC X(5).
+       PROCEDURE DIVISION USING LK-A.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    const lineage = buildCallBoundLineage([
+      model(callerSrc, "CALLER.cbl"),
+      model(calleeSrc, "CALLEE.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    const entry = lineage!.entries[0]!;
+    expect(entry.envelope.confidence).toBe("strong");
+    expect(entry.envelope.basis).toBe("deterministic");
+    expect(entry.envelope.abstain).toBe(false);
+    expect(entry.envelope.provenance).toEqual([
+      { raw: "CALLER.cbl", line: expect.any(Number) },
+      { raw: "CALLEE.cbl" },
+    ]);
+  });
+
+  it("emits caller-arg-not-top-level diagnostic when USING arg is nested", () => {
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -295,7 +345,9 @@ describe("buildCallBoundLineage", () => {
       model(callee, "CALLEE.cbl"),
     ]);
 
-    expect(lineage).toBeNull();
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    expect(lineage!.diagnostics.map((d) => d.kind)).toEqual(["caller-arg-not-top-level"]);
   });
 
   it("does not emit entries when CALL has no USING clause", () => {

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -111,7 +111,7 @@ describe("buildDb2TableLineage", () => {
     expect(readerIds).toEqual(["program:READERA", "program:READERB"]);
   });
 
-  it("returns null when a table is only written and never read in the corpus", () => {
+  it("emits writer-only / reader-only diagnostics when a table flows only one way", () => {
     const writer = programWith("WRITER", [[
       "EXEC SQL INSERT INTO ORPHAN (NAME)",
       "  VALUES (:WS-NAME) END-EXEC",
@@ -126,11 +126,19 @@ describe("buildDb2TableLineage", () => {
       model(other, "OTHER.cbl"),
     ]);
 
-    // ORPHAN has no reader; SOMETHING-ELSE has no writer; no entries.
-    expect(lineage).toBeNull();
+    // ORPHAN has no reader; SOMETHING-ELSE has no writer; no entries but
+    // both are surfaced as diagnostics.
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    const byKind = lineage!.diagnostics.reduce<Record<string, string[]>>((acc, d) => {
+      (acc[d.kind] ??= []).push(d.table ?? "");
+      return acc;
+    }, {});
+    expect(byKind["writer-only"]).toEqual(["ORPHAN"]);
+    expect(byKind["reader-only"]).toEqual(["SOMETHING-ELSE"]);
   });
 
-  it("excludes non-classifiable operations like DECLARE / OPEN / CLOSE", () => {
+  it("emits non-classifiable-op diagnostic for DECLARE / OPEN / CLOSE", () => {
     const declarer = programWith("DECLARER", [[
       "EXEC SQL DECLARE C-CUR CURSOR FOR",
       "  SELECT ID FROM CUSTOMERS END-EXEC",
@@ -145,12 +153,16 @@ describe("buildDb2TableLineage", () => {
       model(reader, "READER.cbl"),
     ]);
 
-    // DECLARE is not classified as a write; CUSTOMERS has no writer in scope.
-    // READER alone reads, so no lineage emitted.
-    expect(lineage).toBeNull();
+    // DECLARE is not in WRITE_OPS or READ_OPS; surfaces as non-classifiable-op.
+    // READER alone reads CUSTOMERS, so it surfaces as reader-only.
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    const declareDiag = lineage!.diagnostics.find((d) => d.kind === "non-classifiable-op");
+    expect(declareDiag?.operation).toBe("DECLARE");
+    expect(lineage!.diagnostics.some((d) => d.kind === "reader-only" && d.table === "CUSTOMERS")).toBe(true);
   });
 
-  it("excludes self-loops where the same program writes and reads the same table", () => {
+  it("emits self-loop diagnostic when one program writes and reads the same table", () => {
     const both = programWith("BOTH", [
       ["EXEC SQL INSERT INTO LOG (MSG)", "  VALUES (:WS-NAME) END-EXEC"],
       ["EXEC SQL SELECT MSG INTO :WS-NAME", "  FROM LOG END-EXEC"],
@@ -166,8 +178,12 @@ describe("buildDb2TableLineage", () => {
     ]);
 
     // BOTH is the only program touching LOG, and it both writes and reads —
-    // self-loop excluded; no cross-program lineage on LOG.
-    expect(lineage).toBeNull();
+    // self-loop diagnostic emitted; no entry on LOG.
+    expect(lineage).not.toBeNull();
+    expect(lineage!.entries).toHaveLength(0);
+    const selfLoop = lineage!.diagnostics.find((d) => d.kind === "self-loop");
+    expect(selfLoop?.table).toBe("LOG");
+    expect(selfLoop?.programId).toBe("program:BOTH");
   });
 
   it("aggregates multiple write ops on the same table from the same program", () => {
@@ -193,6 +209,30 @@ describe("buildDb2TableLineage", () => {
     expect(entry.writer.operations).toEqual(["INSERT", "UPDATE"]);
     expect(entry.evidence.writerOps).toEqual(["INSERT", "UPDATE"]);
     expect(entry.rationale).toContain("INSERT,UPDATE");
+  });
+
+  it("attaches an EvidenceEnvelope (strong/deterministic) to each entry", () => {
+    const writer = programWith("WRITER", [[
+      "EXEC SQL INSERT INTO SHARED (X)",
+      "  VALUES (:WS-X) END-EXEC",
+    ]]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-X",
+      "  FROM SHARED END-EXEC",
+    ]]);
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    const entry = lineage!.entries[0]!;
+    expect(entry.envelope.confidence).toBe("strong");
+    expect(entry.envelope.basis).toBe("deterministic");
+    expect(entry.envelope.abstain).toBe(false);
+    expect(entry.envelope.provenance).toEqual([
+      { raw: "WRITER.cbl" },
+      { raw: "READER.cbl" },
+    ]);
   });
 
   it("returns null when fewer than two parsed programs are provided", () => {

--- a/src/cobol/__tests__/extractors.test.ts
+++ b/src/cobol/__tests__/extractors.test.ts
@@ -152,6 +152,44 @@ describe("COBOL extractors", () => {
       expect(model.calls[0].usingArgs).toEqual(["A", "B", "C"]);
     });
 
+    it("records targetKind=literal for CALL \"NAME\" and CALL 'NAME'", () => {
+      const src = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. LITERALCALL.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "DOUBLEQUOTED" USING WS-A.
+           CALL 'SINGLEQUOTED' USING WS-A.
+           STOP RUN.
+`;
+      const model = extractModel(parse(src, "LITERALCALL.cbl"));
+      expect(model.calls).toHaveLength(2);
+      expect(model.calls[0].target).toBe("DOUBLEQUOTED");
+      expect(model.calls[0].targetKind).toBe("literal");
+      expect(model.calls[1].target).toBe("SINGLEQUOTED");
+      expect(model.calls[1].targetKind).toBe("literal");
+    });
+
+    it("records targetKind=identifier for CALL <variable> (dynamic call)", () => {
+      const src = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DYNAMIC.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PROG-NAME       PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL WS-PROG-NAME USING WS-A.
+           STOP RUN.
+`;
+      const model = extractModel(parse(src, "DYNAMIC.cbl"));
+      expect(model.calls).toHaveLength(1);
+      expect(model.calls[0].target).toBe("WS-PROG-NAME");
+      expect(model.calls[0].targetKind).toBe("identifier");
+    });
+
     it("stops at GIVING / RETURNING / END-CALL", () => {
       const src = `
        IDENTIFICATION DIVISION.

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -344,6 +344,80 @@ describe("COBOL field lineage", () => {
     expect(page.content).toContain("review below");
   });
 
+  it("renders the Excluded-by-diagnostic section only when diagnostics are present", () => {
+    // Two-program corpus where the only CALL site has a shape-mismatch:
+    // the entry list is empty, but a diagnostic should surface in the page.
+    const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-FLD             PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-FLD.
+           STOP RUN.
+`;
+    const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-FLD             PIC 9(8).
+       PROCEDURE DIVISION USING LK-FLD.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    const callLineage = buildCallBoundLineage([
+      model(callerSrc, "CALLER.cbl"),
+      model(calleeSrc, "CALLEE.cbl"),
+    ]);
+    const lineage = attachCallBoundLineage(null, callLineage);
+    expect(lineage).not.toBeNull();
+    const page = generateFieldLineagePage(lineage!);
+    expect(page.content).toContain("## Call Boundary Field Lineage");
+    expect(page.content).toContain("### Excluded by diagnostic");
+    expect(page.content).toContain("shape-mismatch");
+  });
+
+  it("omits the Excluded section when there are no diagnostics", () => {
+    // Same shape on both sides — the call resolves cleanly and no diagnostic fires.
+    const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-FLD             PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-FLD.
+           STOP RUN.
+`;
+    const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-FLD             PIC X(10).
+       PROCEDURE DIVISION USING LK-FLD.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    const callLineage = buildCallBoundLineage([
+      model(callerSrc, "CALLER.cbl"),
+      model(calleeSrc, "CALLEE.cbl"),
+    ]);
+    const lineage = attachCallBoundLineage(null, callLineage);
+    expect(lineage).not.toBeNull();
+    const page = generateFieldLineagePage(lineage!);
+    expect(page.content).toContain("## Call Boundary Field Lineage");
+    expect(page.content).not.toContain("### Excluded by diagnostic");
+  });
+
   it("generates a lineage wiki summary page", () => {
     const lineage = buildFieldLineage([
       model(sharedCopybook, "CUSTOMER-REC.cpy"),

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -382,6 +382,62 @@ describe("COBOL field lineage", () => {
     expect(page.content).toContain("shape-mismatch");
   });
 
+  it("renders the Excluded table rows in pinned kind order, not parser-emit order", () => {
+    // Caller has TWO problematic CALLs in this order in source:
+    //   1. CALL "MISSING" — unresolved-callee (literal, not in corpus)
+    //   2. CALL "CALLEE" with arity mismatch
+    // The diagnostic emit order is unresolved-callee, then arity-mismatch.
+    // The pinned CALL_BOUND_KIND_ORDER also lists unresolved-callee before
+    // arity-mismatch, so the rendered table must reflect that order
+    // independent of parser order. Construct a case where the parser-emit
+    // order and pinned order DIFFER to make the test meaningful: emit
+    // arity-mismatch first, then unresolved-callee.
+    const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-A               PIC X(5).
+       01  WS-B               PIC X(5).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-A WS-B.
+           CALL "MISSING" USING WS-A.
+           STOP RUN.
+`;
+    const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-A               PIC X(5).
+       PROCEDURE DIVISION USING LK-A.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    const callLineage = buildCallBoundLineage([
+      model(callerSrc, "CALLER.cbl"),
+      model(calleeSrc, "CALLEE.cbl"),
+    ]);
+    expect(callLineage).not.toBeNull();
+    // Sanity check: parser-emit order has arity-mismatch BEFORE unresolved-callee.
+    expect(callLineage!.diagnostics.map((d) => d.kind)).toEqual([
+      "arity-mismatch",
+      "unresolved-callee",
+    ]);
+    const lineage = attachCallBoundLineage(null, callLineage);
+    const page = generateFieldLineagePage(lineage!);
+    // Rendered table must have unresolved-callee row BEFORE arity-mismatch row,
+    // matching CALL_BOUND_KIND_ORDER, not the parser order.
+    const unresolvedAt = page.content.indexOf("| unresolved-callee |");
+    const arityAt = page.content.indexOf("| arity-mismatch |");
+    expect(unresolvedAt).toBeGreaterThan(0);
+    expect(arityAt).toBeGreaterThan(0);
+    expect(unresolvedAt).toBeLessThan(arityAt);
+  });
+
   it("omits the Excluded section when there are no diagnostics", () => {
     // Same shape on both sides — the call resolves cleanly and no diagnostic fires.
     const callerSrc = `

--- a/src/cobol/call-boundary-lineage.ts
+++ b/src/cobol/call-boundary-lineage.ts
@@ -10,8 +10,32 @@
 import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
 import { resolveCanonicalId } from "./graph.js";
+import { cobolTierToEvidence } from "./evidence-mapping.js";
+import type { EvidenceEnvelope } from "../evidence.js";
 
 export type CallBoundConfidence = "deterministic" | "high";
+
+/**
+ * Reasons a CALL site or USING-arg pair was excluded from `entries`. Each
+ * silent skip in `buildCallBoundLineage` becomes one diagnostic so the user
+ * can audit why their lineage trace stops at a particular boundary, instead
+ * of guessing whether the data is missing or the analysis chose to drop it.
+ */
+export type CallBoundDiagnosticKind =
+  | "unresolved-callee"        // CALL "FOO" but FOO not in corpus
+  | "dynamic-call"             // CALL <identifier> (resolved at runtime)
+  | "arity-mismatch"           // arg count != callee linkage record count
+  | "shape-mismatch"           // caller/callee record shapes incompatible
+  | "caller-arg-not-top-level"; // USING arg name not a top-level data item
+
+export interface CallBoundDiagnostic {
+  kind: CallBoundDiagnosticKind;
+  callerProgramId: string;
+  /** Callee name as written at the call site (literal stripped of quotes, or identifier). */
+  target: string;
+  callSite: SourceLocation;
+  rationale: string;
+}
 
 export interface CallBoundFieldShape {
   fieldName: string;
@@ -42,7 +66,14 @@ export interface SerializedCallBoundLineageEntry {
   caller: CallBoundParticipant;
   callee: CallBoundParticipant;
   callSite: SourceLocation;
+  /** Domain-specific evidence detail (shape match, picture match, etc.). */
   evidence: CallBoundEvidence;
+  /**
+   * Language-agnostic envelope derived from `confidence` via
+   * `cobolTierToEvidence` — the consumer-facing summary that callers branch
+   * on without parsing domain detail.
+   */
+  envelope: EvidenceEnvelope;
   rationale: string;
 }
 
@@ -50,8 +81,11 @@ export interface CallBoundLineage {
   summary: {
     callSites: number;
     pairs: number;
+    /** Total skipped sites — sum of `diagnostics` length, broken down per kind. */
+    diagnosticsByKind: Record<CallBoundDiagnosticKind, number>;
   };
   entries: SerializedCallBoundLineageEntry[];
+  diagnostics: CallBoundDiagnostic[];
 }
 
 function isCopybook(filename: string): boolean {
@@ -147,12 +181,31 @@ function emitPair(
   callerSourceFile: string,
   calleeSourceFile: string,
   callSite: SourceLocation,
+  calleeName: string,
   entries: SerializedCallBoundLineageEntry[],
+  diagnostics: CallBoundDiagnostic[],
 ): void {
   const callerShape = shapeOf(callerItem, callerQualified);
   const calleeShape = shapeOf(calleeItem, calleeQualified);
   const evidence = compareShape(callerShape, calleeShape);
-  if (!evidence) return;
+  if (!evidence) {
+    // Only surface shape-mismatch at top level — descending into children of
+    // an already-emitted group, then mismatching, is a routine outcome of the
+    // structural match and would flood the diagnostic list with noise.
+    if (isTopLevel) {
+      diagnostics.push({
+        kind: "shape-mismatch",
+        callerProgramId,
+        target: calleeName,
+        callSite,
+        rationale:
+          `Position ${position}: caller \`${callerQualified}\` and callee `
+          + `\`${calleeQualified}\` have incompatible shapes `
+          + `(group/scalar mix or differing PICTURE).`,
+      });
+    }
+    return;
+  }
 
   const confidence: CallBoundConfidence =
     isTopLevel || evidence.nameSuffixMatch ? "deterministic" : "high";
@@ -172,6 +225,7 @@ function emitPair(
     },
     callSite,
     evidence,
+    envelope: buildEnvelope(confidence, callerSourceFile, calleeSourceFile, callSite.line),
     rationale: buildRationale(evidence, position, isTopLevel),
   });
 
@@ -192,10 +246,34 @@ function emitPair(
         callerSourceFile,
         calleeSourceFile,
         callSite,
+        calleeName,
         entries,
+        diagnostics,
       );
     }
   }
+}
+
+function buildEnvelope(
+  confidence: CallBoundConfidence,
+  callerSourceFile: string,
+  calleeSourceFile: string,
+  line: number,
+): EvidenceEnvelope {
+  const tier = cobolTierToEvidence(confidence);
+  return {
+    confidence: tier.confidence,
+    basis: tier.basis,
+    abstain: tier.confidence === "absent",
+    rationale:
+      confidence === "deterministic"
+        ? "Top-level CALL USING boundary or matching name suffix."
+        : "Structural match across CALL USING boundary; names differ.",
+    provenance: [
+      { raw: callerSourceFile, line },
+      { raw: calleeSourceFile },
+    ],
+  };
 }
 
 export function buildCallBoundLineage(models: CobolCodeModel[]): CallBoundLineage | null {
@@ -208,23 +286,63 @@ export function buildCallBoundLineage(models: CobolCodeModel[]): CallBoundLineag
   }
 
   const entries: SerializedCallBoundLineageEntry[] = [];
+  const diagnostics: CallBoundDiagnostic[] = [];
   let callSites = 0;
 
   for (const caller of programs) {
+    const callerProgramId = `program:${resolveCanonicalId(caller)}`;
     for (const call of caller.calls) {
+      // CALL with no USING args has no field lineage to extract — not a
+      // diagnostic, just an empty trace.
       if (call.usingArgs.length === 0) continue;
+
       const callee = byProgramId.get(call.target.toUpperCase());
-      if (!callee) continue;
-      if (callee.linkageItems.length !== call.usingArgs.length) continue;
+      if (!callee) {
+        diagnostics.push({
+          kind: call.targetKind === "identifier" ? "dynamic-call" : "unresolved-callee",
+          callerProgramId,
+          target: call.target,
+          callSite: call.loc,
+          rationale:
+            call.targetKind === "identifier"
+              ? `CALL via identifier \`${call.target}\` is resolved at runtime; static lineage cannot determine the callee.`
+              : `CALL "${call.target}" has no matching program in the corpus.`,
+        });
+        continue;
+      }
+
+      if (callee.linkageItems.length !== call.usingArgs.length) {
+        diagnostics.push({
+          kind: "arity-mismatch",
+          callerProgramId,
+          target: call.target,
+          callSite: call.loc,
+          rationale:
+            `CALL passes ${call.usingArgs.length} arg(s) but callee `
+            + `\`${call.target}\` declares ${callee.linkageItems.length} `
+            + `LINKAGE record(s).`,
+        });
+        continue;
+      }
 
       callSites++;
-      const callerProgramId = `program:${resolveCanonicalId(caller)}`;
       const calleeProgramId = `program:${resolveCanonicalId(callee)}`;
 
       for (let i = 0; i < call.usingArgs.length; i++) {
         const callerArgName = call.usingArgs[i]!;
         const callerItem = findTopLevelDataItem(caller.dataItems, callerArgName);
-        if (!callerItem) continue;
+        if (!callerItem) {
+          diagnostics.push({
+            kind: "caller-arg-not-top-level",
+            callerProgramId,
+            target: call.target,
+            callSite: call.loc,
+            rationale:
+              `Position ${i}: USING arg \`${callerArgName}\` is not a top-level `
+              + `data item in caller \`${resolveCanonicalId(caller)}\`.`,
+          });
+          continue;
+        }
         const calleeRecord = callee.linkageItems[i]!;
 
         emitPair(
@@ -239,13 +357,15 @@ export function buildCallBoundLineage(models: CobolCodeModel[]): CallBoundLineag
           caller.sourceFile,
           callee.sourceFile,
           call.loc,
+          call.target,
           entries,
+          diagnostics,
         );
       }
     }
   }
 
-  if (entries.length === 0) return null;
+  if (entries.length === 0 && diagnostics.length === 0) return null;
 
   entries.sort((a, b) =>
     a.caller.programId.localeCompare(b.caller.programId)
@@ -254,11 +374,22 @@ export function buildCallBoundLineage(models: CobolCodeModel[]): CallBoundLineag
     || a.caller.qualifiedName.localeCompare(b.caller.qualifiedName)
   );
 
+  const diagnosticsByKind: Record<CallBoundDiagnosticKind, number> = {
+    "unresolved-callee": 0,
+    "dynamic-call": 0,
+    "arity-mismatch": 0,
+    "shape-mismatch": 0,
+    "caller-arg-not-top-level": 0,
+  };
+  for (const d of diagnostics) diagnosticsByKind[d.kind]++;
+
   return {
     summary: {
       callSites,
       pairs: entries.length,
+      diagnosticsByKind,
     },
     entries,
+    diagnostics,
   };
 }

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -15,8 +15,32 @@
 import type { CobolCodeModel } from "./extractors.js";
 import type { SourceLocation } from "./types.js";
 import { resolveCanonicalId } from "./graph.js";
+import { cobolTierToEvidence } from "./evidence-mapping.js";
+import type { EvidenceEnvelope } from "../evidence.js";
 
 export type Db2LineageConfidence = "deterministic";
+
+/**
+ * Reasons a DB2 reference or table was excluded from `entries`. See
+ * `buildDb2TableLineage` for where each kind is emitted.
+ */
+export type Db2LineageDiagnosticKind =
+  | "self-loop"           // same program is both writer and reader of the table
+  | "non-classifiable-op" // operation not in WRITE_OPS or READ_OPS (DECLARE/OPEN/CLOSE/WITH)
+  | "writer-only"         // table has writers but no readers in the corpus
+  | "reader-only";        // table has readers but no writers in the corpus
+
+export interface Db2LineageDiagnostic {
+  kind: Db2LineageDiagnosticKind;
+  /** Program that owns the reference (set for non-classifiable-op and self-loop). */
+  programId?: string;
+  /** Table involved (set for self-loop, writer-only, reader-only). */
+  table?: string;
+  /** SQL operation verb (set for non-classifiable-op). */
+  operation?: string;
+  callSite?: SourceLocation;
+  rationale: string;
+}
 
 const DB2_WRITE_OPS = new Set(["INSERT", "UPDATE", "DELETE", "MERGE"]);
 const DB2_READ_OPS = new Set(["SELECT", "FETCH"]);
@@ -42,7 +66,10 @@ export interface SerializedDb2LineageEntry {
   table: string;
   writer: Db2LineageParticipant;
   reader: Db2LineageParticipant;
+  /** Domain-specific evidence detail (table name, ops on each side). */
   evidence: Db2LineageEvidence;
+  /** Language-agnostic envelope; consumers branch on `confidence` / `abstain`. */
+  envelope: EvidenceEnvelope;
   rationale: string;
 }
 
@@ -50,8 +77,10 @@ export interface Db2Lineage {
   summary: {
     sharedTables: number;
     pairs: number;
+    diagnosticsByKind: Record<Db2LineageDiagnosticKind, number>;
   };
   entries: SerializedDb2LineageEntry[];
+  diagnostics: Db2LineageDiagnostic[];
 }
 
 const HOST_VAR_RE = /:\s*([A-Z][A-Z0-9-]*)/g;
@@ -133,15 +162,32 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
   if (programs.length < 2) return null;
 
   const tableState = new Map<string, TableSides>();
+  const diagnostics: Db2LineageDiagnostic[] = [];
 
   for (const program of programs) {
     const programId = `program:${resolveCanonicalId(program)}`;
     const sourceFile = program.sourceFile;
     for (const ref of program.db2References) {
+      // A DB2 reference with no tables (e.g., DECLARE CURSOR with WHERE-only,
+      // or unparseable inline SQL) is silently dropped — neither classifiable
+      // nor useful as a diagnostic, since it carries no table identity.
       if (ref.tables.length === 0) continue;
+
       const op = ref.operation?.toUpperCase();
       const kind = classifyOp(op);
-      if (!kind || !op) continue;
+      if (!kind || !op) {
+        diagnostics.push({
+          kind: "non-classifiable-op",
+          programId,
+          operation: op ?? "(none)",
+          callSite: ref.loc,
+          rationale:
+            `Operation \`${op ?? "(none)"}\` is not in the writer set `
+            + `(INSERT/UPDATE/DELETE/MERGE) or reader set (SELECT/FETCH); `
+            + `excluded from cross-program lineage.`,
+        });
+        continue;
+      }
       const hostVars = extractHostVars(ref.rawText);
       for (const table of ref.tables) {
         bump(tableState, table, kind, programId, sourceFile, op, hostVars, ref.loc);
@@ -153,16 +199,49 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
   let sharedTables = 0;
 
   for (const [table, sides] of tableState.entries()) {
-    if (sides.writers.size === 0 || sides.readers.size === 0) continue;
+    // Skip tables with only one role represented in the corpus — but surface
+    // them as diagnostics so the user knows which tables flow only one way.
+    if (sides.writers.size === 0) {
+      diagnostics.push({
+        kind: "reader-only",
+        table,
+        rationale:
+          `Table \`${table}\` has reader(s) in the corpus but no writer; `
+          + `cross-program write→read lineage cannot be established.`,
+      });
+      continue;
+    }
+    if (sides.readers.size === 0) {
+      diagnostics.push({
+        kind: "writer-only",
+        table,
+        rationale:
+          `Table \`${table}\` has writer(s) in the corpus but no reader; `
+          + `cross-program write→read lineage cannot be established.`,
+      });
+      continue;
+    }
     sharedTables++;
     for (const writer of sides.writers.values()) {
       for (const reader of sides.readers.values()) {
-        if (writer.programId === reader.programId) continue;
+        if (writer.programId === reader.programId) {
+          diagnostics.push({
+            kind: "self-loop",
+            programId: writer.programId,
+            table,
+            rationale:
+              `Program \`${writer.programId.replace("program:", "")}\` is `
+              + `both writer and reader of \`${table}\`; intra-program flow, `
+              + `excluded from cross-file lineage.`,
+          });
+          continue;
+        }
         const writerParticipant = toParticipant(writer);
         const readerParticipant = toParticipant(reader);
         const rationale =
           `${writerParticipant.programId.replace("program:", "")} writes to ${table} via ${writerParticipant.operations.join(",")}; `
           + `${readerParticipant.programId.replace("program:", "")} reads from ${table} via ${readerParticipant.operations.join(",")}.`;
+        const tier = cobolTierToEvidence("deterministic");
         entries.push({
           confidence: "deterministic",
           table,
@@ -173,13 +252,23 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
             writerOps: writerParticipant.operations,
             readerOps: readerParticipant.operations,
           },
+          envelope: {
+            confidence: tier.confidence,
+            basis: tier.basis,
+            abstain: false,
+            rationale: `Shared DB2 table \`${table}\`; writer and reader programs both observed.`,
+            provenance: [
+              { raw: writerParticipant.sourceFile },
+              { raw: readerParticipant.sourceFile },
+            ],
+          },
           rationale,
         });
       }
     }
   }
 
-  if (entries.length === 0) return null;
+  if (entries.length === 0 && diagnostics.length === 0) return null;
 
   entries.sort((a, b) =>
     a.table.localeCompare(b.table)
@@ -187,8 +276,17 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
     || a.reader.programId.localeCompare(b.reader.programId)
   );
 
+  const diagnosticsByKind: Record<Db2LineageDiagnosticKind, number> = {
+    "self-loop": 0,
+    "non-classifiable-op": 0,
+    "writer-only": 0,
+    "reader-only": 0,
+  };
+  for (const d of diagnostics) diagnosticsByKind[d.kind]++;
+
   return {
-    summary: { sharedTables, pairs: entries.length },
+    summary: { sharedTables, pairs: entries.length, diagnosticsByKind },
     entries,
+    diagnostics,
   };
 }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -25,7 +25,20 @@ export interface CobolCodeModel {
   divisions: { name: string; loc: SourceLocation }[];
   sections: { name: string; division: string; loc: SourceLocation }[];
   paragraphs: { name: string; section: string; loc: SourceLocation }[];
-  calls: { target: string; fromParagraph: string; usingArgs: string[]; loc: SourceLocation }[];
+  calls: {
+    target: string;
+    /**
+     * `literal` — CALL "FOO" / 'FOO' (compile-time program name).
+     * `identifier` — CALL FOO (variable resolved at runtime; "dynamic call").
+     * Lineage analysis treats the two differently: an unresolved literal means
+     * the program isn't in the corpus; an unresolved identifier means we
+     * can't determine the callee statically.
+     */
+    targetKind: "literal" | "identifier";
+    fromParagraph: string;
+    usingArgs: string[];
+    loc: SourceLocation;
+  }[];
   performs: { target: string; fromParagraph: string; thru?: string; loc: SourceLocation }[];
   copies: { copybook: string; replacing?: string[]; loc: SourceLocation }[];
   dataItems: DataItemNode[];
@@ -305,11 +318,13 @@ function extractStatementRelations(
   const verb = stmt.verb;
 
   if (verb === "CALL") {
-    // CALL "PROGRAM" or CALL identifier
+    // CALL "PROGRAM" (literal) or CALL identifier (dynamic).
     const target = stmt.operands[0];
     if (target) {
+      const isLiteral = /^['"]/.test(target);
       model.calls.push({
         target: target.replace(/['"]/g, ""),
+        targetKind: isLiteral ? "literal" : "identifier",
         fromParagraph: paragraph,
         usingArgs: extractUsingArgs(stmt.rawText),
         loc: stmt.loc,

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -771,7 +771,15 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push("");
     lines.push(`Cross-program field flow at static \`CALL ... USING\` sites. Top-level entries link a caller's USING argument to the callee's matching LINKAGE record by position; child entries descend into matching group children. Confidence is \`deterministic\` when names align (after stripping a short prefix like \`WS-\`/\`LK-\`) and \`high\` when only structure aligns.`);
     lines.push("");
-    lines.push(`Coverage: ${callBound.summary.callSites} call site(s), ${callBound.entries.length} field pair(s).`);
+    // `callSites` only counts CALLs that resolved to a callee in the corpus
+    // and matched arity. Sites blocked at those gates appear in the Excluded
+    // subsection below — wording reflects this so a "0 call sites" display
+    // doesn't mislead when the source actually has CALLs that all failed.
+    const totalDiag = callBound.diagnostics.length;
+    const coverage = totalDiag > 0
+      ? `Coverage: ${callBound.summary.callSites} resolved call site(s), ${callBound.entries.length} field pair(s); ${totalDiag} excluded — see below.`
+      : `Coverage: ${callBound.summary.callSites} call site(s), ${callBound.entries.length} field pair(s).`;
+    lines.push(coverage);
     lines.push("");
     if (callBound.entries.length > 0) {
       const grouped = groupCallBoundByPair(callBound.entries);
@@ -810,7 +818,11 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push("");
     lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; mapping them to specific columns requires a SQL parser and is out of scope here.`);
     lines.push("");
-    lines.push(`Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s).`);
+    const totalDb2Diag = db2.diagnostics.length;
+    const db2Coverage = totalDb2Diag > 0
+      ? `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s); ${totalDb2Diag} excluded — see below.`
+      : `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s).`;
+    lines.push(db2Coverage);
     lines.push("");
     if (db2.entries.length > 0) {
       lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |");

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -766,63 +766,128 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push("");
   }
 
-  if (callBound && callBound.entries.length > 0) {
+  if (callBound && (callBound.entries.length > 0 || callBound.diagnostics.length > 0)) {
     lines.push("## Call Boundary Field Lineage");
     lines.push("");
     lines.push(`Cross-program field flow at static \`CALL ... USING\` sites. Top-level entries link a caller's USING argument to the callee's matching LINKAGE record by position; child entries descend into matching group children. Confidence is \`deterministic\` when names align (after stripping a short prefix like \`WS-\`/\`LK-\`) and \`high\` when only structure aligns.`);
     lines.push("");
     lines.push(`Coverage: ${callBound.summary.callSites} call site(s), ${callBound.entries.length} field pair(s).`);
     lines.push("");
-    const grouped = groupCallBoundByPair(callBound.entries);
-    for (const group of grouped) {
-      const detCount = group.entries.filter((e) => e.confidence === "deterministic").length;
-      const highCount = group.entries.filter((e) => e.confidence === "high").length;
-      lines.push(`### ${displayLabel(group.callerProgramId)} → ${displayLabel(group.calleeProgramId)}`);
-      lines.push("");
-      const summary = highCount > 0
-        ? `${group.entries.length} pair(s): ${detCount} deterministic, ${highCount} high-confidence (name divergence — review below).`
-        : `${group.entries.length} pair(s), all deterministic.`;
-      lines.push(`*${summary}*`);
-      lines.push("");
-      lines.push("| Pos | Caller | Callee | Confidence | Evidence |");
-      lines.push("|-----|--------|--------|------------|----------|");
-      for (const entry of group.entries) {
-        const evidence = [
-          entry.evidence.shapeMatch,
-          entry.evidence.nameSuffixMatch ? "name-aligned" : null,
-          entry.evidence.levelMatch ? "same-level" : null,
-        ].filter((value): value is string => Boolean(value)).join(", ");
-        lines.push(
-          `| ${entry.position} | ${entry.caller.qualifiedName} | ${entry.callee.qualifiedName} | ${entry.confidence} | ${evidence} |`
-        );
+    if (callBound.entries.length > 0) {
+      const grouped = groupCallBoundByPair(callBound.entries);
+      for (const group of grouped) {
+        const detCount = group.entries.filter((e) => e.confidence === "deterministic").length;
+        const highCount = group.entries.filter((e) => e.confidence === "high").length;
+        lines.push(`### ${displayLabel(group.callerProgramId)} → ${displayLabel(group.calleeProgramId)}`);
+        lines.push("");
+        const summary = highCount > 0
+          ? `${group.entries.length} pair(s): ${detCount} deterministic, ${highCount} high-confidence (name divergence — review below).`
+          : `${group.entries.length} pair(s), all deterministic.`;
+        lines.push(`*${summary}*`);
+        lines.push("");
+        lines.push("| Pos | Caller | Callee | Confidence | Evidence |");
+        lines.push("|-----|--------|--------|------------|----------|");
+        for (const entry of group.entries) {
+          const evidence = [
+            entry.evidence.shapeMatch,
+            entry.evidence.nameSuffixMatch ? "name-aligned" : null,
+            entry.evidence.levelMatch ? "same-level" : null,
+          ].filter((value): value is string => Boolean(value)).join(", ");
+          lines.push(
+            `| ${entry.position} | ${entry.caller.qualifiedName} | ${entry.callee.qualifiedName} | ${entry.confidence} | ${evidence} |`
+          );
+        }
+        lines.push("");
       }
-      lines.push("");
+    }
+    if (callBound.diagnostics.length > 0) {
+      renderCallBoundExclusions(lines, callBound.diagnostics);
     }
   }
 
-  if (db2 && db2.entries.length > 0) {
+  if (db2 && (db2.entries.length > 0 || db2.diagnostics.length > 0)) {
     lines.push("## DB2 Table Lineage");
     lines.push("");
     lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; mapping them to specific columns requires a SQL parser and is out of scope here.`);
     lines.push("");
     lines.push(`Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s).`);
     lines.push("");
-    lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |");
-    lines.push("|-------|--------|------------|------------------|--------|------------|------------------|");
-    for (const entry of db2.entries) {
-      const writerVars = entry.writer.hostVars.length > 0 ? entry.writer.hostVars.join(", ") : "—";
-      const readerVars = entry.reader.hostVars.length > 0 ? entry.reader.hostVars.join(", ") : "—";
-      lines.push(
-        `| ${entry.table} | ${displayLabel(entry.writer.programId)} | ${entry.writer.operations.join(", ")} | ${writerVars} | ${displayLabel(entry.reader.programId)} | ${entry.reader.operations.join(", ")} | ${readerVars} |`
-      );
+    if (db2.entries.length > 0) {
+      lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |");
+      lines.push("|-------|--------|------------|------------------|--------|------------|------------------|");
+      for (const entry of db2.entries) {
+        const writerVars = entry.writer.hostVars.length > 0 ? entry.writer.hostVars.join(", ") : "—";
+        const readerVars = entry.reader.hostVars.length > 0 ? entry.reader.hostVars.join(", ") : "—";
+        lines.push(
+          `| ${entry.table} | ${displayLabel(entry.writer.programId)} | ${entry.writer.operations.join(", ")} | ${writerVars} | ${displayLabel(entry.reader.programId)} | ${entry.reader.operations.join(", ")} | ${readerVars} |`
+        );
+      }
+      lines.push("");
     }
-    lines.push("");
+    if (db2.diagnostics.length > 0) {
+      renderDb2Exclusions(lines, db2.diagnostics);
+    }
   }
 
   return {
     path: "cobol/field-lineage.md",
     content: lines.join("\n"),
   };
+}
+
+/**
+ * Render an "Excluded by diagnostic" subsection under a lineage family.
+ * Counts per kind plus one sample so the user can see what's being skipped
+ * without scrolling through hundreds of identical entries.
+ */
+function renderCallBoundExclusions(
+  lines: string[],
+  diagnostics: NonNullable<CallBoundLineage["diagnostics"]>,
+): void {
+  const byKind = new Map<string, { count: number; sample: typeof diagnostics[number] }>();
+  for (const d of diagnostics) {
+    const existing = byKind.get(d.kind);
+    if (!existing) byKind.set(d.kind, { count: 1, sample: d });
+    else existing.count++;
+  }
+  lines.push("### Excluded by diagnostic");
+  lines.push("");
+  lines.push(`${diagnostics.length} call site(s) or arg pair(s) excluded from the table above. Sample row per kind:`);
+  lines.push("");
+  lines.push("| Kind | Count | Sample |");
+  lines.push("|------|-------|--------|");
+  for (const [kind, { count, sample }] of byKind) {
+    const sampleText = `\`${sample.target}\` in ${displayLabel(sample.callerProgramId)} (line ${sample.callSite.line})`;
+    lines.push(`| ${kind} | ${count} | ${sampleText} |`);
+  }
+  lines.push("");
+}
+
+function renderDb2Exclusions(
+  lines: string[],
+  diagnostics: NonNullable<Db2Lineage["diagnostics"]>,
+): void {
+  const byKind = new Map<string, { count: number; sample: typeof diagnostics[number] }>();
+  for (const d of diagnostics) {
+    const existing = byKind.get(d.kind);
+    if (!existing) byKind.set(d.kind, { count: 1, sample: d });
+    else existing.count++;
+  }
+  lines.push("### Excluded by diagnostic");
+  lines.push("");
+  lines.push(`${diagnostics.length} reference(s) or table(s) excluded from the table above. Sample row per kind:`);
+  lines.push("");
+  lines.push("| Kind | Count | Sample |");
+  lines.push("|------|-------|--------|");
+  for (const [kind, { count, sample }] of byKind) {
+    const parts: string[] = [];
+    if (sample.programId) parts.push(displayLabel(sample.programId));
+    if (sample.table) parts.push(`table \`${sample.table}\``);
+    if (sample.operation) parts.push(`op \`${sample.operation}\``);
+    const sampleText = parts.length > 0 ? parts.join(", ") : "—";
+    lines.push(`| ${kind} | ${count} | ${sampleText} |`);
+  }
+  lines.push("");
 }
 
 interface CallBoundGroup {

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -847,6 +847,25 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
   };
 }
 
+// Fixed kind order for the rendered diagnostic table — orders rows by
+// severity / "earliness in pipeline" so the user reads roughly upstream-to-
+// downstream. Pinned here so the wiki page is byte-stable across rebuilds
+// regardless of which diagnostic fired first in the parsed corpus.
+const CALL_BOUND_KIND_ORDER = [
+  "unresolved-callee",
+  "dynamic-call",
+  "arity-mismatch",
+  "shape-mismatch",
+  "caller-arg-not-top-level",
+] as const;
+
+const DB2_KIND_ORDER = [
+  "non-classifiable-op",
+  "writer-only",
+  "reader-only",
+  "self-loop",
+] as const;
+
 /**
  * Render an "Excluded by diagnostic" subsection under a lineage family.
  * Counts per kind plus one sample so the user can see what's being skipped
@@ -868,7 +887,10 @@ function renderCallBoundExclusions(
   lines.push("");
   lines.push("| Kind | Count | Sample |");
   lines.push("|------|-------|--------|");
-  for (const [kind, { count, sample }] of byKind) {
+  for (const kind of CALL_BOUND_KIND_ORDER) {
+    const bucket = byKind.get(kind);
+    if (!bucket) continue;
+    const { count, sample } = bucket;
     const sampleText = `\`${sample.target}\` in ${displayLabel(sample.callerProgramId)} (line ${sample.callSite.line})`;
     lines.push(`| ${kind} | ${count} | ${sampleText} |`);
   }
@@ -891,7 +913,10 @@ function renderDb2Exclusions(
   lines.push("");
   lines.push("| Kind | Count | Sample |");
   lines.push("|------|-------|--------|");
-  for (const [kind, { count, sample }] of byKind) {
+  for (const kind of DB2_KIND_ORDER) {
+    const bucket = byKind.get(kind);
+    if (!bucket) continue;
+    const { count, sample } = bucket;
     const parts: string[] = [];
     if (sample.programId) parts.push(displayLabel(sample.programId));
     if (sample.table) parts.push(`table \`${sample.table}\``);

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -851,20 +851,26 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
 // severity / "earliness in pipeline" so the user reads roughly upstream-to-
 // downstream. Pinned here so the wiki page is byte-stable across rebuilds
 // regardless of which diagnostic fired first in the parsed corpus.
-const CALL_BOUND_KIND_ORDER = [
+//
+// Typed against the union so removing a valid kind from the type fails
+// typecheck. The renderer additionally falls back to rendering any kinds
+// not listed here at the end of the table, so a future contributor adding
+// a new kind doesn't silently drop its data — they'll see it appended,
+// notice the missing pinned position, and update this array.
+const CALL_BOUND_KIND_ORDER: readonly CallBoundLineage["diagnostics"][number]["kind"][] = [
   "unresolved-callee",
   "dynamic-call",
   "arity-mismatch",
   "shape-mismatch",
   "caller-arg-not-top-level",
-] as const;
+];
 
-const DB2_KIND_ORDER = [
+const DB2_KIND_ORDER: readonly Db2Lineage["diagnostics"][number]["kind"][] = [
   "non-classifiable-op",
   "writer-only",
   "reader-only",
   "self-loop",
-] as const;
+];
 
 /**
  * Render an "Excluded by diagnostic" subsection under a lineage family.
@@ -894,6 +900,15 @@ function renderCallBoundExclusions(
     const sampleText = `\`${sample.target}\` in ${displayLabel(sample.callerProgramId)} (line ${sample.callSite.line})`;
     lines.push(`| ${kind} | ${count} | ${sampleText} |`);
   }
+  // Fallback: any kinds not in the pinned order render at the end (in
+  // insertion order). Prevents silent data loss when a new kind is added
+  // to the type union without updating CALL_BOUND_KIND_ORDER.
+  const known = new Set<string>(CALL_BOUND_KIND_ORDER);
+  for (const [kind, { count, sample }] of byKind) {
+    if (known.has(kind)) continue;
+    const sampleText = `\`${sample.target}\` in ${displayLabel(sample.callerProgramId)} (line ${sample.callSite.line})`;
+    lines.push(`| ${kind} | ${count} | ${sampleText} |`);
+  }
   lines.push("");
 }
 
@@ -913,16 +928,28 @@ function renderDb2Exclusions(
   lines.push("");
   lines.push("| Kind | Count | Sample |");
   lines.push("|------|-------|--------|");
-  for (const kind of DB2_KIND_ORDER) {
-    const bucket = byKind.get(kind);
-    if (!bucket) continue;
-    const { count, sample } = bucket;
+  const renderRow = (
+    kind: string,
+    count: number,
+    sample: { programId?: string; table?: string; operation?: string },
+  ): void => {
     const parts: string[] = [];
     if (sample.programId) parts.push(displayLabel(sample.programId));
     if (sample.table) parts.push(`table \`${sample.table}\``);
     if (sample.operation) parts.push(`op \`${sample.operation}\``);
     const sampleText = parts.length > 0 ? parts.join(", ") : "—";
     lines.push(`| ${kind} | ${count} | ${sampleText} |`);
+  };
+  for (const kind of DB2_KIND_ORDER) {
+    const bucket = byKind.get(kind);
+    if (!bucket) continue;
+    renderRow(kind, bucket.count, bucket.sample);
+  }
+  // Fallback for kinds not in DB2_KIND_ORDER — see CALL renderer for rationale.
+  const known = new Set<string>(DB2_KIND_ORDER);
+  for (const [kind, { count, sample }] of byKind) {
+    if (known.has(kind)) continue;
+    renderRow(kind, count, sample);
   }
   lines.push("");
 }

--- a/src/cobol/plugin.ts
+++ b/src/cobol/plugin.ts
@@ -95,6 +95,13 @@ export function migrateLoadedModel(raw: unknown): CobolCodeModel {
     if (!Array.isArray((call as { usingArgs?: unknown }).usingArgs)) {
       (call as { usingArgs: string[] }).usingArgs = [];
     }
+    // targetKind added in evidence-first phase 3 to distinguish unresolved
+    // literal CALLs from dynamic identifier CALLs in lineage diagnostics.
+    // Old artifacts default to "literal" — the more common pattern, and a
+    // safe over-attribution that won't surface false dynamic-call entries.
+    if (!(call as { targetKind?: unknown }).targetKind) {
+      (call as { targetKind: "literal" | "identifier" }).targetKind = "literal";
+    }
   }
   return m as CobolCodeModel;
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2703,6 +2703,44 @@ Content for backward compatibility test.`);
     expect(parsed.variable).toBe("WS-X");
   });
 
+  it("code_trace_variable response carries an evidence envelope (phase 3)", async () => {
+    const wiki = freshWiki();
+    const cobol = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TRACEENV.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 WS-Y PIC 9(4) VALUE 0.
+       PROCEDURE DIVISION.
+           MOVE 7 TO WS-Y.
+           STOP RUN.`;
+    wiki.rawAdd("TRACEENV.cbl", { content: cobol });
+    await handleTool(wiki, "code_parse", { path: "TRACEENV.cbl" });
+
+    // References found → strong/deterministic envelope.
+    const found = JSON.parse(
+      (await handleTool(wiki, "code_trace_variable", {
+        path: "TRACEENV.cbl",
+        variable: "WS-Y",
+      })) as string,
+    );
+    expect(found.evidence).toBeDefined();
+    expect(found.evidence.confidence).toBe("strong");
+    expect(found.evidence.basis).toBe("deterministic");
+    expect(found.evidence.abstain).toBe(false);
+    expect(found.evidence.provenance).toEqual([{ raw: "TRACEENV.cbl" }]);
+
+    // No references → absent + abstain.
+    const missing = JSON.parse(
+      (await handleTool(wiki, "code_trace_variable", {
+        path: "TRACEENV.cbl",
+        variable: "WS-NOT-THERE",
+      })) as string,
+    );
+    expect(missing.evidence.confidence).toBe("absent");
+    expect(missing.evidence.abstain).toBe(true);
+    expect(missing.references).toEqual([]);
+  });
+
   it("code_impact still throws when no compiled graph exists", async () => {
     const wiki = freshWiki();
     await expect(

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs
 import { buildSearchEnvelope, downgradeForReadPage } from "./evidence-search.js";
 import { rotateEventLog, summarizeLastWeek } from "./evidence-write-log.js";
 import { migrateExistingPagesForEvidence } from "./evidence-migration.js";
+import type { EvidenceEnvelope } from "./evidence.js";
 import { join, resolve, basename, extname } from "node:path";
 import { Wiki, splitSections, buildToc, findSectionByHeading, matchSimpleGlob, safePath } from "./wiki.js";
 import { extractDocument, chunkSegments, guessMime, type ExtractionSegment } from "./extraction.js";
@@ -1111,6 +1112,42 @@ function buildFieldLineageResponse(
     inferredEntryMatches(entry, fieldName, qualifiedName, copybook)
   );
 
+  // Top-level envelope summarizes the strongest evidence in the response.
+  // Consumers (LLM agents, downstream tools) branch on `confidence` /
+  // `abstain` without inspecting per-entry tier detail.
+  const evidence: EvidenceEnvelope =
+    deterministic.length > 0
+      ? {
+          confidence: "strong",
+          basis: "deterministic",
+          abstain: false,
+          rationale: `${deterministic.length} deterministic match(es) via copybook lineage.`,
+          provenance: [],
+        }
+      : inferredHighConfidence.length > 0
+      ? {
+          confidence: "weak",
+          basis: "inferred",
+          abstain: false,
+          rationale: `${inferredHighConfidence.length} inferred high-confidence match(es); no deterministic matches.`,
+          provenance: [],
+        }
+      : inferredAmbiguous.length > 0
+      ? {
+          confidence: "absent",
+          basis: "inferred",
+          abstain: true,
+          rationale: `${inferredAmbiguous.length} ambiguous match(es) only; lineage cannot be determined with confidence.`,
+          provenance: [],
+        }
+      : {
+          confidence: "absent",
+          basis: "inferred",
+          abstain: true,
+          rationale: "No matches found for the requested field.",
+          provenance: [],
+        };
+
   return {
     query: {
       type: "field_lineage",
@@ -1124,6 +1161,7 @@ function buildFieldLineageResponse(
       inferredHighConfidenceMatches: inferredHighConfidence.length,
       inferredAmbiguousMatches: inferredAmbiguous.length,
     },
+    evidence,
     deterministic,
     inferredHighConfidence,
     inferredAmbiguous,
@@ -1326,6 +1364,37 @@ function buildImpactResponse(graph: KnowledgeGraph, sourceNode: GraphNode, maxDe
     Array.from(diagnosticNodeIds(diag)).some((id) => relevantNodeIds.has(id))
   );
 
+  // Envelope reflects the weakest link in the impact path: any unresolved
+  // node or any non-deterministic edge downgrades the whole response,
+  // because a consumer claiming "X impacts Y" is only as strong as the
+  // shakiest hop.
+  const evidence: EvidenceEnvelope =
+    impactedIds.size === 0
+      ? {
+          confidence: "absent",
+          basis: "deterministic",
+          abstain: true,
+          rationale: "No nodes impacted by the requested source.",
+          provenance: [],
+        }
+      : unresolvedNodes === 0 && lowerConfidencePaths === 0
+      ? {
+          confidence: "strong",
+          basis: "deterministic",
+          abstain: false,
+          rationale: `${impactedIds.size} node(s) reachable via fully deterministic edges.`,
+          provenance: [],
+        }
+      : {
+          confidence: "weak",
+          basis: "inferred",
+          abstain: false,
+          rationale:
+            `${impactedIds.size} node(s) reached, with ${unresolvedNodes} unresolved `
+            + `and ${lowerConfidencePaths} non-deterministic path(s).`,
+          provenance: [],
+        };
+
   return {
     query: {
       requested: sourceNode.id,
@@ -1346,6 +1415,7 @@ function buildImpactResponse(graph: KnowledgeGraph, sourceNode: GraphNode, maxDe
       lowerConfidencePaths,
       diagnostics: relevantDiagnostics.length,
     },
+    evidence,
     impactedByDepth,
     diagnostics: relevantDiagnostics,
   };
@@ -2244,7 +2314,28 @@ export async function handleTool(
       }
       const ast = plugin.parse(rawResult.content, filePath);
       const refs = plugin.traceVariable(ast, varName);
-      return JSON.stringify({ variable: varName, file: filePath, references: refs }, null, 2);
+      // Trace is intra-file structural lookup — strong when references found,
+      // absent + abstain when nothing matches the requested name.
+      const traceEnvelope: EvidenceEnvelope = refs.length > 0
+        ? {
+            confidence: "strong",
+            basis: "deterministic",
+            abstain: false,
+            rationale: `${refs.length} reference(s) to \`${varName}\` in ${filePath}.`,
+            provenance: [{ raw: filePath }],
+          }
+        : {
+            confidence: "absent",
+            basis: "deterministic",
+            abstain: true,
+            rationale: `No references to \`${varName}\` found in ${filePath}.`,
+            provenance: [{ raw: filePath }],
+          };
+      return JSON.stringify(
+        { variable: varName, file: filePath, evidence: traceEnvelope, references: refs },
+        null,
+        2,
+      );
     }
 
     case "code_impact": {


### PR DESCRIPTION
## Summary

Phase 3 of the evidence-first program. The two COBOL lineage builders no longer silently drop "out of scope" cases — every skip becomes a structured diagnostic — and entries + top-level `code_query` responses now carry the `EvidenceEnvelope` contract from Phase 0.

## Diagnostics

### `call-boundary-lineage.ts`

| Kind | Trigger |
|---|---|
| `unresolved-callee` | `CALL "FOO"` but `FOO` not in the corpus |
| `dynamic-call` | `CALL <identifier>` (resolved at runtime) |
| `arity-mismatch` | USING arg count differs from callee LINKAGE record count |
| `shape-mismatch` | Caller/callee record shapes incompatible (group/scalar mix or differing PICTURE) |
| `caller-arg-not-top-level` | USING arg is not a top-level data item |

`shape-mismatch` is emitted only at top level — descending into children of an already-emitted group, then mismatching, is a routine outcome of structural matching and would flood the diagnostic list with noise.

To distinguish unresolved-literal from dynamic-call, the extractor records `targetKind: "literal" | "identifier"` on each parsed CALL (detected by the original quote presence). Old artifacts default to `"literal"` via `migrateLoadedModel` — the safer over-attribution.

### `db2-table-lineage.ts`

| Kind | Trigger |
|---|---|
| `non-classifiable-op` | Op not in WRITE_OPS / READ_OPS (DECLARE, OPEN, CLOSE, WITH) |
| `writer-only` | Table has writer(s) in the corpus but no reader |
| `reader-only` | Table has reader(s) in the corpus but no writer |
| `self-loop` | Same program is both writer and reader of a table |

## Envelope

Each entry in both builders gets `envelope: EvidenceEnvelope` derived via `cobolTierToEvidence` (Phase 0). The existing `evidence` field stays as domain-specific detail; `envelope` is the consumer-facing summary callers branch on without parsing tier structure.

> Issue #6 called the new field `evidence`. Renaming would break every existing consumer that reads `entry.evidence.shapeMatch` / `entry.evidence.writerOps` / etc., so it lands as `envelope` — same contract, different slot.

`code_query` responses get a top-level envelope:

| Tool | Strong | Weak | Absent + abstain |
|---|---|---|---|
| `field_lineage` | deterministic matches > 0 | only inferred matches | nothing found |
| `impact` | all paths deterministic and resolved | any unresolved or non-deterministic edge | no impact |
| `trace_variable` | references found | — | no references |

## Wiki rendering

`cobol/field-lineage.md` gets an `### Excluded by diagnostic` subsection under each lineage family — counts and a sample line per kind. Renders only when diagnostics are non-empty (verified by tests).

## Tests (4 new + updates to 8 existing)

- Each diagnostic kind in both builders (5 call-boundary + 4 DB2 = 9 cases). Existing tests that previously asserted `expect(lineage).toBeNull()` for these cases were updated to assert the new contract.
- Envelope shape on a deterministic call-boundary entry.
- Envelope shape on a deterministic DB2 entry.
- Wiki page renders Excluded section when diagnostics present.
- Wiki page omits Excluded section when no diagnostics.
- `cobolTierToEvidence` exhaustive enumeration was already in main.

`npm test` — 1529/1529 (1525 baseline + 4 new).

## Out of scope

- Surface diagnostics in `code_query` `impact` (graph-side); follow-up.
- Render diagnostics for inferred copybook lineage — already separated in `field-lineage.ts` via `inferredHighConfidence` / `inferredAmbiguous`.

Closes #6.