### PR TITLE
feat(cobol): join SQL host vars to in-program data items (#17 phase A+C)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -50,11 +50,17 @@ describe("buildDb2TableLineage", () => {
     expect(entry.table).toBe("CUSTOMERS");
     expect(entry.writer.programId).toBe("program:WRITER");
     expect(entry.writer.operations).toEqual(["INSERT"]);
-    expect(entry.writer.hostVars).toContain("WS-NAME");
+    expect(entry.writer.hostVars.map((hv) => hv.name)).toContain("WS-NAME");
     expect(entry.reader.programId).toBe("program:READER");
     expect(entry.reader.operations).toEqual(["SELECT"]);
-    expect(entry.reader.hostVars).toContain("WS-NAME");
-    expect(entry.reader.hostVars).toContain("WS-ID");
+    expect(entry.reader.hostVars.map((hv) => hv.name)).toContain("WS-NAME");
+    expect(entry.reader.hostVars.map((hv) => hv.name)).toContain("WS-ID");
+    // Phase A: each resolved host var carries a DataItem ref with shape info.
+    const wsName = entry.writer.hostVars.find((hv) => hv.name === "WS-NAME");
+    expect(wsName?.dataItem?.picture).toBe("X(30)");
+    expect(wsName?.dataItem?.level).toBe(1);
+    const wsId = entry.reader.hostVars.find((hv) => hv.name === "WS-ID");
+    expect(wsId?.dataItem?.picture).toBe("9(8)");
   });
 
   it("emits one entry per (writer × reader) pair when multiple writers feed one reader", () => {
@@ -241,5 +247,98 @@ describe("buildDb2TableLineage", () => {
       "  VALUES (:WS-ID) END-EXEC",
     ]]);
     expect(buildDb2TableLineage([model(writer, "WRITER.cbl")])).toBeNull();
+  });
+
+  it("emits host-var-unresolved diagnostic when SQL references a name not in the data tree", () => {
+    // The fixture only declares WS-NAME and WS-ID; :WS-MISSING is bogus.
+    const writer = programWith("WRITER", [[
+      "EXEC SQL INSERT INTO ORDERS (ID, NAME)",
+      "  VALUES (:WS-ID, :WS-MISSING) END-EXEC",
+    ]]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT NAME INTO :WS-NAME FROM ORDERS END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const unresolved = lineage!.diagnostics.filter((d) => d.kind === "host-var-unresolved");
+    expect(unresolved).toHaveLength(1);
+    expect(unresolved[0].programId).toBe("program:WRITER");
+    expect(unresolved[0].hostVar).toBe("WS-MISSING");
+    expect(unresolved[0].rationale).toContain("WS-MISSING");
+    expect(lineage!.summary.diagnosticsByKind["host-var-unresolved"]).toBe(1);
+    // The unresolved name still appears on the participant (without dataItem)
+    // so the wiki can render it with a `(?)` flag rather than dropping it.
+    const writerEntry = lineage!.entries.find((e) => e.writer.programId === "program:WRITER");
+    const missing = writerEntry?.writer.hostVars.find((hv) => hv.name === "WS-MISSING");
+    expect(missing).toBeDefined();
+    expect(missing?.dataItem).toBeUndefined();
+  });
+
+  it("dedupes host-var-unresolved diagnostics — same name across multiple SQL blocks fires once", () => {
+    const writer = programWith("WRITER", [
+      [
+        "EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC",
+      ],
+      [
+        "EXEC SQL UPDATE T SET X = :WS-MISSING WHERE ID = :WS-ID END-EXEC",
+      ],
+    ]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const unresolved = lineage!.diagnostics.filter(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+    );
+    expect(unresolved).toHaveLength(1);
+  });
+
+  it("resolves nested host vars (declared as a child of a group record)", () => {
+    // Override the standard fixture with a program that declares the SQL host
+    // var as a 05-level child of a group record — this is the typical layout
+    // when the field lives in a copybook-defined record like CUSTOMER-RECORD.
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  CUSTOMER-RECORD.
+           05  CUST-ID         PIC 9(8).
+           05  CUST-NAME       PIC X(30).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)
+             VALUES (:CUST-ID, :CUST-NAME) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT ID INTO :WS-ID FROM CUSTOMERS END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const writerEntry = lineage!.entries.find((e) => e.writer.programId === "program:WRITER");
+    const custId = writerEntry?.writer.hostVars.find((hv) => hv.name === "CUST-ID");
+    expect(custId?.dataItem?.level).toBe(5);
+    expect(custId?.dataItem?.picture).toBe("9(8)");
+    // No unresolved diagnostic for the nested fields.
+    const unresolved = lineage!.diagnostics.filter((d) => d.kind === "host-var-unresolved");
+    expect(unresolved).toHaveLength(0);
   });
 });

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -304,6 +304,73 @@ describe("buildDb2TableLineage", () => {
     expect(unresolved).toHaveLength(1);
   });
 
