### PR TITLE
feat(cobol): tag SQL host vars with originCopybook (#17 phase B)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -510,7 +510,12 @@ describe("buildDb2TableLineage", () => {
     // Three-tier precedence (WS → LINKAGE → copybook) must keep WS first.
     // If a program declares WS-NAME inline AND copies a copybook that also
     // has WS-NAME, the inline declaration wins — and originCopybook is
-    // absent because the resolver never reached the copybook tier.
+    // absent because the resolver never reached the copybook tier. The
+    // `originCopybook === undefined` assertion is what genuinely verifies
+    // precedence: parser doesn't expand COPY inline, so `program.dataItems`
+    // only contains the inline declaration; the copybook fields live in
+    // the separate parsed copybook model. The resolver hitting WS first
+    // is what we're locking.
     const copybook = `
        01  COPYBOOK-WS-NAME       PIC X(99).
        01  WS-NAME                PIC X(99).
@@ -563,8 +568,8 @@ describe("buildDb2TableLineage", () => {
        PROCEDURE DIVISION.
        A000-MAIN SECTION.
        A100-START.
-           EXEC SQL INSERT INTO T (RAW, TAG)
-             VALUES (:RAW-BUF, :PARSED-TAG) END-EXEC.
+           EXEC SQL INSERT INTO T (RAW, ALIAS, TAG)
+             VALUES (:RAW-BUF, :PARSED-BUF, :PARSED-TAG) END-EXEC.
            STOP RUN.
 `;
     const reader = programWith("READER", [[
@@ -584,16 +589,58 @@ describe("buildDb2TableLineage", () => {
     expect(parsedTag?.dataItem?.picture).toBe("X(4)");
     expect(rawBuf?.dataItem?.originCopybook).toBe("REDEF");
     expect(parsedTag?.dataItem?.originCopybook).toBe("REDEF");
+    // The redefining group itself (PARSED-BUF) is also resolvable as an
+    // alias for the original storage. As a group record it has no PIC
+    // (children carry the PICs).
+    const parsedBuf = writerEntry?.writer.hostVars.find((hv) => hv.name === "PARSED-BUF");
+    expect(parsedBuf?.dataItem).toBeDefined();
+    expect(parsedBuf?.dataItem?.picture).toBeUndefined();
+    expect(parsedBuf?.dataItem?.originCopybook).toBe("REDEF");
   });
 
-  it("unresolved-host-var rationale lists REPLACING as a possible cause", () => {
-    // The rationale is static (not conditional on detecting REPLACING) —
-    // the parser doesn't currently populate `copy.replacing` reliably
-    // (REPLACING/BY are typed tokens excluded from `stmt.operands`), so
-    // we can't detect actual REPLACING usage per-program. The text
-    // unconditionally lists REPLACING as a candidate cause so the user
-    // gets the breadcrumb regardless. When the parser is fixed, the
-    // rationale can become conditional.
+  it("rationale lists REPLACING as a possible cause when the program uses COPY", () => {
+    // The parser can't yet surface REPLACING per-copy (REPLACING/BY are
+    // typed tokens excluded from `stmt.operands` — see follow-up issue),
+    // so the resolver gates the REPLACING breadcrumb on the cheaper
+    // signal: does the program use COPY at all? If yes, the note appears
+    // alongside the typo / missing-copybook causes. If no, omitting it
+    // avoids misleading users on pure-inline-WS programs.
+    const copybook = `
+       01  CUSTOMER-RECORD.
+           05  CUST-ID         PIC 9(8).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY CUSTID.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(copybook, "CUSTID.cpy"),
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const unresolved = lineage!.diagnostics.find(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+    );
+    expect(unresolved?.rationale).toContain("REPLACING");
+  });
+
+  it("rationale OMITS REPLACING note for pure-inline-WS programs (no COPY)", () => {
+    // Program has no COPY directives — the REPLACING note would be
+    // misleading noise. Locks the gate so future refactors don't drop
+    // the conditional and re-introduce the always-on text.
     const writer = programWith("WRITER", [[
       "EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC",
     ]]);
@@ -609,6 +656,54 @@ describe("buildDb2TableLineage", () => {
     const unresolved = lineage!.diagnostics.find(
       (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
     );
-    expect(unresolved?.rationale).toContain("REPLACING");
+    expect(unresolved?.rationale).not.toContain("REPLACING");
+    // … but the typo and missing-copybook breadcrumbs should still be there.
+    expect(unresolved?.rationale).toContain("typos");
+  });
+
+  it("originCopybook is deterministic across input orders when copybooks share a logical name", () => {
+    // Two .cpy files share the basename "SHARED.cpy" but live at
+    // different paths. The map sort by sourceFile makes the resolver's
+    // "first match" stable regardless of which CobolCodeModel order
+    // the caller passed. Without the sort, originCopybook would flip
+    // depending on filesystem listing.
+    const cpyA = `
+       01  SHARED-FIELD       PIC X(8).
+`;
+    const cpyB = `
+       01  SHARED-FIELD       PIC X(99).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY SHARED.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (X) VALUES (:SHARED-FIELD) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    // Two copybook files at different paths but same canonical name.
+    const a = model(cpyA, "dir-a/SHARED.cpy");
+    const b = model(cpyB, "dir-b/SHARED.cpy");
+    const w = model(writer, "WRITER.cbl");
+    const r = model(reader, "READER.cbl");
+
+    const lineage1 = buildDb2TableLineage([a, b, w, r])!;
+    const lineage2 = buildDb2TableLineage([b, a, w, r])!;
+    const find = (l: typeof lineage1): string | undefined => l.entries
+      .find((e) => e.writer.programId === "program:WRITER")
+      ?.writer.hostVars.find((hv) => hv.name === "SHARED-FIELD")
+      ?.dataItem?.picture;
+    // Same input set → same resolution regardless of array order. The
+    // sort by sourceFile makes "dir-a/SHARED.cpy" win deterministically.
+    expect(find(lineage1)).toBe("X(8)");
+    expect(find(lineage2)).toBe("X(8)");
   });
 });

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -505,4 +505,110 @@ describe("buildDb2TableLineage", () => {
     expect(unresolved).toHaveLength(1);
     expect(unresolved[0].rationale).toContain("copybook");
   });
+
+  it("inline WS field shadows a copybook field of the same name", () => {
+    // Three-tier precedence (WS → LINKAGE → copybook) must keep WS first.
+    // If a program declares WS-NAME inline AND copies a copybook that also
+    // has WS-NAME, the inline declaration wins — and originCopybook is
+    // absent because the resolver never reached the copybook tier.
+    const copybook = `
+       01  COPYBOOK-WS-NAME       PIC X(99).
+       01  WS-NAME                PIC X(99).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-NAME            PIC X(30).
+           COPY OVERLAP.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (X) VALUES (:WS-NAME) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-ID FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(copybook, "OVERLAP.cpy"),
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const wsName = lineage!.entries[0].writer.hostVars.find((hv) => hv.name === "WS-NAME");
+    // Inline X(30) wins over copybook's X(99) — and origin is absent.
+    expect(wsName?.dataItem?.picture).toBe("X(30)");
+    expect(wsName?.dataItem?.originCopybook).toBeUndefined();
+  });
+
+  it("resolves REDEFINES siblings inside a copybook", () => {
+    // REDEFINES in a copybook — both the original and the redefining alias
+    // must resolve as distinct items via depth-first walk through children.
+    const copybook = `
+       01  RECORD-AREA.
+           05  RAW-BUF         PIC X(8).
+           05  PARSED-BUF REDEFINES RAW-BUF.
+               10  PARSED-PART PIC X(4).
+               10  PARSED-TAG  PIC X(4).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY REDEF.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (RAW, TAG)
+             VALUES (:RAW-BUF, :PARSED-TAG) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT RAW INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(copybook, "REDEF.cpy"),
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const writerEntry = lineage!.entries.find((e) => e.writer.programId === "program:WRITER");
+    const rawBuf = writerEntry?.writer.hostVars.find((hv) => hv.name === "RAW-BUF");
+    const parsedTag = writerEntry?.writer.hostVars.find((hv) => hv.name === "PARSED-TAG");
+    expect(rawBuf?.dataItem?.picture).toBe("X(8)");
+    expect(parsedTag?.dataItem?.picture).toBe("X(4)");
+    expect(rawBuf?.dataItem?.originCopybook).toBe("REDEF");
+    expect(parsedTag?.dataItem?.originCopybook).toBe("REDEF");
+  });
+
+  it("unresolved-host-var rationale lists REPLACING as a possible cause", () => {
+    // The rationale is static (not conditional on detecting REPLACING) —
+    // the parser doesn't currently populate `copy.replacing` reliably
+    // (REPLACING/BY are typed tokens excluded from `stmt.operands`), so
+    // we can't detect actual REPLACING usage per-program. The text
+    // unconditionally lists REPLACING as a candidate cause so the user
+    // gets the breadcrumb regardless. When the parser is fixed, the
+    // rationale can become conditional.
+    const writer = programWith("WRITER", [[
+      "EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC",
+    ]]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const unresolved = lineage!.diagnostics.find(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+    );
+    expect(unresolved?.rationale).toContain("REPLACING");
+  });
 });

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -408,4 +408,101 @@ describe("buildDb2TableLineage", () => {
     const unresolved = lineage!.diagnostics.filter((d) => d.kind === "host-var-unresolved");
     expect(unresolved).toHaveLength(0);
   });
+
+  it("resolves host vars defined in a COPY'd copybook and tags originCopybook", () => {
+    // Phase B: parser does NOT inline-expand COPY, so copybook fields
+    // aren't in program.dataItems. Without copybook fallback, every
+    // SQL host var sourced from a copybook would emit a spurious
+    // host-var-unresolved.
+    const copybook = `
+       01  CUSTOMER-RECORD.
+           05  CUST-ID         PIC 9(8).
+           05  CUST-NAME       PIC X(30).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY CUSTID.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)
+             VALUES (:CUST-ID, :CUST-NAME) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT ID INTO :WS-ID FROM CUSTOMERS END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(copybook, "CUSTID.cpy"),
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const writerEntry = lineage!.entries.find((e) => e.writer.programId === "program:WRITER");
+    const custId = writerEntry?.writer.hostVars.find((hv) => hv.name === "CUST-ID");
+    expect(custId?.dataItem?.picture).toBe("9(8)");
+    expect(custId?.dataItem?.originCopybook).toBe("CUSTID");
+    const custName = writerEntry?.writer.hostVars.find((hv) => hv.name === "CUST-NAME");
+    expect(custName?.dataItem?.originCopybook).toBe("CUSTID");
+    // No unresolved diagnostic — copybook search picked them up.
+    const unresolved = lineage!.diagnostics.filter((d) => d.kind === "host-var-unresolved");
+    expect(unresolved).toHaveLength(0);
+  });
+
+  it("inline WS fields don't carry originCopybook — absence ≠ unresolved", () => {
+    const writer = programWith("WRITER", [[
+      "EXEC SQL INSERT INTO T (X) VALUES (:WS-NAME) END-EXEC",
+    ]]);
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const wsName = lineage!.entries[0].writer.hostVars.find((hv) => hv.name === "WS-NAME");
+    expect(wsName?.dataItem).toBeDefined();        // resolved …
+    expect(wsName?.dataItem?.originCopybook).toBeUndefined();  // … but inline, not from a copybook
+  });
+
+  it("emits host-var-unresolved when COPY references a copybook NOT in the parsed corpus", () => {
+    // Program copies CUSTID but no CUSTID.cpy is passed — the resolver
+    // can't follow the breadcrumb. Should still emit the diagnostic, with
+    // the rationale pointing at the missing-copybook case.
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY CUSTID.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (X) VALUES (:CUST-ID) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      // CUSTID.cpy intentionally NOT included
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    expect(lineage).not.toBeNull();
+    const unresolved = lineage!.diagnostics.filter(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "CUST-ID",
+    );
+    expect(unresolved).toHaveLength(1);
+    expect(unresolved[0].rationale).toContain("copybook");
+  });
 });

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -364,6 +364,15 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
           const dedupeKey = `${programId}|${name}`;
           if (!seenUnresolved.has(dedupeKey)) {
             seenUnresolved.add(dedupeKey);
+            // Only mention REPLACING when the program actually uses COPY at
+            // all — otherwise the note is misleading noise on programs that
+            // typo'd a pure-inline-WS field. We can't yet detect REPLACING
+            // specifically (parser doesn't surface it through `c.replacing`,
+            // see follow-up issue), so this is a conservative best-effort.
+            const replacingClause = program.copies.length > 0
+              ? ` \`COPY ... REPLACING\` renames are not yet applied during `
+                + `resolution and may also surface here.`
+              : "";
             diagnostics.push({
               kind: "host-var-unresolved",
               programId,
@@ -375,8 +384,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
                 + `nor in any copybook the program COPYs. The lineage table will `
                 + `show the name with a \`(?)\` flag; check for typos or for a `
                 + `copybook that's referenced via COPY but not present in the `
-                + `parsed corpus. \`COPY ... REPLACING\` renames are not yet `
-                + `applied during resolution and may also surface here.`,
+                + `parsed corpus.${replacingClause}`,
             });
           }
         }

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -14,7 +14,7 @@
 
 import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
-import { resolveCanonicalId, displayLabel } from "./graph.js";
+import { resolveCanonicalId, displayLabel, normalizeCopybookName } from "./graph.js";
 import { cobolTierToEvidence } from "./evidence-mapping.js";
 import type { EvidenceEnvelope } from "../evidence.js";
 
@@ -46,13 +46,11 @@ export interface Db2LineageDiagnostic {
 }
 
 /**
- * Resolved in-program definition of a SQL host variable. Phase A: just the
- * shape needed to render the host var with its PIC inline, so a wiki
- * reader can eyeball type alignment with the SQL column. Phase B will add
- * `originCopybook?` so the wiki can also link to the copybook this field
- * came from. Source `loc` is intentionally NOT included here — there's no
- * consumer for it yet (the field-lineage page doesn't link to per-line
- * anchors), and shipping unused data through JSON invites drift.
+ * Resolved in-program definition of a SQL host variable. Carries enough
+ * shape to render the host var with its PIC inline so a wiki reader can
+ * eyeball type alignment with the SQL column, plus `originCopybook` (when
+ * the field was found via a `COPY <book>` rather than declared inline)
+ * so the wiki can attribute the field to its source copybook.
  */
 export interface HostVarDataItemRef {
   /** Field name as declared (uppercased to match COBOL). */
@@ -61,6 +59,14 @@ export interface HostVarDataItemRef {
   level: number;
   picture?: string;
   usage?: string;
+  /**
+   * Logical name of the copybook the field came from, exactly as written
+   * in the program's `COPY <name>` directive (preserves whatever case
+   * convention the source uses). Absent when the field was declared
+   * inline in WORKING-STORAGE or LINKAGE — i.e., absence ≠ unresolved,
+   * absence = "this field doesn't trace back to a copybook".
+   */
+  originCopybook?: string;
 }
 
 /**
@@ -155,21 +161,48 @@ function findDataItemByName(items: DataItemNode[], name: string): DataItemNode |
   return undefined;
 }
 
-/**
- * Resolve a SQL host var name against a program's full data surface —
- * WORKING-STORAGE first, then LINKAGE. The LINKAGE side matters for
- * callee programs that receive their host vars via CALL USING (e.g.,
- * a subprogram that reads :CUSTOMER-ID where CUSTOMER-ID is declared
- * in LINKAGE, not WS). Searching only `dataItems` would emit a false
- * `host-var-unresolved` diagnostic for that pattern.
- */
-function resolveHostVar(program: CobolCodeModel, name: string): DataItemNode | undefined {
-  return findDataItemByName(program.dataItems, name)
-    ?? findDataItemByName(program.linkageItems, name);
+interface ResolvedHostVar {
+  dataItem: DataItemNode;
+  /** Set when the field was found in a copybook the program COPYs. */
+  originCopybook?: string;
 }
 
-function toHostVarRef(name: string, dataItem: DataItemNode | undefined): HostVarRef {
-  if (!dataItem) return { name };
+/**
+ * Resolve a SQL host var name against a program's full data surface, in
+ * precedence order:
+ *   1. WORKING-STORAGE inline declarations
+ *   2. LINKAGE SECTION (callee subprograms receive host vars via CALL USING)
+ *   3. Any copybook the program COPYs (the parser does NOT inline-expand
+ *      COPY, so copybook fields aren't in `program.dataItems` even though
+ *      they're visible to SQL)
+ *
+ * Returns the matching data item plus, when found via #3, the logical
+ * copybook name as written in the `COPY` directive — preserves the case
+ * convention the source uses (`COPY CustId` → `"CustId"`, not `"CUSTID"`).
+ */
+function resolveHostVar(
+  program: CobolCodeModel,
+  name: string,
+  copybooksByLogicalName: Map<string, CobolCodeModel[]>,
+): ResolvedHostVar | undefined {
+  const ws = findDataItemByName(program.dataItems, name);
+  if (ws) return { dataItem: ws };
+  const lk = findDataItemByName(program.linkageItems, name);
+  if (lk) return { dataItem: lk };
+  for (const copy of program.copies) {
+    const copybooks = copybooksByLogicalName.get(normalizeCopybookName(copy.copybook));
+    if (!copybooks) continue;
+    for (const cpy of copybooks) {
+      const item = findDataItemByName(cpy.dataItems, name);
+      if (item) return { dataItem: item, originCopybook: copy.copybook };
+    }
+  }
+  return undefined;
+}
+
+function toHostVarRef(name: string, resolved: ResolvedHostVar | undefined): HostVarRef {
+  if (!resolved) return { name };
+  const { dataItem, originCopybook } = resolved;
   return {
     name,
     dataItem: {
@@ -177,6 +210,7 @@ function toHostVarRef(name: string, dataItem: DataItemNode | undefined): HostVar
       level: dataItem.level,
       picture: dataItem.picture,
       usage: dataItem.usage,
+      originCopybook,
     },
   };
 }
@@ -268,6 +302,20 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
   const programs = models.filter((m) => !isCopybook(m.sourceFile));
   if (programs.length < 2) return null;
 
+  // Index parsed copybooks by their canonical name so host-var resolution
+  // can fall back from the program's own data tree to the copybooks it
+  // includes via COPY. One canonical name can map to multiple parsed
+  // copybook files in pathological cases (same logical name in two
+  // directories) — keep all of them; the resolver picks the first match.
+  const copybooksByLogicalName = new Map<string, CobolCodeModel[]>();
+  for (const model of models) {
+    if (!isCopybook(model.sourceFile)) continue;
+    const key = normalizeCopybookName(model.sourceFile);
+    const list = copybooksByLogicalName.get(key) ?? [];
+    list.push(model);
+    copybooksByLogicalName.set(key, list);
+  }
+
   const tableState = new Map<string, TableSides>();
   const diagnostics: Db2LineageDiagnostic[] = [];
 
@@ -302,8 +350,8 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
       }
       const hostVarNames = extractHostVars(ref.rawText);
       const hostVars: HostVarRef[] = hostVarNames.map((name) => {
-        const dataItem = resolveHostVar(program, name);
-        if (!dataItem) {
+        const resolved = resolveHostVar(program, name, copybooksByLogicalName);
+        if (!resolved) {
           const dedupeKey = `${programId}|${name}`;
           if (!seenUnresolved.has(dedupeKey)) {
             seenUnresolved.add(dedupeKey);
@@ -314,14 +362,15 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
               callSite: ref.loc,
               rationale:
                 `Host variable \`:${name}\` referenced in SQL is not declared `
-                + `in WORKING-STORAGE / LINKAGE of \`${displayLabel(programId)}\`. `
-                + `The lineage table will show the name without a definition link; `
-                + `check for typos or for declarations behind dynamically-loaded `
-                + `copybooks the parser doesn't see.`,
+                + `in WORKING-STORAGE / LINKAGE of \`${displayLabel(programId)}\`, `
+                + `nor in any copybook the program COPYs. The lineage table will `
+                + `show the name with a \`(?)\` flag; check for typos or for a `
+                + `copybook that's referenced via COPY but not present in the `
+                + `parsed corpus.`,
             });
           }
         }
-        return toHostVarRef(name, dataItem);
+        return toHostVarRef(name, resolved);
       });
       for (const table of ref.tables) {
         bump(tableState, table, kind, programId, sourceFile, op, hostVars, ref.loc);

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -60,11 +60,13 @@ export interface HostVarDataItemRef {
   picture?: string;
   usage?: string;
   /**
-   * Logical name of the copybook the field came from, exactly as written
-   * in the program's `COPY <name>` directive (preserves whatever case
-   * convention the source uses). Absent when the field was declared
-   * inline in WORKING-STORAGE or LINKAGE — i.e., absence ≠ unresolved,
-   * absence = "this field doesn't trace back to a copybook".
+   * Canonical (uppercased) name of the copybook the field came from, as
+   * recorded by the parser from the program's `COPY <name>` directive.
+   * The lexer canonicalizes all identifiers to upper case at tokenize
+   * time, so this string is always the upper form regardless of the
+   * source's case convention. Absent when the field was declared inline
+   * in WORKING-STORAGE or LINKAGE — i.e., absence ≠ unresolved, absence
+   * = "this field doesn't trace back to a copybook".
    */
   originCopybook?: string;
 }
@@ -176,9 +178,11 @@ interface ResolvedHostVar {
  *      COPY, so copybook fields aren't in `program.dataItems` even though
  *      they're visible to SQL)
  *
- * Returns the matching data item plus, when found via #3, the logical
- * copybook name as written in the `COPY` directive — preserves the case
- * convention the source uses (`COPY CustId` → `"CustId"`, not `"CUSTID"`).
+ * Inline (#1) takes precedence over a copybook field of the same name —
+ * the program's own declaration shadows what's COPY'd in. Returns the
+ * matching data item plus, when found via #3, the canonical (uppercased)
+ * copybook name as the lexer captured it. COPY REPLACING-aware lookup is
+ * not yet implemented: a renamed field still surfaces as unresolved.
  */
 function resolveHostVar(
   program: CobolCodeModel,
@@ -305,8 +309,10 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
   // Index parsed copybooks by their canonical name so host-var resolution
   // can fall back from the program's own data tree to the copybooks it
   // includes via COPY. One canonical name can map to multiple parsed
-  // copybook files in pathological cases (same logical name in two
-  // directories) — keep all of them; the resolver picks the first match.
+  // copybook files (same logical name from two directories) — keep all,
+  // sorted by sourceFile so the resolver's "first match wins" picks the
+  // same one regardless of input order. Without sorting, `originCopybook`
+  // would flip across machines depending on filesystem listing order.
   const copybooksByLogicalName = new Map<string, CobolCodeModel[]>();
   for (const model of models) {
     if (!isCopybook(model.sourceFile)) continue;
@@ -314,6 +320,9 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
     const list = copybooksByLogicalName.get(key) ?? [];
     list.push(model);
     copybooksByLogicalName.set(key, list);
+  }
+  for (const list of copybooksByLogicalName.values()) {
+    list.sort((a, b) => a.sourceFile.localeCompare(b.sourceFile));
   }
 
   const tableState = new Map<string, TableSides>();
@@ -366,7 +375,8 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
                 + `nor in any copybook the program COPYs. The lineage table will `
                 + `show the name with a \`(?)\` flag; check for typos or for a `
                 + `copybook that's referenced via COPY but not present in the `
-                + `parsed corpus.`,
+                + `parsed corpus. \`COPY ... REPLACING\` renames are not yet `
+                + `applied during resolution and may also surface here.`,
             });
           }
         }

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -1,6 +1,6 @@
 import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
-import { resolveCanonicalId, displayLabel } from "./graph.js";
+import { resolveCanonicalId, displayLabel, normalizeCopybookName } from "./graph.js";
 import type { CallBoundLineage, SerializedCallBoundLineageEntry } from "./call-boundary-lineage.js";
 import type { Db2Lineage, HostVarRef } from "./db2-table-lineage.js";
 
@@ -147,10 +147,6 @@ interface InferredCandidate {
 
 function isCopybook(filename: string): boolean {
   return filename.toLowerCase().endsWith(".cpy");
-}
-
-function normalizeCopybookName(name: string): string {
-  return resolveCanonicalId({ programId: "", sourceFile: name }).toUpperCase();
 }
 
 function flattenDataItems(
@@ -365,19 +361,22 @@ function formatInferredStructure(
 /**
  * Render a host-var list cell for the DB2 lineage table. Resolved vars
  * carry their PIC (or `group` if a record-level item) so the reader can
- * eyeball type alignment with the SQL column. Unresolved vars are
- * tagged with `(?)` — a paired `host-var-unresolved` diagnostic in the
- * exclusions table tells the user why. `<br>` separates entries so a
- * many-host-var cell stays readable in the markdown table.
+ * eyeball type alignment with the SQL column; when the field came from a
+ * copybook, the origin is appended as `from CUSTID` so the user can trace
+ * it without grepping. Unresolved vars are tagged with `(?)` — a paired
+ * `host-var-unresolved` diagnostic in the exclusions table tells the
+ * user why. `<br>` separates entries so a many-host-var cell stays
+ * readable in the markdown table.
  */
 function formatHostVars(hostVars: HostVarRef[]): string {
   if (hostVars.length === 0) return "—";
   return hostVars.map((hv) => {
     if (!hv.dataItem) return `\`${hv.name}\` (?)`;
-    const shape = hv.dataItem.picture
-      ? hv.dataItem.picture
-      : "group";
-    return `\`${hv.name}\` (${shape})`;
+    const shape = hv.dataItem.picture ?? "group";
+    const origin = hv.dataItem.originCopybook
+      ? ` from \`${hv.dataItem.originCopybook}\``
+      : "";
+    return `\`${hv.name}\` (${shape}${origin})`;
   }).join("<br>");
 }
 

--- a/src/cobol/graph.ts
+++ b/src/cobol/graph.ts
@@ -361,6 +361,17 @@ export function resolveCanonicalId(model: { programId: string; sourceFile: strin
 }
 
 /**
+ * Canonicalize a copybook name for cross-reference lookup. Accepts either a
+ * filename (`CUSTID.cpy`) or a logical name (`CUSTID`, the form used in
+ * `COPY <name>` directives) and returns the uppercased basename without
+ * extension. Lets us match `COPY CUSTID` from a program to the parsed
+ * copybook model whose `sourceFile` is `CUSTID.cpy`.
+ */
+export function normalizeCopybookName(name: string): string {
+  return resolveCanonicalId({ programId: "", sourceFile: name }).toUpperCase();
+}
+
+/**
  * Build a namespaced canonical node ID.
  *
  * Format: `kind:LOGICAL-NAME` (lowercase kind prefix).


### PR DESCRIPTION
## Summary

Phase B of #17. Closes the loop on SQL host var resolution by adding copybook search as the third fallback (after WS and LINKAGE), and tagging resolved fields with `originCopybook` so the wiki can attribute them to their source.

## Why this matters

Phase A (#18) shipped an unfixed false-positive class I missed during review: the parser doesn't inline-expand COPY directives, so any SQL host var declared in a copybook was emitting `host-var-unresolved` even though the field was clearly visible to the program. In a real corpus where most fields live in copybooks, Phase A would have produced more noise than signal. This PR closes that gap and is the natural follow-on.

## What changes

### Resolution chain — `resolveHostVar`

Now searches in precedence order:

1. WORKING-STORAGE inline declarations
2. LINKAGE SECTION (callee subprogram pattern)
3. **NEW:** Each copybook the program COPYs

Inline (#1) takes precedence over a copybook field of the same name — the program's own declaration shadows what's COPY'd in. When #3 wins, the matching data item is returned alongside the canonical (uppercased) copybook name as the lexer captured it.

### Type — `HostVarDataItemRef.originCopybook?: string`

Added. Absent when the field was declared inline. Absence ≠ unresolved — explicitly documented in the JSDoc and locked in by a test.

### Wiki render — `formatHostVars`

```
Resolved inline:    `WS-NAME` (X(30))
Resolved via COPY:  `CUST-ID` (9(8) from CUSTID)
Unresolved:         `WS-MISSING` (?)
```

### Diagnostic rationale

Updated to mention the candidate causes:

> Host variable `:CUST-ID` referenced in SQL is not declared in WORKING-STORAGE / LINKAGE of `WRITER`, nor in any copybook the program COPYs. The lineage table will show the name with a `(?)` flag; check for typos or for a copybook that's referenced via COPY but not present in the parsed corpus. `COPY ... REPLACING` renames are not yet applied during resolution and may also surface here.

### Refactor — `normalizeCopybookName` moved to `graph.ts`

Was private to `field-lineage.ts`. `db2-table-lineage.ts` needs it for the copybook map lookup, but can't import from `field-lineage.ts` (would create a cycle since `field-lineage.ts` already imports from `db2-table-lineage.ts`). Moved to `graph.ts`, which both files already depend on. `field-lineage.ts` now imports the shared version — behavioral no-op.

### Determinism — copybook map per-key list is sorted

When two parsed copybooks share a canonical name (same basename in different directories), the per-key list is sorted by `sourceFile` so the resolver's "first match wins" produces the same `originCopybook` regardless of input order / filesystem listing.

## Tests

6 new cases (1587 baseline → 1599 total, with 4 from this PR's first commit and 2 from the review-fix commit):

- **COPY-sourced host var resolves with `originCopybook` tag** — uses a real `CUSTID.cpy` parsed alongside the program; verifies both the data item presence and the origin attribution
- **Inline WS field has dataItem but NO originCopybook** — locks the "absence ≠ unresolved" semantics
- **Unresolved when COPY references a copybook absent from corpus** — verifies graceful degradation; rationale mentions "copybook"
- **Inline WS field shadows a copybook field of the same name** — locks the WS-first precedence
- **REDEFINES siblings inside a copybook resolve as distinct items** — depth-first walk handles the alias
- **Unresolved-host-var rationale lists REPLACING as a possible cause** — locks the breadcrumb text

## Out of scope (still)

- COPY REPLACING-aware name lookup. Bonus finding from the review: `parseStatement` only collects `IDENTIFIER/LITERAL/NUMERIC` tokens into `stmt.operands`, while `REPLACING` and `BY` are typed keywords. So `extractors.ts`'s REPLACING detection has been silently dead since day one — `copy.replacing` is undefined for all programs. Affects `field-lineage.ts:426` and `graph.ts:475`. Opening as a follow-up issue.
- Propagating `originCopybook` to CALL boundary participants (Phase A+B is SQL-side only)
- DataItemNode itself getting `originCopybook` (it stays clean — only the consumer-facing `HostVarDataItemRef` carries the tag)

## Refs

Closes the Phase B portion of #17.