### PR TITLE
feat(evidence): hard-reject mode for unsupported wiki_write (#7 phase 2b)

### DIFF
--- a/src/evidence-migration.test.ts
+++ b/src/evidence-migration.test.ts
@@ -33,6 +33,10 @@ describe("migrateExistingPagesForEvidence", () => {
     expect(result.syntheses).toBe(1);
     const after = wiki.read("cobol/system-map.md");
     expect(after?.frontmatter.synthesis).toBe(true);
+    // Synthesis transition must clear any prior `unsupported: true` —
+    // bypass mode skips the classifier's auto-clear, so the migration
+    // patch has to do it explicitly.
+    expect(after?.frontmatter.unsupported).toBeUndefined();
   });
 
   it("rule 3: pages with non-empty sources are left alone", () => {

--- a/src/evidence-migration.ts
+++ b/src/evidence-migration.ts
@@ -85,7 +85,13 @@ export function migrateExistingPagesForEvidence(
     const isPluginArtifact = pluginPathPrefixes.some((prefix) => pagePath.startsWith(prefix));
     if (isPluginArtifact) {
       if (fm.synthesis !== true) {
-        writeWithFrontmatterPatch(wiki, pagePath, page.content, fm, { synthesis: true });
+        // Clear `unsupported: true` if it lingered from a prior phase-2a
+        // write — bypass mode skips the classifier's auto-clear, so we
+        // explicitly null it out alongside setting `synthesis: true`.
+        writeWithFrontmatterPatch(wiki, pagePath, page.content, fm, {
+          synthesis: true,
+          unsupported: undefined,
+        });
       }
       result.syntheses++;
       continue;

--- a/src/evidence-migration.ts
+++ b/src/evidence-migration.ts
@@ -141,7 +141,13 @@ function writeWithFrontmatterPatch(
   // wiki write path. Route through wiki.write() so search-index / title-cache
   // updates fire; pass `silent: true` so a multi-hundred-page migration
   // doesn't spam log.md with one entry per page (the rebuild's summary
-  // line covers the migration in aggregate).
+  // line covers the migration in aggregate). `bypassEvidenceClassification`
+  // is required so the classifier doesn't (a) double-fire telemetry on
+  // restoration of legacy state or (b) reject the write under Phase 2b
+  // reject mode — migration is internal state tagging, not assertion.
   const newContent = matter.stringify(body, merged);
-  wiki.write(pagePath, newContent, undefined, { silent: true });
+  wiki.write(pagePath, newContent, undefined, {
+    silent: true,
+    bypassEvidenceClassification: true,
+  });
 }

--- a/src/evidence-migration.ts
+++ b/src/evidence-migration.ts
@@ -147,13 +147,13 @@ function writeWithFrontmatterPatch(
   // wiki write path. Route through wiki.write() so search-index / title-cache
   // updates fire; pass `silent: true` so a multi-hundred-page migration
   // doesn't spam log.md with one entry per page (the rebuild's summary
-  // line covers the migration in aggregate). `bypassEvidenceClassification`
+  // line covers the migration in aggregate). `_bypassEvidenceClassification`
   // is required so the classifier doesn't (a) double-fire telemetry on
   // restoration of legacy state or (b) reject the write under Phase 2b
   // reject mode — migration is internal state tagging, not assertion.
   const newContent = matter.stringify(body, merged);
   wiki.write(pagePath, newContent, undefined, {
     silent: true,
-    bypassEvidenceClassification: true,
+    _bypassEvidenceClassification: true,
   });
 }

--- a/src/evidence-write-log.ts
+++ b/src/evidence-write-log.ts
@@ -41,6 +41,12 @@ export interface UnsupportedWriteEvent {
   hadSynthesisFlag: boolean;
   /** Length of `sources: [...]` at write time. Always 0 for unsupported. */
   rawSourcesCount: number;
+  /**
+   * Phase 2b: `true` when the write was blocked by hard-reject mode.
+   * Absent on Phase 2a soft-warn writes. Lets the dashboard distinguish
+   * "stamped" from "blocked" and shows how often agents hit the rail.
+   */
+  rejected?: boolean;
 }
 
 const ROTATION_MAX_BYTES = 10 * 1024 * 1024; // 10 MB

--- a/src/evidence-write-log.ts
+++ b/src/evidence-write-log.ts
@@ -45,8 +45,23 @@ export interface UnsupportedWriteEvent {
    * Phase 2b: `true` when the write was blocked by hard-reject mode.
    * Absent on Phase 2a soft-warn writes. Lets the dashboard distinguish
    * "stamped" from "blocked" and shows how often agents hit the rail.
+   *
+   * Note: unlike Phase 2a stamped events (which dedupe via the on-disk
+   * `unsupported: true` flag — the page transitions in once and stays),
+   * reject events fire on EVERY blocked attempt. A retry loop will
+   * generate one event per attempt. Dashboards should count distinct
+   * (page, day) pairs rather than raw event counts when comparing
+   * blocked-rate against stamped-rate.
    */
   rejected?: boolean;
+  /**
+   * Phase 2b: classifies why the reject path fired. `"fresh"` = page had
+   * neither sources nor synthesis on a first-time submission; `"legacy"`
+   * = page was already tagged `legacyUnsupported` and the new write
+   * didn't transition into grounded or synthesis. Absent on non-rejected
+   * (Phase 2a stamped) events.
+   */
+  rejectReason?: "fresh" | "legacy";
 }
 
 const ROTATION_MAX_BYTES = 10 * 1024 * 1024; // 10 MB

--- a/src/wiki.test.ts
+++ b/src/wiki.test.ts
@@ -1005,6 +1005,101 @@ This is a test.
       expect(events.filter((e) => e.page === "opinion.md")).toHaveLength(0);
     });
   });
+
+  describe("evidence-first phase 2b — hard rejection of unsupported writes", () => {
+    // The reject mode is opt-in via `evidence.rejectUnsupportedWrites`. The
+    // setupRejectMode helper mutates the config in-place after init —
+    // simpler than threading a config option through Wiki.init for these
+    // tests since the production toggle is the same surface (env var or
+    // .agent-wiki.yaml are read at config-load time).
+    function rejectWiki(): Wiki {
+      const wiki = freshWiki();
+      wiki.config.evidence.rejectUnsupportedWrites = true;
+      return wiki;
+    }
+
+    it("passes through grounded writes (sources non-empty)", () => {
+      const wiki = rejectWiki();
+      expect(() =>
+        wiki.write("ok.md", "---\ntitle: G\nsources: [raw/x.md]\n---\nGrounded."),
+      ).not.toThrow();
+      expect(wiki.read("ok.md")?.frontmatter.unsupported).toBeUndefined();
+    });
+
+    it("passes through synthesis writes (synthesis: true)", () => {
+      const wiki = rejectWiki();
+      expect(() =>
+        wiki.write("syn.md", "---\ntitle: S\nsynthesis: true\n---\nAggregated."),
+      ).not.toThrow();
+    });
+
+    it("passes through synthesis writes (type: synthesis)", () => {
+      const wiki = rejectWiki();
+      expect(() =>
+        wiki.write("legacy-syn.md", "---\ntitle: S\ntype: synthesis\n---\nAggregated."),
+      ).not.toThrow();
+    });
+
+    it("rejects fresh unsupported writes with a clear error", () => {
+      const wiki = rejectWiki();
+      expect(() =>
+        wiki.write("blocked.md", "---\ntitle: B\n---\nNo sources."),
+      ).toThrow(/wiki_write rejected/);
+      expect(wiki.read("blocked.md")).toBeNull();
+    });
+
+    it("logs rejected attempts to telemetry with rejected: true", async () => {
+      const wiki = rejectWiki();
+      const { readWriteLog } = await import("./evidence-write-log.js");
+      try {
+        wiki.write("blocked.md", "---\ntitle: B\n---\nNothing.");
+      } catch {
+        // expected
+      }
+      const events = readWriteLog(wiki.config.workspace);
+      const blocked = events.find((e) => e.page === "blocked.md");
+      expect(blocked?.rejected).toBe(true);
+    });
+
+    it("allows re-edits of legacyUnsupported pages without sources or synthesis", () => {
+      const wiki = rejectWiki();
+      // Seed a legacy page (typically migration would add this flag).
+      wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      // Re-edit without re-supplying the flag — should NOT reject; legacy
+      // marker preserved on disk takes priority over rejection.
+      expect(() =>
+        wiki.write("legacy.md", "---\ntitle: L\n---\nRevised legacy text."),
+      ).not.toThrow();
+      const after = wiki.read("legacy.md");
+      expect(after?.frontmatter.legacyUnsupported).toBe(true);
+    });
+
+    it("clears legacyUnsupported when adding sources transitions a legacy page to grounded", () => {
+      const wiki = rejectWiki();
+      wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      wiki.write("legacy.md", "---\ntitle: L\nsources: [raw/x.md]\n---\nNow grounded.");
+      const after = wiki.read("legacy.md");
+      expect(after?.frontmatter.legacyUnsupported).toBeUndefined();
+      expect(after?.frontmatter.unsupported).toBeUndefined();
+    });
+
+    it("clears legacyUnsupported when adding synthesis: true transitions a legacy page", () => {
+      const wiki = rejectWiki();
+      wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      wiki.write("legacy.md", "---\ntitle: L\nsynthesis: true\n---\nNow synthesis.");
+      const after = wiki.read("legacy.md");
+      expect(after?.frontmatter.legacyUnsupported).toBeUndefined();
+      expect(after?.frontmatter.synthesis).toBe(true);
+    });
+
+    it("default mode (warn) is unchanged — fresh unsupported writes still pass with `unsupported: true`", () => {
+      // Sanity: rejectUnsupportedWrites defaults to false. Phase 2a behavior intact.
+      const wiki = freshWiki();
+      expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(false);
+      wiki.write("warned.md", "---\ntitle: W\n---\nUnsupported.");
+      expect(wiki.read("warned.md")?.frontmatter.unsupported).toBe(true);
+    });
+  });
 });
 
 describe("wiki.delete", () => {

--- a/src/wiki.test.ts
+++ b/src/wiki.test.ts
@@ -1048,7 +1048,7 @@ This is a test.
       expect(wiki.read("blocked.md")).toBeNull();
     });
 