+  it("resolves host vars declared in LINKAGE (callee subprogram pattern)", () => {
+    // A callee subprogram receives its host vars via CALL USING, so they
+    // live in LINKAGE, not WORKING-STORAGE. Searching only dataItems
+    // would emit a spurious `host-var-unresolved` for this very common
+    // pattern in COBOL/DB2 systems.
+    const callee = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-LOCAL           PIC X(8).
+       LINKAGE SECTION.
+       01  LK-CUSTOMER-ID     PIC 9(8).
+       01  LK-NAME            PIC X(30).
+       PROCEDURE DIVISION USING LK-CUSTOMER-ID, LK-NAME.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL UPDATE CUSTOMERS SET NAME = :LK-NAME
+             WHERE ID = :LK-CUSTOMER-ID END-EXEC.
+           GOBACK.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT NAME INTO :WS-NAME FROM CUSTOMERS END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(callee, "CALLEE.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const writerEntry = lineage!.entries.find((e) => e.writer.programId === "program:CALLEE");
+    const lkId = writerEntry?.writer.hostVars.find((hv) => hv.name === "LK-CUSTOMER-ID");
+    expect(lkId?.dataItem?.picture).toBe("9(8)");
+    expect(lkId?.dataItem?.level).toBe(1);
+    const lkName = writerEntry?.writer.hostVars.find((hv) => hv.name === "LK-NAME");
+    expect(lkName?.dataItem?.picture).toBe("X(30)");
+    // LINKAGE-declared host vars are NOT unresolved.
+    const unresolved = lineage!.diagnostics.filter((d) => d.kind === "host-var-unresolved");
+    expect(unresolved).toHaveLength(0);
+  });
+
+  it("emits one host-var-unresolved per program when the SAME missing name appears in multiple programs", () => {
+    // The dedup key is `${programId}|${name}` — same name in two programs
+    // must NOT collapse to one diagnostic, since the user has to fix both
+    // programs independently.
+    const writer = programWith("WRITER", [[
+      "EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC",
+    ]]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-MISSING FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const unresolved = lineage!.diagnostics.filter(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+    );
+    expect(unresolved).toHaveLength(2);
+    const programIds = unresolved.map((d) => d.programId).sort();
+    expect(programIds).toEqual(["program:READER", "program:WRITER"]);
+  });
+
   it("resolves nested host vars (declared as a child of a group record)", () => {
     // Override the standard fixture with a program that declares the SQL host
     // var as a 05-level child of a group record — this is the typical layout

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -47,9 +47,12 @@ export interface Db2LineageDiagnostic {
 
 /**
  * Resolved in-program definition of a SQL host variable. Phase A: just the
- * shape needed to render a link from the DB2 table page to the data item's
- * declaration. Phase B will add `originCopybook?` so the wiki can also link
- * to the copybook this field came from.
+ * shape needed to render the host var with its PIC inline, so a wiki
+ * reader can eyeball type alignment with the SQL column. Phase B will add
+ * `originCopybook?` so the wiki can also link to the copybook this field
+ * came from. Source `loc` is intentionally NOT included here — there's no
+ * consumer for it yet (the field-lineage page doesn't link to per-line
+ * anchors), and shipping unused data through JSON invites drift.
  */
 export interface HostVarDataItemRef {
   /** Field name as declared (uppercased to match COBOL). */
@@ -58,8 +61,6 @@ export interface HostVarDataItemRef {
   level: number;
   picture?: string;
   usage?: string;
-  /** Source location of the declaration; lets the wiki link to it. */
-  loc: SourceLocation;
 }
 
 /**
@@ -131,12 +132,16 @@ function extractHostVars(rawText: string): string[] {
 }
 
 /**
- * Recursive name lookup over a program's data tree. SQL host vars can be
- * any data item — top-level (`01 WS-NAME`) or nested (`05 WS-CUST-ID`
- * inside `01 WS-CUSTOMER`) — so a flat top-level scan would miss the
- * common case. Returns the first match (depth-first); duplicate names
- * across REDEFINES are extremely rare in host-var usage and not worth
- * the disambiguation cost here.
+ * Recursive name lookup over a list of data item subtrees. SQL host vars
+ * can be any data item — top-level (`01 WS-NAME`) or nested (`05 CUST-ID`
+ * inside `01 CUSTOMER-RECORD`) — so a flat top-level scan would miss the
+ * common case (the field is in a copybook-defined record). Returns the
+ * first depth-first match; duplicate names across REDEFINES are rare in
+ * host-var usage and not worth disambiguation cost here.
+ *
+ * `item.name.toUpperCase()` is defensive — the parser already canonicalizes
+ * to uppercase, but hand-constructed test fixtures sometimes don't, and
+ * the cost is negligible.
  */
 function findDataItemByName(items: DataItemNode[], name: string): DataItemNode | undefined {
   const upper = name.toUpperCase();
@@ -150,6 +155,19 @@ function findDataItemByName(items: DataItemNode[], name: string): DataItemNode |
   return undefined;
 }
 
+/**
+ * Resolve a SQL host var name against a program's full data surface —
+ * WORKING-STORAGE first, then LINKAGE. The LINKAGE side matters for
+ * callee programs that receive their host vars via CALL USING (e.g.,
+ * a subprogram that reads :CUSTOMER-ID where CUSTOMER-ID is declared
+ * in LINKAGE, not WS). Searching only `dataItems` would emit a false
+ * `host-var-unresolved` diagnostic for that pattern.
+ */
+function resolveHostVar(program: CobolCodeModel, name: string): DataItemNode | undefined {
+  return findDataItemByName(program.dataItems, name)
+    ?? findDataItemByName(program.linkageItems, name);
+}
+
 function toHostVarRef(name: string, dataItem: DataItemNode | undefined): HostVarRef {
   if (!dataItem) return { name };
   return {
@@ -159,7 +177,6 @@ function toHostVarRef(name: string, dataItem: DataItemNode | undefined): HostVar
       level: dataItem.level,
       picture: dataItem.picture,
       usage: dataItem.usage,
-      loc: dataItem.loc,
     },
   };
 }
@@ -285,7 +302,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
       }
       const hostVarNames = extractHostVars(ref.rawText);
       const hostVars: HostVarRef[] = hostVarNames.map((name) => {
-        const dataItem = findDataItemByName(program.dataItems, name);
+        const dataItem = resolveHostVar(program, name);
         if (!dataItem) {
           const dedupeKey = `${programId}|${name}`;
           if (!seenUnresolved.has(dedupeKey)) {

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -13,8 +13,8 @@
  */
 
 import type { CobolCodeModel } from "./extractors.js";
-import type { SourceLocation } from "./types.js";
-import { resolveCanonicalId } from "./graph.js";
+import type { DataItemNode, SourceLocation } from "./types.js";
+import { resolveCanonicalId, displayLabel } from "./graph.js";
 import { cobolTierToEvidence } from "./evidence-mapping.js";
 import type { EvidenceEnvelope } from "../evidence.js";
 
@@ -25,21 +25,54 @@ export type Db2LineageConfidence = "deterministic";
  * `buildDb2TableLineage` for where each kind is emitted.
  */
 export type Db2LineageDiagnosticKind =
-  | "self-loop"           // same program is both writer and reader of the table
-  | "non-classifiable-op" // operation not in WRITE_OPS or READ_OPS (DECLARE/OPEN/CLOSE/WITH)
-  | "writer-only"         // table has writers but no readers in the corpus
-  | "reader-only";        // table has readers but no writers in the corpus
+  | "self-loop"             // same program is both writer and reader of the table
+  | "non-classifiable-op"   // operation not in WRITE_OPS or READ_OPS (DECLARE/OPEN/CLOSE/WITH)
+  | "writer-only"           // table has writers but no readers in the corpus
+  | "reader-only"           // table has readers but no writers in the corpus
+  | "host-var-unresolved";  // SQL :HOSTVAR not declared in WORKING-STORAGE / LINKAGE
 
 export interface Db2LineageDiagnostic {
   kind: Db2LineageDiagnosticKind;
-  /** Program that owns the reference (set for non-classifiable-op and self-loop). */
+  /** Program that owns the reference (set for non-classifiable-op, self-loop, host-var-unresolved). */
   programId?: string;
   /** Table involved (set for self-loop, writer-only, reader-only). */
   table?: string;
   /** SQL operation verb (set for non-classifiable-op). */
   operation?: string;
+  /** Host variable name without the leading colon (set for host-var-unresolved). */
+  hostVar?: string;
   callSite?: SourceLocation;
   rationale: string;
+}
+
+/**
+ * Resolved in-program definition of a SQL host variable. Phase A: just the
+ * shape needed to render a link from the DB2 table page to the data item's
+ * declaration. Phase B will add `originCopybook?` so the wiki can also link
+ * to the copybook this field came from.
+ */
+export interface HostVarDataItemRef {
+  /** Field name as declared (uppercased to match COBOL). */
+  name: string;
+  /** Level number (01, 05, ...). */
+  level: number;
+  picture?: string;
+  usage?: string;
+  /** Source location of the declaration; lets the wiki link to it. */
+  loc: SourceLocation;
+}
+
+/**
+ * A SQL host variable reference, possibly resolved to its in-program
+ * data item declaration. `dataItem` is undefined when the name in the
+ * SQL block doesn't match any item in the program's data tree — those
+ * cases also surface as `host-var-unresolved` diagnostics.
+ */
+export interface HostVarRef {
+  /** Name as it appeared in the SQL block (without the leading `:`). */
+  name: string;
+  /** In-program declaration; undefined if lookup failed. */
+  dataItem?: HostVarDataItemRef;
 }
 
 const DB2_WRITE_OPS = new Set(["INSERT", "UPDATE", "DELETE", "MERGE"]);
@@ -51,7 +84,14 @@ export interface Db2LineageParticipant {
   programId: string;
   sourceFile: string;
   operations: string[];
-  hostVars: string[];
+  /**
+   * SQL host variables referenced on this side of the join, deduped by
+   * name and sorted alphabetically. Each entry carries an optional
+   * `dataItem` resolved against the program's data tree — present when
+   * the name matches a declaration, absent (with a paired
+   * `host-var-unresolved` diagnostic) when the lookup fails.
+   */
+  hostVars: HostVarRef[];
   callSites: SourceLocation[];
 }
 
@@ -90,6 +130,40 @@ function extractHostVars(rawText: string): string[] {
   return [...new Set([...upper.matchAll(HOST_VAR_RE)].map((m) => m[1]))];
 }
 
+/**
+ * Recursive name lookup over a program's data tree. SQL host vars can be
+ * any data item — top-level (`01 WS-NAME`) or nested (`05 WS-CUST-ID`
+ * inside `01 WS-CUSTOMER`) — so a flat top-level scan would miss the
+ * common case. Returns the first match (depth-first); duplicate names
+ * across REDEFINES are extremely rare in host-var usage and not worth
+ * the disambiguation cost here.
+ */
+function findDataItemByName(items: DataItemNode[], name: string): DataItemNode | undefined {
+  const upper = name.toUpperCase();
+  for (const item of items) {
+    if (item.name.toUpperCase() === upper) return item;
+    if (item.children.length > 0) {
+      const inner = findDataItemByName(item.children, name);
+      if (inner) return inner;
+    }
+  }
+  return undefined;
+}
+
+function toHostVarRef(name: string, dataItem: DataItemNode | undefined): HostVarRef {
+  if (!dataItem) return { name };
+  return {
+    name,
+    dataItem: {
+      name: dataItem.name,
+      level: dataItem.level,
+      picture: dataItem.picture,
+      usage: dataItem.usage,
+      loc: dataItem.loc,
+    },
+  };
+}
+
 function classifyOp(op: string | undefined): AccessKind | null {
   if (!op) return null;
   const upper = op.toUpperCase();
@@ -106,7 +180,15 @@ interface ProgramTableUsage {
   programId: string;
   sourceFile: string;
   operations: Set<string>;
-  hostVars: Set<string>;
+  /**
+   * Map keyed by host-var name so the same name across multiple SQL
+   * statements collapses to one entry. The first resolved ref wins (a
+   * later unresolved lookup of the same name does not overwrite a
+   * previously-resolved entry — this can happen if one SQL block
+   * references the field by a misspelled qualifier and another by its
+   * real name).
+   */
+  hostVars: Map<string, HostVarRef>;
   callSites: SourceLocation[];
 }
 
@@ -122,7 +204,7 @@ function bump(
   programId: string,
   sourceFile: string,
   op: string,
-  hostVars: string[],
+  hostVars: HostVarRef[],
   loc: SourceLocation,
 ): void {
   let sides = state.get(table);
@@ -137,13 +219,21 @@ function bump(
       programId,
       sourceFile,
       operations: new Set(),
-      hostVars: new Set(),
+      hostVars: new Map(),
       callSites: [],
     };
     sideMap.set(programId, usage);
   }
   usage.operations.add(op);
-  for (const hv of hostVars) usage.hostVars.add(hv);
+  for (const hv of hostVars) {
+    const existing = usage.hostVars.get(hv.name);
+    // Keep the first resolved entry — don't let a later unresolved hit
+    // (e.g., from a different SQL block in the same program) clobber
+    // useful structural info we already collected.
+    if (!existing || (!existing.dataItem && hv.dataItem)) {
+      usage.hostVars.set(hv.name, hv);
+    }
+  }
   usage.callSites.push(loc);
 }
 
@@ -152,7 +242,7 @@ function toParticipant(usage: ProgramTableUsage): Db2LineageParticipant {
     programId: usage.programId,
     sourceFile: usage.sourceFile,
     operations: [...usage.operations].sort(),
-    hostVars: [...usage.hostVars].sort(),
+    hostVars: [...usage.hostVars.values()].sort((a, b) => a.name.localeCompare(b.name)),
     callSites: usage.callSites,
   };
 }
@@ -163,6 +253,11 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
 
   const tableState = new Map<string, TableSides>();
   const diagnostics: Db2LineageDiagnostic[] = [];
+
+  // Track unresolved-host-var diagnostics per (programId, hostVar) so a
+  // typo'd field referenced across many SQL blocks doesn't blow up the
+  // diagnostic list — the user only needs to be told once per program.
+  const seenUnresolved = new Set<string>();
 
   for (const program of programs) {
     const programId = `program:${resolveCanonicalId(program)}`;
@@ -188,7 +283,29 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
         });
         continue;
       }
-      const hostVars = extractHostVars(ref.rawText);
+      const hostVarNames = extractHostVars(ref.rawText);
+      const hostVars: HostVarRef[] = hostVarNames.map((name) => {
+        const dataItem = findDataItemByName(program.dataItems, name);
+        if (!dataItem) {
+          const dedupeKey = `${programId}|${name}`;
+          if (!seenUnresolved.has(dedupeKey)) {
+            seenUnresolved.add(dedupeKey);
+            diagnostics.push({
+              kind: "host-var-unresolved",
+              programId,
+              hostVar: name,
+              callSite: ref.loc,
+              rationale:
+                `Host variable \`:${name}\` referenced in SQL is not declared `
+                + `in WORKING-STORAGE / LINKAGE of \`${displayLabel(programId)}\`. `
+                + `The lineage table will show the name without a definition link; `
+                + `check for typos or for declarations behind dynamically-loaded `
+                + `copybooks the parser doesn't see.`,
+            });
+          }
+        }
+        return toHostVarRef(name, dataItem);
+      });
       for (const table of ref.tables) {
         bump(tableState, table, kind, programId, sourceFile, op, hostVars, ref.loc);
       }
@@ -281,6 +398,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
     "non-classifiable-op": 0,
     "writer-only": 0,
     "reader-only": 0,
+    "host-var-unresolved": 0,
   };
   for (const d of diagnostics) diagnosticsByKind[d.kind]++;
 

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -2,7 +2,7 @@ import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
 import { resolveCanonicalId, displayLabel } from "./graph.js";
 import type { CallBoundLineage, SerializedCallBoundLineageEntry } from "./call-boundary-lineage.js";
-import type { Db2Lineage } from "./db2-table-lineage.js";
+import type { Db2Lineage, HostVarRef } from "./db2-table-lineage.js";
 
 export type LineageLinkage = "deterministic";
 export type InferredLineageConfidence = "high" | "ambiguous";
@@ -360,6 +360,25 @@ function formatInferredStructure(
   return participant.parentQualifiedName
     ? `${participant.parentQualifiedName}.${participant.qualifiedName.split(".").pop()}`
     : participant.qualifiedName;
+}
+
+/**
+ * Render a host-var list cell for the DB2 lineage table. Resolved vars
+ * carry their PIC (or `group` if a record-level item) so the reader can
+ * eyeball type alignment with the SQL column. Unresolved vars are
+ * tagged with `(?)` — a paired `host-var-unresolved` diagnostic in the
+ * exclusions table tells the user why. `<br>` separates entries so a
+ * many-host-var cell stays readable in the markdown table.
+ */
+function formatHostVars(hostVars: HostVarRef[]): string {
+  if (hostVars.length === 0) return "—";
+  return hostVars.map((hv) => {
+    if (!hv.dataItem) return `\`${hv.name}\` (?)`;
+    const shape = hv.dataItem.picture
+      ? hv.dataItem.picture
+      : "group";
+    return `\`${hv.name}\` (${shape})`;
+  }).join("<br>");
 }
 
 export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLineage | null {
@@ -828,8 +847,8 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
       lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |");
       lines.push("|-------|--------|------------|------------------|--------|------------|------------------|");
       for (const entry of db2.entries) {
-        const writerVars = entry.writer.hostVars.length > 0 ? entry.writer.hostVars.join(", ") : "—";
-        const readerVars = entry.reader.hostVars.length > 0 ? entry.reader.hostVars.join(", ") : "—";
+        const writerVars = formatHostVars(entry.writer.hostVars);
+        const readerVars = formatHostVars(entry.reader.hostVars);
         lines.push(
           `| ${entry.table} | ${displayLabel(entry.writer.programId)} | ${entry.writer.operations.join(", ")} | ${writerVars} | ${displayLabel(entry.reader.programId)} | ${entry.reader.operations.join(", ")} | ${readerVars} |`
         );
@@ -870,6 +889,7 @@ const DB2_KIND_ORDER: readonly Db2Lineage["diagnostics"][number]["kind"][] = [
   "writer-only",
   "reader-only",
   "self-loop",
+  "host-var-unresolved",
 ];
 
 /**
@@ -931,12 +951,13 @@ function renderDb2Exclusions(
   const renderRow = (
     kind: string,
     count: number,
-    sample: { programId?: string; table?: string; operation?: string },
+    sample: { programId?: string; table?: string; operation?: string; hostVar?: string },
   ): void => {
     const parts: string[] = [];
     if (sample.programId) parts.push(displayLabel(sample.programId));
     if (sample.table) parts.push(`table \`${sample.table}\``);
     if (sample.operation) parts.push(`op \`${sample.operation}\``);
+    if (sample.hostVar) parts.push(`host var \`:${sample.hostVar}\``);
     const sampleText = parts.length > 0 ? parts.join(", ") : "—";
     lines.push(`| ${kind} | ${count} | ${sampleText} |`);
   };


### PR DESCRIPTION
## Summary

Phase A + C of #17. Closes the most visible part of the SQL ↔ field lineage gap: the wiki's DB2 Table Lineage rows now show host-var shape inline (PIC / group / unresolved) instead of raw names, and the underlying data carries a structured `HostVarRef` that downstream tools can pivot on. Phase B (copybook origin tagging on data items) is left for a sibling PR.

## What changes

### Type — `Db2LineageParticipant.hostVars`

```ts
// before
hostVars: string[];

// after
hostVars: HostVarRef[];

interface HostVarRef {
  name: string;                       // as written in SQL, no leading colon
  dataItem?: HostVarDataItemRef;      // resolved declaration; undefined if lookup fails
}

interface HostVarDataItemRef {
  name: string;
  level: number;
  picture?: string;
  usage?: string;
  loc: SourceLocation;
}
```

This is a breaking change for any consumer treating `hostVars` as `string[]`. Inside this repo only `field-lineage.ts` and the tests were affected.

### Lookup — `findDataItemByName`

Recursive name match over a program's data tree. Walks children too — SQL host vars are commonly declared as `05`-level fields inside a group record (the typical copybook layout `01 CUSTOMER-RECORD / 05 CUST-ID`), and a flat top-level scan would miss them.

### New diagnostic — `host-var-unresolved`

Emitted once per (program, hostVar) when a SQL `:NAME` doesn't match any item in the program's data tree. Deduped by `(programId, hostVar)` so a typo'd name referenced across many SQL blocks fires one diagnostic, not N. Rationale points the user at the two likely causes (typo or copybook the parser doesn't see).

### Wiki rendering — `formatHostVars`

Replaces the plain `hostVars.join(", ")` at `field-lineage.ts:831`. Each entry renders as:

| Case | Output |
|---|---|
| Resolved with PIC | `` `WS-NAME` (X(30)) `` |
| Resolved group record | `` `CUSTOMER-RECORD` (group) `` |
| Unresolved | `` `WS-MISSING` (?) `` |

`<br>`-separated so a many-host-var cell stays readable in the markdown table.

### Wiki exclusions — `host-var-unresolved` row

Added to `DB2_KIND_ORDER`; `renderRow` now picks up `hostVar` from the sample diagnostic and renders it as ``host var `:WS-MISSING` ``.

## Out of scope (Phase B sibling)

- `originCopybook?: string` on `DataItemNode` and `HostVarDataItemRef`
- Wiki link from host var to the originating copybook page
- Renaming-aware lookup for COPY REPLACING

The `HostVarDataItemRef` shape leaves the slot for `originCopybook` so adding it later doesn't break consumers — the renderer just needs to extend `formatHostVars`.

## Tests

- 1583 / 1583 passing (1577 baseline + 6 net additions: 3 new test cases for unresolved / dedup / nested resolution, plus shape assertions on the pre-existing happy-path test)
- New cases:
  - `emits host-var-unresolved diagnostic when SQL references a name not in the data tree` — verifies diagnostic fires AND the unresolved name still appears on the participant (so wiki can flag, not drop)
  - `dedupes host-var-unresolved diagnostics — same name across multiple SQL blocks fires once` — locks the per-(program, name) dedup
  - `resolves nested host vars (declared as a child of a group record)` — covers the copybook-layout case that `findTopLevelDataItem` would have missed

## Refs

Closes the Phase A + C portion of #17. Phase B remains open in that issue.