### PR TITLE
fix(cobol): qualifier collapse + clause-keyword markers (#20 phase C+D)

### DIFF
--- a/src/cobol/__tests__/variable-tracer.test.ts
+++ b/src/cobol/__tests__/variable-tracer.test.ts
@@ -227,6 +227,37 @@ describe("COBOL extractDataflowEdges", () => {
     expect(allEdges.some((e) => e.from === "IN" || e.to === "IN")).toBe(false);
   });
 
+  it("collapses multi-level qualifiers: A OF B OF C TO D produces one chained node (#20 phase C)", () => {
+    // COBOL allows arbitrary qualification depth. The while-loop
+    // collapse must capture all OF/IN chain segments — without it, only
+    // the innermost OF would be folded and outer parents would surface
+    // as phantom variables.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DEEP-Q.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  C.
+           05  B.
+               10  A      PIC X(4).
+       01  D                  PIC X(4).
+       PROCEDURE DIVISION.
+       A100.
+           MOVE A OF B OF C TO D.
+           STOP RUN.
+`;
+    const ast = parse(source, "DEEP-Q.cbl");
+    const moveEdges = extractDataflowEdges(ast).filter((e) => e.via === "MOVE");
+    expect(moveEdges).toHaveLength(1);
+    expect(moveEdges[0].from).toBe("A OF B OF C");
+    expect(moveEdges[0].to).toBe("D");
+    // Critically, no phantom edge from the outermost qualifier `C`.
+    const phantomC = extractDataflowEdges(ast).filter(
+      (e) => e.from === "C" || e.from === "B",
+    );
+    expect(phantomC).toHaveLength(0);
+  });
+
   it("STRING WITH POINTER classifies the pointer var as both read and written (#20 phase D)", () => {
     // Phase D: WITH POINTER var is read-and-written each iteration. The
     // POINTER marker switches access to "both" so the pointer var is
@@ -255,6 +286,80 @@ describe("COBOL extractDataflowEdges", () => {
     expect(ptrAsTo).toBe(true);
     // POINTER itself is not an edge endpoint (it's now a marker keyword).
     expect(stringEdges.some((e) => e.from === "POINTER" || e.to === "POINTER")).toBe(false);
+    // Known-noise: the simple Cartesian model produces WS-SRC → WS-PTR
+    // and WS-PTR → WS-RES even though semantically the pointer doesn't
+    // dataflow to/from source/result. Eliminating these requires a
+    // per-clause state machine — out of scope for #20 phase D, see the
+    // PR description's "Known limitation" section. Asserting the noise
+    // edges exist locks the trade-off so a future state-machine fix
+    // explicitly removes them.
+    expect(stringEdges.some((e) => e.from === "WS-SRC" && e.to === "WS-PTR")).toBe(true);
+    expect(stringEdges.some((e) => e.from === "WS-PTR" && e.to === "WS-RES")).toBe(true);
+  });
+
+  it("UNSTRING: DELIMITER IN <var> and COUNT IN <var> are writes, not reads (#20 phase D)", () => {
+    // UNSTRING-specific markers: `DELIMITER IN <var>` captures which
+    // delimiter matched (write to var); `COUNT IN <var>` captures how
+    // many chars matched (write). Pre-fix these were classified by the
+    // surrounding mode (often read) so the captures appeared as
+    // phantom inputs to the UNSTRING dataflow.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. UNS-CAP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-INPUT     PIC X(40).
+       01  WS-DEL       PIC X(1).
+       01  WS-PART1     PIC X(20).
+       01  WS-WHICH-DEL PIC X(1).
+       01  WS-LEN       PIC 9(4).
+       PROCEDURE DIVISION.
+       A100.
+           UNSTRING WS-INPUT DELIMITED BY WS-DEL
+             INTO WS-PART1 DELIMITER IN WS-WHICH-DEL COUNT IN WS-LEN.
+           STOP RUN.
+`;
+    const ast = parse(source, "UNS-CAP.cbl");
+    const unstringEdges = extractDataflowEdges(ast).filter((e) => e.via === "UNSTRING");
+    // Capture vars receive output, so they appear as `to`, not `from`.
+    expect(unstringEdges.some((e) => e.to === "WS-WHICH-DEL")).toBe(true);
+    expect(unstringEdges.some((e) => e.to === "WS-LEN")).toBe(true);
+    // No clause keyword surfaces as an endpoint.
+    for (const kw of ["DELIMITED", "DELIMITER", "COUNT", "BY", "IN"]) {
+      expect(unstringEdges.some((e) => e.from === kw || e.to === kw)).toBe(false);
+    }
+  });
+
+  it("INSPECT: BEFORE/AFTER INITIAL <delim> classifies delim as read (#20 phase D)", () => {
+    // INSPECT TALLYING / REPLACING with a BEFORE/AFTER INITIAL clause:
+    // the delim var is a read (it's a literal-or-var pattern to match,
+    // not a write target). Pre-fix the surrounding mode (TALLYING set
+    // to write) would have leaked into the delim classification.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. INS-BA.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-INPUT   PIC X(40).
+       01  WS-COUNT   PIC 9(4).
+       01  WS-DELIM   PIC X(1).
+       PROCEDURE DIVISION.
+       A100.
+           INSPECT WS-INPUT TALLYING WS-COUNT FOR ALL "X"
+             BEFORE INITIAL WS-DELIM.
+           STOP RUN.
+`;
+    const ast = parse(source, "INS-BA.cbl");
+    const inspectEdges = extractDataflowEdges(ast).filter((e) => e.via === "INSPECT");
+    // WS-COUNT is the tally write target.
+    expect(inspectEdges.some((e) => e.to === "WS-COUNT")).toBe(true);
+    // WS-DELIM (the delim) is read, never written.
+    expect(inspectEdges.some((e) => e.to === "WS-DELIM")).toBe(false);
+    expect(inspectEdges.some((e) => e.from === "WS-DELIM")).toBe(true);
+    // INITIAL / BEFORE / AFTER never as endpoints.
+    for (const kw of ["INITIAL", "BEFORE", "AFTER"]) {
+      expect(inspectEdges.some((e) => e.from === kw || e.to === kw)).toBe(false);
+    }
   });
 
   it("STRING DELIMITED clause keywords are not treated as variables (#20 phase D)", () => {

--- a/src/cobol/__tests__/variable-tracer.test.ts
+++ b/src/cobol/__tests__/variable-tracer.test.ts
@@ -170,6 +170,120 @@ describe("COBOL extractDataflowEdges", () => {
     expect(literalToken?.value).toBe('"DAS IST EIN TEST"');
   });
 
+  it("collapses qualified references into one edge: MOVE A OF G1 TO B OF G2 (#20 phase C)", () => {
+    // Pre-fix: lexer emitted OF as a typed token but dataflow re-split
+    // rawText, treating OF as a "variable" token. With OF passing the
+    // identifier check, MOVE A OF GROUP-1 TO B OF GROUP-2 produced a
+    // 2x2 Cartesian (A→B, A→GROUP-2, GROUP-1→B, GROUP-1→GROUP-2) plus
+    // OF→OF self-edges. Phase C: OF/IN are keywords, and adjacent
+    // IDENT OF IDENT collapses to one qualified node matching
+    // traceVariable's existing format.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. QUAL-MV.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  GROUP-1.
+           05  A      PIC X(4).
+       01  GROUP-2.
+           05  B      PIC X(4).
+       PROCEDURE DIVISION.
+       A100.
+           MOVE A OF GROUP-1 TO B OF GROUP-2.
+           STOP RUN.
+`;
+    const ast = parse(source, "QUAL-MV.cbl");
+    const moveEdges = extractDataflowEdges(ast).filter((e) => e.via === "MOVE");
+    // Exactly one edge between the qualified names.
+    expect(moveEdges).toHaveLength(1);
+    expect(moveEdges[0].from).toBe("A OF GROUP-1");
+    expect(moveEdges[0].to).toBe("B OF GROUP-2");
+    // Critically, no separate edges from/to the parent group names.
+    const gParent = extractDataflowEdges(ast).filter(
+      (e) => e.from === "GROUP-1" || e.to === "GROUP-2" || e.from === "OF" || e.to === "OF",
+    );
+    expect(gParent).toHaveLength(0);
+  });
+
+  it("does not surface bare OF/IN as a dataflow variable (#20 phase C keywords)", () => {
+    // Spot check: even without qualifier collapse firing (e.g., a non-
+    // canonical OF in some bizarre fixture), OF / IN should not show up
+    // as edge endpoints because they're now in NON_VARIABLE_KEYWORDS.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NO-OF.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  X    PIC X(4).
+       01  Y    PIC X(4).
+       PROCEDURE DIVISION.
+       A100.
+           MOVE X TO Y.
+           STOP RUN.
+`;
+    const ast = parse(source, "NO-OF.cbl");
+    const allEdges = extractDataflowEdges(ast);
+    expect(allEdges.some((e) => e.from === "OF" || e.to === "OF")).toBe(false);
+    expect(allEdges.some((e) => e.from === "IN" || e.to === "IN")).toBe(false);
+  });
+
+  it("STRING WITH POINTER classifies the pointer var as both read and written (#20 phase D)", () => {
+    // Phase D: WITH POINTER var is read-and-written each iteration. The
+    // POINTER marker switches access to "both" so the pointer var is
+    // classified r/w. WS-PTR should appear as a self-edge candidate
+    // (reads + writes), so non-self edges include WS-PTR on both sides.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. STR-PTR.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-SRC    PIC X(8).
+       01  WS-RES    PIC X(40).
+       01  WS-PTR    PIC 9(4) COMP.
+       PROCEDURE DIVISION.
+       A100.
+           STRING WS-SRC INTO WS-RES WITH POINTER WS-PTR.
+           STOP RUN.
+`;
+    const ast = parse(source, "STR-PTR.cbl");
+    const stringEdges = extractDataflowEdges(ast).filter((e) => e.via === "STRING");
+    // Pointer var participates as both read and write — appears in edges
+    // both as `from` and as `to`.
+    const ptrAsFrom = stringEdges.some((e) => e.from === "WS-PTR");
+    const ptrAsTo = stringEdges.some((e) => e.to === "WS-PTR");
+    expect(ptrAsFrom).toBe(true);
+    expect(ptrAsTo).toBe(true);
+    // POINTER itself is not an edge endpoint (it's now a marker keyword).
+    expect(stringEdges.some((e) => e.from === "POINTER" || e.to === "POINTER")).toBe(false);
+  });
+
+  it("STRING DELIMITED clause keywords are not treated as variables (#20 phase D)", () => {
+    // Phase C+D combined: STRING SRC DELIMITED BY DELIM INTO TARGET.
+    // The DELIMITED / BY / WITH / OVERFLOW clause keywords were
+    // previously surfaced as phantom variables. Now they're keyword-
+    // filtered (Phase C) and also act as access-mode markers (Phase D).
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. STR-DEL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-SRC      PIC X(8).
+       01  WS-DELIM    PIC X(1).
+       01  WS-RES      PIC X(40).
+       PROCEDURE DIVISION.
+       A100.
+           STRING WS-SRC DELIMITED BY WS-DELIM INTO WS-RES.
+           STOP RUN.
+`;
+    const ast = parse(source, "STR-DEL.cbl");
+    const stringEdges = extractDataflowEdges(ast).filter((e) => e.via === "STRING");
+    // No edges with clause keywords as endpoints.
+    const phantomKeywords = ["DELIMITED", "BY", "WITH", "POINTER", "OVERFLOW"];
+    for (const kw of phantomKeywords) {
+      expect(stringEdges.some((e) => e.from === kw || e.to === kw)).toBe(false);
+    }
+  });
+
   it("typed-token path matches existing numeric-prefix filtering for NUMERIC tokens", () => {
     // Numeric literals (`12345`) were already filtered pre-Phase-B by
     // `isDataflowVariable`'s `^[0-9]` check, so this case isn't a new

--- a/src/cobol/__tests__/variable-tracer.test.ts
+++ b/src/cobol/__tests__/variable-tracer.test.ts
@@ -330,6 +330,44 @@ describe("COBOL extractDataflowEdges", () => {
     }
   });
 
+  it("INSPECT REPLACING: in-place rewrite classifies the inspected target correctly (#20 phase D)", () => {
+    // INSPECT REPLACING is an in-place rewrite — the inspected target
+    // is both read (input) and written (output). Pre-Phase-D fix,
+    // INSPECT wasn't in DATAFLOW_VERBS so produced zero edges. The
+    // REPLACING marker (write) plus defaultBefore=both classifies the
+    // target as read+write, producing a self-edge candidate that the
+    // dataflow filter strips, while keyword-filtered ALL/BY and the
+    // literal patterns don't surface as endpoints.
+    const source = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. INS-RP.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-INPUT   PIC X(40).
+       01  WS-COUNT   PIC 9(4).
+       PROCEDURE DIVISION.
+       A100.
+           INSPECT WS-INPUT REPLACING ALL "A" BY "B".
+           STOP RUN.
+`;
+    const ast = parse(source, "INS-RP.cbl");
+    const inspectEdges = extractDataflowEdges(ast).filter((e) => e.via === "INSPECT");
+    // Self-edges (WS-INPUT → WS-INPUT) are filtered by the Cartesian
+    // builder, so a single-target REPLACING with no other vars yields
+    // zero edges — but importantly, no phantom from BY / ALL / "A" /
+    // "B" either. The INSPECT IS extracted (verb is in DATAFLOW_VERBS)
+    // even when it produces no surviving edges.
+    for (const kw of ["ALL", "BY", "A", "B", "REPLACING"]) {
+      expect(inspectEdges.some((e) => e.from === kw || e.to === kw)).toBe(false);
+    }
+    // Sanity: the parsed statement IS an INSPECT (verb in dataflow set).
+    const stmts = ast.divisions
+      .flatMap((d) => d.sections)
+      .flatMap((s) => s.paragraphs)
+      .flatMap((p) => p.statements);
+    expect(stmts.some((s) => s.verb === "INSPECT")).toBe(true);
+  });
+
   it("INSPECT: BEFORE/AFTER INITIAL <delim> classifies delim as read (#20 phase D)", () => {
     // INSPECT TALLYING / REPLACING with a BEFORE/AFTER INITIAL clause:
     // the delim var is a read (it's a literal-or-var pattern to match,

--- a/src/cobol/variable-tracer.ts
+++ b/src/cobol/variable-tracer.ts
@@ -61,9 +61,49 @@ const VERB_RULES: Record<string, VerbRule> = {
   "COMPUTE": { defaultBefore: "write", markers: { "=": "read" }, fallback: "read" },
   "SET": { defaultBefore: "write", markers: { "TO": "read", "UP": "read", "DOWN": "read" }, fallback: "read" },
   "INITIALIZE": { defaultBefore: "write", markers: {}, fallback: "write" },
-  "STRING": { defaultBefore: "read", markers: { "INTO": "write" }, fallback: "read" },
-  "UNSTRING": { defaultBefore: "read", markers: { "INTO": "write", "TALLYING": "write" }, fallback: "read" },
-  "INSPECT": { defaultBefore: "both", markers: { "TALLYING": "write", "REPLACING": "write" }, fallback: "read" },
+  // #20 phase D — STRING/UNSTRING/INSPECT clause-boundary markers.
+  // Pre-fix, only INTO / TALLYING / REPLACING were recognised, so vars
+  // in DELIMITED / WITH POINTER / ON OVERFLOW clauses got swept into the
+  // surrounding mode (typically read), creating ~17.5× edge inflation.
+  // The full grammar wants a per-clause state machine; this is a
+  // pragmatic approximation: each clause keyword resets the access mode
+  // so its argument is classified correctly, not as part of the
+  // surrounding source/target list. Clause keywords themselves are
+  // filtered by NON_VARIABLE_KEYWORDS (phase C); these markers steer
+  // mode for the var that immediately follows.
+  "STRING": {
+    defaultBefore: "read",
+    markers: {
+      "INTO": "write",
+      "DELIMITED": "read",   // delimiter values are reads, not sources
+      "POINTER": "both",     // WITH POINTER ptr — pointer var is r/w
+      "OVERFLOW": "read",    // ON OVERFLOW imp-stmt — vars after are unrelated
+    },
+    fallback: "read",
+  },
+  "UNSTRING": {
+    defaultBefore: "read",
+    markers: {
+      "INTO": "write",
+      "TALLYING": "write",
+      "DELIMITED": "read",
+      "DELIMITER": "write",  // DELIMITER IN <var> captures matched delim
+      "COUNT": "write",      // COUNT IN <var> captures matched length
+      "POINTER": "both",
+      "OVERFLOW": "read",
+    },
+    fallback: "read",
+  },
+  "INSPECT": {
+    defaultBefore: "both",
+    markers: {
+      "TALLYING": "write",
+      "REPLACING": "write",
+      "BEFORE": "read",      // BEFORE/AFTER INITIAL <delim> — delim is read
+      "AFTER": "read",
+    },
+    fallback: "read",
+  },
   "ACCEPT": { defaultBefore: "write", markers: {}, fallback: "write" },
   "DISPLAY": { defaultBefore: "read", markers: {}, fallback: "read" },
   "READ": { defaultBefore: "read", markers: { "INTO": "write" }, fallback: "read" },
@@ -101,6 +141,13 @@ const NON_VARIABLE_KEYWORDS = new Set([
   "BEFORE", "WITH", "UPON", "ADVANCING", "AT", "INVALID",
   "CORRESPONDING", "CORR", "ROUNDED",
   "INPUT", "OUTPUT", "I-O", "EXTEND",
+  // #20 phase C — qualifier and clause keywords that previously surfaced
+  // as phantom variables in STRING/UNSTRING/INSPECT clause arguments and
+  // OF/IN qualified-reference chains.
+  "OF", "IN",                                  // qualifier keywords
+  "POINTER", "OVERFLOW",                       // STRING/UNSTRING WITH POINTER, ON OVERFLOW
+  "COUNT", "CHARACTER", "CHARACTERS",          // UNSTRING COUNT IN, INSPECT CHARACTERS
+  "LEADING", "TRAILING", "FIRST", "INITIAL",   // INSPECT REPLACING / INITIALIZE
   "=", "(", ")", "<", ">", "+", "-", "*", "/",
 ]);
 
@@ -242,11 +289,19 @@ function edgesFromStatement(
   // into rawText with spaces, which dataflow then re-split into
   // ["DAS", "IST", "EIN", "TEST"], creating phantom pseudo-variables.
   // Numeric tokens are also dropped — they're never dataflow variables.
+  //
+  // Phase C: index-based loop so we can peek 2 ahead to detect qualified
+  // references (`NAME OF PARENT` / `NAME IN PARENT`) and emit one node
+  // `"NAME OF PARENT"` instead of independent `NAME` and `PARENT` reads.
+  // Without this, `MOVE A OF GROUP-1 TO B OF GROUP-2` produced a 2×2
+  // Cartesian (4 edges) instead of the correct single edge between the
+  // qualified names.
   let currentAccess: AccessMode = rule.defaultBefore;
   const reads: string[] = [];
   const writes: string[] = [];
 
-  for (const t of stmt.tokens) {
+  for (let i = 0; i < stmt.tokens.length; i++) {
+    const t = stmt.tokens[i];
     if (t.type === "LITERAL" || t.type === "NUMERIC") continue;
     const tok = t.value.toUpperCase();
     if (rule.markers[tok] !== undefined) {
@@ -254,13 +309,30 @@ function edgesFromStatement(
       continue;
     }
     if (!isDataflowVariable(tok)) continue;
+
+    // Qualified-name collapse: NAME OF/IN PARENT → emit "NAME OF PARENT"
+    // and skip the OF/IN + parent tokens. The format matches the existing
+    // `traceVariable` qualified-name shape.
+    let name = tok;
+    const next = stmt.tokens[i + 1];
+    const nextNext = stmt.tokens[i + 2];
+    if (
+      next && nextNext
+      && (next.type === "OF" || next.type === "IN")
+      && nextNext.type === "IDENTIFIER"
+      && isDataflowVariable(nextNext.value.toUpperCase())
+    ) {
+      name = `${tok} ${next.value.toUpperCase()} ${nextNext.value.toUpperCase()}`;
+      i += 2;
+    }
+
     if (currentAccess === "read") {
-      reads.push(tok);
+      reads.push(name);
     } else if (currentAccess === "write") {
-      writes.push(tok);
+      writes.push(name);
     } else {
-      reads.push(tok);
-      writes.push(tok);
+      reads.push(name);
+      writes.push(name);
     }
   }
 

--- a/src/cobol/variable-tracer.ts
+++ b/src/cobol/variable-tracer.ts
@@ -101,6 +101,10 @@ const VERB_RULES: Record<string, VerbRule> = {
       "REPLACING": "write",
       "BEFORE": "read",      // BEFORE/AFTER INITIAL <delim> — delim is read
       "AFTER": "read",
+      // INITIAL is intentionally NOT a marker: it's a no-op keyword
+      // between BEFORE/AFTER and the delim. The BEFORE/AFTER marker has
+      // already set mode=read; INITIAL is keyword-filtered (Phase C),
+      // and the delim that follows is classified read (correct).
     },
     fallback: "read",
   },
@@ -148,6 +152,7 @@ const NON_VARIABLE_KEYWORDS = new Set([
   "POINTER", "OVERFLOW",                       // STRING/UNSTRING WITH POINTER, ON OVERFLOW
   "COUNT", "CHARACTER", "CHARACTERS",          // UNSTRING COUNT IN, INSPECT CHARACTERS
   "LEADING", "TRAILING", "FIRST", "INITIAL",   // INSPECT REPLACING / INITIALIZE
+  "FOR",                                       // INSPECT TALLYING <var> FOR ALL/LEADING/CHARACTERS
   "=", "(", ")", "<", ">", "+", "-", "*", "/",
 ]);
 
@@ -249,7 +254,13 @@ function classifyStatement(
 
 const DATAFLOW_VERBS = new Set([
   "MOVE", "COMPUTE", "ADD", "SUBTRACT", "MULTIPLY", "DIVIDE",
-  "SET", "STRING", "UNSTRING", "READ", "WRITE", "REWRITE",
+  "SET", "STRING", "UNSTRING",
+  // #20 phase D: INSPECT extracts real dataflow (TALLYING writes a count
+  // var from reading the inspected target; REPLACING is in-place r/w).
+  // Was previously excluded — adding it now that the markers in
+  // VERB_RULES correctly classify the clause arguments.
+  "INSPECT",
+  "READ", "WRITE", "REWRITE",
   "SORT", "MERGE", "RELEASE", "RETURN",
 ]);
 
@@ -310,21 +321,24 @@ function edgesFromStatement(
     }
     if (!isDataflowVariable(tok)) continue;
 
-    // Qualified-name collapse: NAME OF/IN PARENT → emit "NAME OF PARENT"
-    // and skip the OF/IN + parent tokens. The format matches the existing
-    // `traceVariable` qualified-name shape.
+    // Qualified-name collapse: NAME [OF/IN PARENT]+ → emit a single
+    // chained qualified node ("A OF B OF C") matching the existing
+    // `traceVariable` shape. The while loop handles multi-level
+    // qualification (COBOL allows arbitrary depth) so e.g.
+    // `MOVE A OF B OF C TO D` produces ONE source node `"A OF B OF C"`,
+    // not `"A OF B"` + a phantom outermost-qualifier `C`.
     let name = tok;
-    const next = stmt.tokens[i + 1];
-    const nextNext = stmt.tokens[i + 2];
-    if (
-      next && nextNext
-      && (next.type === "OF" || next.type === "IN")
-      && nextNext.type === "IDENTIFIER"
-      && isDataflowVariable(nextNext.value.toUpperCase())
+    let j = i + 1;
+    while (
+      j + 1 < stmt.tokens.length
+      && (stmt.tokens[j].type === "OF" || stmt.tokens[j].type === "IN")
+      && stmt.tokens[j + 1].type === "IDENTIFIER"
+      && isDataflowVariable(stmt.tokens[j + 1].value.toUpperCase())
     ) {
-      name = `${tok} ${next.value.toUpperCase()} ${nextNext.value.toUpperCase()}`;
-      i += 2;
+      name = `${name} ${stmt.tokens[j].value.toUpperCase()} ${stmt.tokens[j + 1].value.toUpperCase()}`;
+      j += 2;
     }
+    i = j - 1;  // -1 because the for-loop's i++ will advance to j next
 
     if (currentAccess === "read") {
       reads.push(name);


### PR DESCRIPTION
## Summary

Combined Phases C and D of the COBOL dataflow precision audit (#20). Both touch `variable-tracer.ts` and benefit from Phase B's typed tokens — packaging together so the qualifier-collapse logic (C) can use the typed-token state already shipped, and the clause markers (D) can be evaluated alongside the keyword filter that gates them.

## Phase C — qualifier semantics + missing keywords

### Added 12 keywords to `NON_VARIABLE_KEYWORDS`

| Keyword | Where it appears |
|---|---|
| `OF`, `IN` | Qualifier keywords (the **1,251 false-edge OF-class** bucket from the audit) |
| `POINTER`, `OVERFLOW` | STRING/UNSTRING `WITH POINTER`, `ON OVERFLOW` |
| `COUNT`, `CHARACTER`, `CHARACTERS` | UNSTRING `COUNT IN`, INSPECT |
| `LEADING`, `TRAILING`, `FIRST`, `INITIAL` | INSPECT `REPLACING` / INITIALIZE |
| `FOR` | INSPECT `TALLYING ... FOR ALL/CHARACTERS/LEADING` (added in fixup) |

(`DELIMITED` was already there.)

### Multi-level qualified-reference collapse

`edgesFromStatement` now uses an index-based loop with a while-chain that detects `IDENTIFIER [OF/IN IDENTIFIER]+`. Multi-level qualification (COBOL allows arbitrary depth) collapses into a single chained node `\"A OF B OF C\"` matching `traceVariable`'s existing format. Without the chain, only the innermost OF would fold and outer parents would surface as phantom variables.

Net effect:

```cobol
MOVE A OF B OF C TO D
```

Pre-fix: 3×1 Cartesian → 3 wrong edges (A→D, B→D, C→D).
Post-fix: ONE edge `\"A OF B OF C\" → D` → correct.

## Phase D — STRING/UNSTRING/INSPECT clause-boundary markers

Extended `VERB_RULES` so vars in delimiter / pointer / overflow clauses get classified by their actual role, and added `INSPECT` to `DATAFLOW_VERBS` (it was previously excluded — making the rule additions dead code).

```ts
\"STRING\":   markers: { INTO: write, DELIMITED: read, POINTER: both, OVERFLOW: read }
\"UNSTRING\": markers: { INTO: write, TALLYING: write, DELIMITED: read,
                       DELIMITER: write, COUNT: write, POINTER: both, OVERFLOW: read }
\"INSPECT\":  markers: { TALLYING: write, REPLACING: write, BEFORE: read, AFTER: read }
```

The pointer var in `STRING ... WITH POINTER WS-PTR` is now correctly r/w (in/out parameter). `DELIMITER IN var` and `COUNT IN var` UNSTRING outputs are classified as writes.

### Known limitations

- **STRING/UNSTRING grammar requires a per-clause state machine for full correctness.** The current pragmatic-first-cut produces some Cartesian noise (e.g., `WS-SRC → WS-PTR` and `WS-PTR → WS-RES` when `STRING ... WITH POINTER WS-PTR` runs the markers as designed but the simple read × write Cartesian flattens semantics). The test now asserts these noise edges DO exist, so a future state-machine fix has explicit removal targets.
- **ON OVERFLOW imperative vars** still get classified as reads — improvement vs being writes pre-fix, but they remain noise.

## Tests (8 new)

- **MOVE qualifier collapse**: exactly one edge between `\"A OF GROUP-1\"` and `\"B OF GROUP-2\"`; no separate edges to/from the parent group names; no phantom `OF` endpoints.
- **Multi-level qualifier**: `MOVE A OF B OF C TO D` produces ONE chained source node `\"A OF B OF C\"`, no phantom from outermost qualifier.
- **Bare OF/IN keyword filter**: even on a simple `MOVE X TO Y`, `OF` / `IN` never appear as edge endpoints.
- **STRING WITH POINTER**: pointer var is `from` and `to` (proves `POINTER: both`); known-noise `WS-SRC → WS-PTR` / `WS-PTR → WS-RES` asserted as present (locks the trade-off).
- **STRING DELIMITED clause keywords**: `DELIMITED`, `BY`, `WITH`, `POINTER`, `OVERFLOW` filtered out — none surface as endpoints.
- **UNSTRING capture vars**: `DELIMITER IN` and `COUNT IN` targets correctly classified as writes.
- **INSPECT TALLYING with BEFORE/AFTER**: delim classified as read; tally var classified as write; `INITIAL`/`BEFORE`/`AFTER`/`FOR` keyword-filtered.
- **INSPECT REPLACING**: in-place rewrite produces filtered self-edges; INSPECT IS extracted as a dataflow verb (proves `DATAFLOW_VERBS` membership); no clause keywords or literal patterns surface as endpoints.

1627 / 1627 passing (1611 baseline + 16 with src+dist double-run).

## Expected impact (combined #20 phases A+B+C+D)

| Phase | Removes |
|---|---|
| A (col-7 `*` filter) — merged | ~19.9% noise |
| B (typed tokens, no literal shatter) — merged | ~8% noise (1,251 OF-class edges) |
| C (keywords + qualifier collapse) — this PR | keyword-as-variable noise, qualified-reference cardinality correction |
| D (clause markers + INSPECT extraction) — this PR | STRING/UNSTRING/INSPECT inflation; INSPECT signal added |

Per the audit's projection: precision **~61% → ~85%+** on the audit corpus.

⚠ **Audit denominator caveat**: the 15,199-edge baseline pre-dates INSPECT extraction (INSPECT was excluded from `DATAFLOW_VERBS` in the audited code). Adding INSPECT in this PR introduces new edges (real signal from TALLYING / REPLACING plus residual Cartesian noise), so the post-merge audit corpus has a different shape. The 85%+ projection still holds qualitatively for the noise-removal phases (A/B/C) but should be re-measured against the new denominator after merge to get a precise post-fix number.

## Out of scope

- Per-clause state machine for full STRING/UNSTRING/INSPECT correctness.
- ON OVERFLOW imperative handling.
- `DELIMITED BY <delim>` source-pairing semantics (multi-source STRING with multiple delimiters).
- Cross-program flow-sensitive narrowing (KG-level work, not dataflow extractor's job).
- Validation that a qualifier chain doesn't reference itself (`MOVE A OF A` is invalid COBOL but the resolver doesn't reject it).

## Refs

#20 phases C and D. Phase A merged in #22, Phase B merged in #23.