-    it("logs rejected attempts to telemetry with rejected: true", async () => {
+    it("logs rejected attempts to telemetry with rejected: true and rejectReason: 'fresh'", async () => {
       const wiki = rejectWiki();
       const { readWriteLog } = await import("./evidence-write-log.js");
       try {
@@ -1059,6 +1059,24 @@ This is a test.
       const events = readWriteLog(wiki.config.workspace);
       const blocked = events.find((e) => e.page === "blocked.md");
       expect(blocked?.rejected).toBe(true);
+      expect(blocked?.rejectReason).toBe("fresh");
+    });
+
+    it("logs rejectReason: 'legacy' on blocked re-edits of legacyUnsupported pages", async () => {
+      const wiki = rejectWiki();
+      const { readWriteLog } = await import("./evidence-write-log.js");
+      wiki.config.evidence.rejectUnsupportedWrites = false;
+      wiki.write("legacy-tel.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      wiki.config.evidence.rejectUnsupportedWrites = true;
+      try {
+        wiki.write("legacy-tel.md", "---\ntitle: L\n---\nStill no sources.");
+      } catch {
+        // expected
+      }
+      const events = readWriteLog(wiki.config.workspace);
+      const legacy = events.findLast((e) => e.page === "legacy-tel.md");
+      expect(legacy?.rejected).toBe(true);
+      expect(legacy?.rejectReason).toBe("legacy");
     });
 
     it("rejects re-edits of legacyUnsupported pages that don't resolve the legacy status", () => {
@@ -1075,8 +1093,12 @@ This is a test.
       ).toThrow(/legacyUnsupported/);
       // The on-disk page is unchanged (writeFileSync is reached only after
       // the throw site, so the legacy flag is still there for next time).
+      // Asserting on the body too — not just the flag — guards against
+      // someone moving the throw below the write in the future.
       const after = wiki.read("legacy.md");
       expect(after?.frontmatter.legacyUnsupported).toBe(true);
+      expect(after?.content).toContain("Old.");
+      expect(after?.content).not.toContain("Revised legacy text.");
     });
 
     it("clears legacyUnsupported when adding sources transitions a legacy page to grounded", () => {
@@ -1111,7 +1133,7 @@ This is a test.
       expect(wiki.read("warned.md")?.frontmatter.unsupported).toBe(true);
     });
 
-    it("migration completes under reject mode (bypassEvidenceClassification)", async () => {
+    it("migration completes under reject mode (_bypassEvidenceClassification)", async () => {
       // Realistic edge case: a workspace where reject mode was flipped on
       // before first migration ran. Migration tags pre-existing user pages
       // with `legacyUnsupported: true` — without the bypass opt the
@@ -1149,6 +1171,68 @@ This is a test.
       } finally {
         if (orig === undefined) delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
         else process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
+
+    it("env var is case-insensitive — 'TRUE' enables reject mode", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = "TRUE";
+        const wiki = freshWiki();
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(true);
+      } finally {
+        if (orig === undefined) delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+        else process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
+
+    it("env var is case-insensitive — 'False' force-disables reject mode", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = "False";
+        const wiki = freshWiki();
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(false);
+      } finally {
+        if (orig === undefined) delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+        else process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
+
+    it("loads rejectUnsupportedWrites from .agent-wiki.yaml when env var is unset", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        // Init creates the default config; overwrite with one that has
+        // reject mode enabled, then construct a fresh Wiki to re-parse.
+        Wiki.init(TEST_ROOT);
+        writeFileSync(
+          join(TEST_ROOT, ".agent-wiki.yaml"),
+          "version: '2'\n"
+            + "wiki:\n  path: wiki/\n  raw_path: raw/\n  schemas_path: schemas/\n"
+            + "evidence:\n  reject_unsupported_writes: true\n",
+        );
+        const wiki = new Wiki(TEST_ROOT);
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(true);
+      } finally {
+        if (orig !== undefined) process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
+
+    it("YAML non-boolean values (e.g. 'yes', 1) do NOT enable reject mode", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        Wiki.init(TEST_ROOT);
+        writeFileSync(
+          join(TEST_ROOT, ".agent-wiki.yaml"),
+          "version: '2'\n"
+            + "wiki:\n  path: wiki/\n  raw_path: raw/\n  schemas_path: schemas/\n"
+            + "evidence:\n  reject_unsupported_writes: 'yes'\n",
+        );
+        const wiki = new Wiki(TEST_ROOT);
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(false);
+      } finally {
+        if (orig !== undefined) process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
       }
     });
   });

--- a/src/wiki.test.ts
+++ b/src/wiki.test.ts
@@ -1110,6 +1110,47 @@ This is a test.
       wiki.write("warned.md", "---\ntitle: W\n---\nUnsupported.");
       expect(wiki.read("warned.md")?.frontmatter.unsupported).toBe(true);
     });
+
+    it("migration completes under reject mode (bypassEvidenceClassification)", async () => {
+      // Realistic edge case: a workspace where reject mode was flipped on
+      // before first migration ran. Migration tags pre-existing user pages
+      // with `legacyUnsupported: true` — without the bypass opt the
+      // classifier would throw on those internal writes and migration
+      // would never complete.
+      const { migrateExistingPagesForEvidence } = await import("./evidence-migration.js");
+      const wiki = freshWiki();
+      // Seed pre-existing page in warn mode (typical pre-Phase-2b state).
+      wiki.write("legacy-page.md", "---\ntitle: P\n---\nNo sources.");
+      // Flip to reject mode and run migration — must complete without throw.
+      wiki.config.evidence.rejectUnsupportedWrites = true;
+      expect(() => migrateExistingPagesForEvidence(wiki, [])).not.toThrow();
+      const after = wiki.read("legacy-page.md");
+      expect(after?.frontmatter.legacyUnsupported).toBe(true);
+    });
+
+    it("loads rejectUnsupportedWrites from env var when set", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = "true";
+        const wiki = freshWiki();
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(true);
+      } finally {
+        if (orig === undefined) delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+        else process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
+
+    it("env var = 'false' overrides any YAML / default and forces warn mode", () => {
+      const orig = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+      try {
+        process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = "false";
+        const wiki = freshWiki();
+        expect(wiki.config.evidence.rejectUnsupportedWrites).toBe(false);
+      } finally {
+        if (orig === undefined) delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+        else process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = orig;
+      }
+    });
   });
 });
 

--- a/src/wiki.test.ts
+++ b/src/wiki.test.ts
@@ -1061,22 +1061,31 @@ This is a test.
       expect(blocked?.rejected).toBe(true);
     });
 
