### PR TITLE
fix(cobol): strip col-7 `*` comments unconditionally (#20 phase A)

### DIFF
--- a/src/cobol/__tests__/lexer.test.ts
+++ b/src/cobol/__tests__/lexer.test.ts
@@ -119,4 +119,48 @@ describe("COBOL lexer", () => {
     expect(values).toContain("SELECT");
     expect(values).toContain("CUSTOMERS");
   });
+
+  it("strips col-7 `*` comments even when the file is otherwise free-format (mixed-mode corpora — #20 phase A)", () => {
+    // The real-world failure mode this fix targets: a file the heuristic
+    // classifies as free-format (because most lines start at col 1) but
+    // that still has legacy fixed-format comment lines (`*` at col 7).
+    // Pre-fix, those tokenized as code and produced phantom dataflow edges.
+    // Six leading-spaces puts the `*` at index 6 (col 7); the rest of the
+    // file is free-format COBOL starting at col 1.
+    const source = [
+      "      * THIS IS A LEGACY COMMENT LINE",
+      "      * MOVE GHOST-FIELD TO PHANTOM-VAR",
+      "IDENTIFICATION DIVISION.",
+      "PROGRAM-ID. MIXED.",
+      "PROCEDURE DIVISION.",
+      "    MOVE A TO B.",
+    ].join("\n");
+    const tokens = tokenize(source);
+    const values = tokens.map((t) => t.value);
+    // Comment-line tokens must be filtered.
+    expect(values).not.toContain("GHOST-FIELD");
+    expect(values).not.toContain("PHANTOM-VAR");
+    expect(values).not.toContain("LEGACY");
+    // Free-format code below stays intact.
+    expect(values).toContain("IDENTIFICATION");
+    expect(values).toContain("MOVE");
+    expect(values).toContain("A");
+    expect(values).toContain("B");
+  });
+
+  it("does NOT misfire on free-format code where col 7 happens to be alphanumeric", () => {
+    // Defensive: the col-7 `*` filter only fires on `*`. Other characters
+    // at index 6 (letters, digits, hyphens) must NOT be treated as comment
+    // indicators in free-format mode.
+    const source = [
+      "PROGRAM-ID. SAMPLE.",  // index 6 = 'M' (PROGRA[M])
+      "PROCEDURE DIVISION.",  // index 6 = 'U' (PROCED[U])
+      "MOVE-IT SECTION.",     // index 6 = 'T' (MOVE-I[T])
+    ].join("\n");
+    const tokens = tokenize(source);
+    const values = tokens.map((t) => t.value);
+    expect(values).toContain("PROGRAM-ID");
+    expect(values).toContain("PROCEDURE");
+    expect(values).toContain("MOVE-IT");
+  });
 });

--- a/src/cobol/lexer.ts
+++ b/src/cobol/lexer.ts
@@ -107,6 +107,18 @@ function preprocessLines(source: string): SourceLine[] {
     const raw = rawLines[i];
     const lineNum = i + 1;
 
+    // Real-world COBOL is often mixed-mode: a file the heuristic classifies
+    // as free-format (because most lines start at col 1) can still contain
+    // legacy fixed-format comment lines with `*` in column 7. Without this
+    // filter those lines tokenize as code and produce phantom dataflow
+    // edges (~19.9% of audit-corpus noise per #20). False positives in
+    // genuinely free-format code require a 6-char prefix ending in `*`,
+    // which is rare in practice. The fixed branch below still has its own
+    // `*`/`/` indicator handling — this is a pre-filter, not a replacement.
+    if (raw.length >= 7 && raw[6] === "*") {
+      continue;
+    }
+
     if (fixed) {
       if (raw.length < 7) {
         // Too short — skip


### PR DESCRIPTION
## Summary

Phase A of #20 — the COBOL dataflow precision audit's largest single noise source.

The audit attributed **~19.9% of false dataflow edges** to comment lines bleeding into the token stream. Root cause: `isFixedFormat` requires ≥60% of lines to match the fixed-format layout before treating col-7 `*` as a comment indicator. Real-world corpora are mixed-mode — files migrated from mainframes commonly carry change-control prefixes plus leading-`*` comment lines, but most lines start at col 1, so the heuristic flips to free-format. The free-format branch only recognises `*>` inline comments, so the legacy `*`-at-col-7 lines tokenise as code and produce phantom edges.

## Change

One pre-filter at the top of `preprocessLines`:

```ts
// Real-world COBOL is often mixed-mode: a file the heuristic classifies
// as free-format (because most lines start at col 1) can still contain
// legacy fixed-format comment lines with `*` in column 7. ...
if (raw.length >= 7 && raw[6] === "*") {
  continue;
}
```

Runs before the fixed-vs-free branching. Fixed-format files were already handled by the existing indicator check inside the fixed branch; this is a pre-filter that catches the mixed-mode case. The fixed branch's own `*`/`/` handling stays intact.

## Why this is safe

False positives in genuinely free-format code require a 6-char prefix ending in `*`. In practice this is rare:

- COBOL keywords are usually shorter (`MOVE`, `STOP`, `IF`) or longer (`IDENTIFICATION`, `PROCEDURE`) than 6 chars
- Hyphenated names rarely happen to land `*` at exactly index 6
- The `*` operator (multiplication) in COMPUTE etc. typically appears mid-expression with surrounding spaces, not at index 6

The negative-case test (`does NOT misfire on free-format code where col 7 happens to be alphanumeric`) locks this assumption — `PROGRAM-ID`, `PROCEDURE`, `MOVE-IT` all preserve correctly.

## Tests

2 new cases (1603 baseline → 1607 total, +4 with vitest's src+dist double-run):

- **Mixed-mode file** (the failure mode this fixes): legacy `*`-comment lines at col 7 are stripped; free-format code below stays intact. Asserts the comment-line tokens (`GHOST-FIELD`, `PHANTOM-VAR`, `LEGACY`) don't appear in the stream and the live code (`IDENTIFICATION`, `MOVE`, `A`, `B`) does.
- **Free-format with alphanumeric col 7**: tokens preserved when index 6 is a letter (verifies no misfire on `PROGRAM-ID`, `PROCEDURE`, `MOVE-IT` patterns).

## Expected impact

Per the audit report, comment-line noise was 19.9% of total. After this PR:

- ~3,000 phantom dataflow edges removed from the audit corpus (15,199 → ~12,200)
- Dataflow precision: ~61% → ~67% (single phase)

Phases B–D remain in #20 for follow-up PRs.

## Out of scope

- `/` indicator (page-eject) — handled correctly in fixed branch already; rare enough in mixed-mode files that the issue didn't flag it.
- Continuation `-` indicator — fixed-format only by spec; treating it specially in free-format risks false positives on `MOVE -1 TO X` patterns.

## Refs

#20 phase A.