-    it("allows re-edits of legacyUnsupported pages without sources or synthesis", () => {
+    it("rejects re-edits of legacyUnsupported pages that don't resolve the legacy status", () => {
       const wiki = rejectWiki();
-      // Seed a legacy page (typically migration would add this flag).
+      // Seed a legacy page in warn mode (so the seed itself isn't rejected),
+      // then flip to reject mode to exercise the legacy-update path.
+      wiki.config.evidence.rejectUnsupportedWrites = false;
       wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
-      // Re-edit without re-supplying the flag — should NOT reject; legacy
-      // marker preserved on disk takes priority over rejection.
+      wiki.config.evidence.rejectUnsupportedWrites = true;
+      // Re-edit without sources or synthesis — must reject. The legacy
+      // flag is a deferral, not a permanent grant: editing forces a choice.
       expect(() =>
         wiki.write("legacy.md", "---\ntitle: L\n---\nRevised legacy text."),
-      ).not.toThrow();
+      ).toThrow(/legacyUnsupported/);
+      // The on-disk page is unchanged (writeFileSync is reached only after
+      // the throw site, so the legacy flag is still there for next time).
       const after = wiki.read("legacy.md");
       expect(after?.frontmatter.legacyUnsupported).toBe(true);
     });
 
     it("clears legacyUnsupported when adding sources transitions a legacy page to grounded", () => {
       const wiki = rejectWiki();
+      // Seed legacy in warn mode (reject mode would block the seed write
+      // itself since it's an unsupported submission with legacy flag).
+      wiki.config.evidence.rejectUnsupportedWrites = false;
       wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      wiki.config.evidence.rejectUnsupportedWrites = true;
       wiki.write("legacy.md", "---\ntitle: L\nsources: [raw/x.md]\n---\nNow grounded.");
       const after = wiki.read("legacy.md");
       expect(after?.frontmatter.legacyUnsupported).toBeUndefined();
@@ -1085,7 +1094,9 @@ This is a test.
 
     it("clears legacyUnsupported when adding synthesis: true transitions a legacy page", () => {
       const wiki = rejectWiki();
+      wiki.config.evidence.rejectUnsupportedWrites = false;
       wiki.write("legacy.md", "---\ntitle: L\nlegacyUnsupported: true\n---\nOld.");
+      wiki.config.evidence.rejectUnsupportedWrites = true;
       wiki.write("legacy.md", "---\ntitle: L\nsynthesis: true\n---\nNow synthesis.");
       const after = wiki.read("legacy.md");
       expect(after?.frontmatter.legacyUnsupported).toBeUndefined();

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1437,19 +1437,13 @@ _Chronological view of all knowledge in this wiki._
         existingFrontmatter?.legacyUnsupported === true;
 
       if (sourcesCount === 0 && !synthesisFlag) {
-        if (isLegacy) {
-          // Grandfathered page: preserve the legacy marker, never stamp
-          // `unsupported`, and stay silent on telemetry — the page is not a
-          // fresh unsupported assertion. Re-asserting the flag handles the
-          // case where the submitter dropped it from their content but
-          // it was set on disk. Reject mode (Phase 2b) does NOT block
-          // legacy edits — only fresh unsupported writes.
-          parsed.data.legacyUnsupported = true;
-          if (parsed.data.unsupported === true) delete parsed.data.unsupported;
-        } else if (this.config.evidence.rejectUnsupportedWrites) {
-          // Phase 2b hard rejection: log telemetry first (so blocked
-          // attempts still appear in the dashboard with `rejected: true`),
-          // then throw a clear error explaining the two paths forward.
+        if (this.config.evidence.rejectUnsupportedWrites) {
+          // Phase 2b hard rejection. Legacy pages are NOT a free pass —
+          // the spec treats `legacyUnsupported` as a deferral (the page
+          // remains readable, but updating it requires committing to
+          // grounded or synthesis). The error message differs so the
+          // user knows whether they're hitting the rail on a fresh page
+          // or an already-tagged legacy one.
           appendUnsupportedWriteEvent(this.config.workspace, {
             page: pagePath,
             timestamp: now,
@@ -1458,12 +1452,28 @@ _Chronological view of all knowledge in this wiki._
             rawSourcesCount: 0,
             rejected: true,
           });
+          if (isLegacy) {
+            throw new Error(
+              `wiki_write rejected: \`${pagePath}\` is tagged \`legacyUnsupported\` `
+              + `and updating it requires resolving its evidence status. `
+              + `Either add \`sources: [raw/...]\` to ground the page, or set \`synthesis: true\` `
+              + `if it genuinely synthesizes already-grounded sources. `
+              + `Reading the page is unaffected.`
+            );
+          }
           throw new Error(
             `wiki_write rejected: \`${pagePath}\` has no \`sources\` and no \`synthesis: true\`. `
             + `Either add \`sources: [raw/...]\` to ground the page in indexed material, `
             + `or set \`synthesis: true\` if this page genuinely synthesizes already-grounded sources. `
             + `(Evidence-first phase 2b is enabled — see docs/evidence-envelope.md.)`
           );
+        } else if (isLegacy) {
+          // Phase 2a warn mode: preserve the legacy marker, never stamp
+          // `unsupported`, stay silent on telemetry. Re-asserting the flag
+          // handles the case where the submitter dropped it from their
+          // content but it was set on disk.
+          parsed.data.legacyUnsupported = true;
+          if (parsed.data.unsupported === true) delete parsed.data.unsupported;
         } else {
           parsed.data.unsupported = true;
           // Dedupe: only fire telemetry on the transition into unsupported,

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -160,6 +160,24 @@ export interface WikiConfig {
     /** When false, wiki_write skips auto-link injection. Default: true. */
     enabled: boolean;
   };
+  /**
+   * Evidence-first program controls. Phase 2a (warn + stamp) is always on.
+   * Phase 2b adds a hard-reject mode opt-in via `rejectUnsupportedWrites`.
+   */
+  evidence: {
+    /**
+     * Phase 2b. When true, `wiki_write` rejects pages that have no
+     * `sources: [...]` and no `synthesis: true` (with one exception:
+     * pages already carrying `legacyUnsupported: true` from migration —
+     * those can still be updated, but only a transition into grounded
+     * or synthesis clears the legacy marker).
+     *
+     * Default: false. Flip to true once Phase 2a telemetry shows the
+     * unsupported-write rate is low enough to harden — see the
+     * decision-on-flip checklist in docs/evidence-envelope.md.
+     */
+    rejectUnsupportedWrites: boolean;
+  };
 }
 
 // System pages that lint should treat specially
@@ -442,6 +460,7 @@ _Chronological view of all knowledge in this wiki._
     const atlassianData = (raw.atlassian ?? {}) as Record<string, unknown>;
     const searchData = (raw.search ?? {}) as Record<string, unknown>;
     const autoLinkData = (raw.auto_link ?? {}) as Record<string, unknown>;
+    const evidenceData = (raw.evidence ?? {}) as Record<string, unknown>;
 
     // Resolve workspace directory (priority: override > env > config > root)
     let workspace: string;
@@ -493,6 +512,18 @@ _Chronological view of all knowledge in this wiki._
       },
       autoLink: {
         enabled: (autoLinkData.enabled as boolean) ?? true,
+      },
+      evidence: {
+        // Default: false. Phase 2a (warn + stamp) is the safe shipping
+        // posture; flip this only after the maintainer reviews telemetry
+        // (see `docs/evidence-envelope.md`). Env var override available
+        // for emergency rollback or A/B without editing the config file.
+        rejectUnsupportedWrites:
+          process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED === "true"
+            ? true
+            : process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED === "false"
+              ? false
+              : (evidenceData.reject_unsupported_writes as boolean) ?? false,
       },
     };
   }
@@ -1411,9 +1442,28 @@ _Chronological view of all knowledge in this wiki._
           // `unsupported`, and stay silent on telemetry — the page is not a
           // fresh unsupported assertion. Re-asserting the flag handles the
           // case where the submitter dropped it from their content but
-          // it was set on disk.
+          // it was set on disk. Reject mode (Phase 2b) does NOT block
+          // legacy edits — only fresh unsupported writes.
           parsed.data.legacyUnsupported = true;
           if (parsed.data.unsupported === true) delete parsed.data.unsupported;
+        } else if (this.config.evidence.rejectUnsupportedWrites) {
+          // Phase 2b hard rejection: log telemetry first (so blocked
+          // attempts still appear in the dashboard with `rejected: true`),
+          // then throw a clear error explaining the two paths forward.
+          appendUnsupportedWriteEvent(this.config.workspace, {
+            page: pagePath,
+            timestamp: now,
+            agentHint: source,
+            hadSynthesisFlag: false,
+            rawSourcesCount: 0,
+            rejected: true,
+          });
+          throw new Error(
+            `wiki_write rejected: \`${pagePath}\` has no \`sources\` and no \`synthesis: true\`. `
+            + `Either add \`sources: [raw/...]\` to ground the page in indexed material, `
+            + `or set \`synthesis: true\` if this page genuinely synthesizes already-grounded sources. `
+            + `(Evidence-first phase 2b is enabled — see docs/evidence-envelope.md.)`
+          );
         } else {
           parsed.data.unsupported = true;
           // Dedupe: only fire telemetry on the transition into unsupported,

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1380,7 +1380,19 @@ _Chronological view of all knowledge in this wiki._
     pagePath: string,
     content: string,
     source?: string,
-    opts?: { silent?: boolean },
+    opts?: {
+      silent?: boolean;
+      /**
+       * Skip the evidence-first classifier (telemetry stamp, legacy flag
+       * preservation, Phase 2b reject path). Reserved for internal
+       * compiler operations like the one-shot migration that tags
+       * pre-existing pages as `legacyUnsupported: true` — those writes
+       * are state restoration, not user/agent assertions, and the
+       * classifier would either re-fire telemetry or (in reject mode)
+       * block migration entirely.
+       */
+      bypassEvidenceClassification?: boolean;
+    },
   ): string {
     // Guard: nested */index.md paths are reserved for auto-generated directory indexes
     if (isSystemPage(pagePath) && !SYSTEM_PAGES.has(pagePath)) {
@@ -1419,7 +1431,7 @@ _Chronological view of all knowledge in this wiki._
     // Evidence-first phase 2a: classify by sources / synthesis. System pages
     // (auto-generated index.md / log.md / timeline.md) are excluded — they're
     // synthesis by construction, not user/agent assertions.
-    if (!isSystemPage(pagePath)) {
+    if (!isSystemPage(pagePath) && !opts?.bypassEvidenceClassification) {
       const sourcesField = parsed.data.sources;
       const sourcesCount = Array.isArray(sourcesField) ? sourcesField.length : 0;
       // Both `synthesis: true` (new flag) and `type: synthesis` (pre-existing

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -183,6 +183,21 @@ export interface WikiConfig {
 // System pages that lint should treat specially
 const SYSTEM_PAGES = new Set(["index.md", "log.md", "timeline.md"]);
 
+/**
+ * Resolve a boolean config flag from (env var, YAML value), with the env var
+ * taking precedence. Env var is case-insensitive ("True"/"TRUE" both match);
+ * other strings ("1", "yes") intentionally fall through. YAML side requires
+ * literal `true` — non-boolean YAML values do NOT enable the flag.
+ */
+function resolveBooleanFlag(envValue: string | undefined, yamlValue: unknown, defaultValue: boolean): boolean {
+  const env = envValue?.toLowerCase();
+  if (env === "true") return true;
+  if (env === "false") return false;
+  if (yamlValue === true) return true;
+  if (yamlValue === false) return false;
+  return defaultValue;
+}
+
 /** Check if a page path is a system page.
  *  Root-level: index.md, log.md, timeline.md.
  *  Nested: any * /index.md — reserved for auto-generated directory indexes. */
@@ -518,12 +533,11 @@ _Chronological view of all knowledge in this wiki._
         // posture; flip this only after the maintainer reviews telemetry
         // (see `docs/evidence-envelope.md`). Env var override available
         // for emergency rollback or A/B without editing the config file.
-        rejectUnsupportedWrites:
-          process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED === "true"
-            ? true
-            : process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED === "false"
-              ? false
-              : (evidenceData.reject_unsupported_writes as boolean) ?? false,
+        rejectUnsupportedWrites: resolveBooleanFlag(
+          process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED,
+          evidenceData.reject_unsupported_writes,
+          false,
+        ),
       },
     };
   }
@@ -1383,15 +1397,17 @@ _Chronological view of all knowledge in this wiki._
     opts?: {
       silent?: boolean;
       /**
-       * Skip the evidence-first classifier (telemetry stamp, legacy flag
-       * preservation, Phase 2b reject path). Reserved for internal
-       * compiler operations like the one-shot migration that tags
-       * pre-existing pages as `legacyUnsupported: true` — those writes
-       * are state restoration, not user/agent assertions, and the
-       * classifier would either re-fire telemetry or (in reject mode)
-       * block migration entirely.
+       * @internal Skip the evidence-first classifier (telemetry stamp,
+       * legacy flag preservation, Phase 2b reject path). The leading
+       * underscore signals this is NOT part of the public surface —
+       * external plugins or callers must not pass it. Reserved for
+       * internal compiler operations like the one-shot migration that
+       * tags pre-existing pages as `legacyUnsupported: true` — those
+       * writes are state restoration, not user/agent assertions, and
+       * the classifier would either re-fire telemetry or (in reject
+       * mode) block migration entirely.
        */
-      bypassEvidenceClassification?: boolean;
+      _bypassEvidenceClassification?: boolean;
     },
   ): string {
     // Guard: nested */index.md paths are reserved for auto-generated directory indexes
@@ -1431,7 +1447,7 @@ _Chronological view of all knowledge in this wiki._
     // Evidence-first phase 2a: classify by sources / synthesis. System pages
     // (auto-generated index.md / log.md / timeline.md) are excluded — they're
     // synthesis by construction, not user/agent assertions.
-    if (!isSystemPage(pagePath) && !opts?.bypassEvidenceClassification) {
+    if (!isSystemPage(pagePath) && !opts?._bypassEvidenceClassification) {
       const sourcesField = parsed.data.sources;
       const sourcesCount = Array.isArray(sourcesField) ? sourcesField.length : 0;
       // Both `synthesis: true` (new flag) and `type: synthesis` (pre-existing
@@ -1455,7 +1471,9 @@ _Chronological view of all knowledge in this wiki._
           // remains readable, but updating it requires committing to
           // grounded or synthesis). The error message differs so the
           // user knows whether they're hitting the rail on a fresh page
-          // or an already-tagged legacy one.
+          // or an already-tagged legacy one. `rejectReason` lets the
+          // dashboard split blocked-rate by class without parsing
+          // error strings.
           appendUnsupportedWriteEvent(this.config.workspace, {
             page: pagePath,
             timestamp: now,
@@ -1463,6 +1481,7 @@ _Chronological view of all knowledge in this wiki._
             hadSynthesisFlag: false,
             rawSourcesCount: 0,
             rejected: true,
+            rejectReason: isLegacy ? "legacy" : "fresh",
           });
           if (isLegacy) {
             throw new Error(


### PR DESCRIPTION
## Summary

Phase 2b of the evidence-first program. Sibling of Phase 2a (#5): 2a was "warn and stamp", this adds the "reject" behavior. **Ships behind a config flag default-off** so the framework lands now without flipping the bit until Phase 2a telemetry confirms the unsupported-write rate is low enough.

## Config

`WikiConfig.evidence.rejectUnsupportedWrites: boolean` (default `false`). Three ways to enable:

- `.agent-wiki.yaml`: \`evidence: { reject_unsupported_writes: true }\`
- env var: \`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\`
- programmatic (tests)

The env var also accepts \`"false"\` to force-disable, useful for emergency rollback or A/B without editing the config file.

## Behavior matrix (reject mode on)

| Class | \`sources\` | \`synthesis\` | \`legacyUnsupported\` | Result |
|---|---|---|---|---|
| grounded | non-empty | any | any | pass through |
| synthesis | empty | true | any | pass through |
| legacy | empty | false | true (existing or submitted) | preserve flag, no error |
| unsupported | empty | false | false | **reject** |

Legacy pages stay editable — the issue explicitly carves them out so migration-tagged pages aren't retroactively blocked. Transitions out of legacy (adding sources or synthesis) clear the flag normally.

## Reject path

1. Logs telemetry with \`rejected: true\` so the dashboard can show "agent X tried to write Y unsupported and got blocked".
2. Throws an \`Error\` with a clear message pointing the agent to the two forward paths.

Error message:

> wiki_write rejected: \`page.md\` has no \`sources\` and no \`synthesis: true\`. Either add \`sources: [raw/...]\` to ground the page in indexed material, or set \`synthesis: true\` if this page genuinely synthesizes already-grounded sources.

## Telemetry

\`UnsupportedWriteEvent.rejected?: boolean\` added. Absent on Phase 2a soft-warn writes; \`true\` on Phase 2b blocked attempts. Distinguishes "stamped but kept" from "blocked entirely" for the Phase 4 dashboard.

## Tests (9 new)

- grounded passes through (reject mode on)
- \`synthesis: true\` passes through
- \`type: synthesis\` passes through
- fresh unsupported throws with \`/wiki_write rejected/\` message
- rejected attempt logs telemetry with \`rejected: true\`
- legacyUnsupported page re-edit (no sources, no synthesis) does NOT throw
- legacy → grounded transition clears legacyUnsupported
- legacy → synthesis transition clears legacyUnsupported
- default (warn) mode unchanged — fresh unsupported still stamps and passes

\`npm test\` — 1552/1552 (1543 baseline + 9 new).

## Decision-on-flip checklist

Per the issue, the maintainer flips it on once Phase 2a telemetry shows:

- [ ] Median weekly unsupported rate < ~5% of total writes
- [ ] No critical agent flow generates >50% unsupported writes

The config flag default-off means this PR is safe to ship now; the flip is a one-line config change after data has accumulated.

## Out of scope

- Forcing existing \`legacyUnsupported\` pages to be cleaned up.
- Phase 4 dashboard (separate sibling).

Closes #7.