### PR TITLE
fix(cobol): detect COPY REPLACING via rawText, not stmt.operands (#21)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -598,13 +598,50 @@ describe("buildDb2TableLineage", () => {
     expect(parsedBuf?.dataItem?.originCopybook).toBe("REDEF");
   });
 
-  it("rationale lists REPLACING as a possible cause when the program uses COPY", () => {
-    // The parser can't yet surface REPLACING per-copy (REPLACING/BY are
-    // typed tokens excluded from `stmt.operands` — see follow-up issue),
-    // so the resolver gates the REPLACING breadcrumb on the cheaper
-    // signal: does the program use COPY at all? If yes, the note appears
-    // alongside the typo / missing-copybook causes. If no, omitting it
-    // avoids misleading users on pure-inline-WS programs.
+  it("rationale lists REPLACING as a possible cause when the program uses COPY ... REPLACING (#21)", () => {
+    // Now that #21 fixed the parser's REPLACING detection (rawText-based
+    // instead of stmt.operands-based, which always missed because
+    // REPLACING/BY are typed keyword tokens), the gate is accurate
+    // per-program: ONLY programs that actually use REPLACING get the
+    // breadcrumb, not every program that uses any COPY.
+    const copybook = `
+       01  CUSTOMER-RECORD.
+           05  CUST-ID         PIC 9(8).
+`;
+    const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY CUSTID REPLACING CUST-ID BY ORDER-ID.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO T (X) VALUES (:WS-MISSING) END-EXEC.
+           STOP RUN.
+`;
+    const reader = programWith("READER", [[
+      "EXEC SQL SELECT X INTO :WS-NAME FROM T END-EXEC",
+    ]]);
+
+    const lineage = buildDb2TableLineage([
+      model(copybook, "CUSTID.cpy"),
+      model(writer, "WRITER.cbl"),
+      model(reader, "READER.cbl"),
+    ]);
+
+    const unresolved = lineage!.diagnostics.find(
+      (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+    );
+    expect(unresolved?.rationale).toContain("REPLACING");
+  });
+
+  it("rationale OMITS REPLACING note when program uses COPY but NOT REPLACING (#21 accurate gate)", () => {
+    // Companion test: prior to #21, this case would have falsely
+    // surfaced the REPLACING breadcrumb because the gate was the loose
+    // heuristic `program.copies.length > 0`. Now the gate uses the
+    // accurate per-copy REPLACING flag, so a plain COPY (no REPLACING)
+    // doesn't trigger the note.
     const copybook = `
        01  CUSTOMER-RECORD.
            05  CUST-ID         PIC 9(8).
@@ -634,7 +671,10 @@ describe("buildDb2TableLineage", () => {
     const unresolved = lineage!.diagnostics.find(
       (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
     );
-    expect(unresolved?.rationale).toContain("REPLACING");
+    expect(unresolved?.rationale).not.toContain("REPLACING");
+    // Other breadcrumbs still present.
+    expect(unresolved?.rationale).toContain("typos");
+    expect(unresolved?.rationale).toContain("copybook");
   });
 
   it("rationale OMITS REPLACING note for pure-inline-WS programs (no COPY)", () => {

--- a/src/cobol/__tests__/extractors.test.ts
+++ b/src/cobol/__tests__/extractors.test.ts
@@ -122,6 +122,66 @@ describe("COBOL extractors", () => {
     });
   });
 
+  describe("COPY REPLACING detection (#21)", () => {
+    // Pre-#21 the parser tried to find REPLACING in stmt.operands, but
+    // REPLACING/BY are typed keyword tokens excluded from operands, so
+    // detection always failed and `c.replacing` was always undefined.
+    // The fix uses rawText.indexOf("REPLACING") instead — best-effort
+    // tokenization that produces a non-empty array on detection.
+    function copyModel(source: string) {
+      const ast = parse(`
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CP-RPL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       ${source}
+       PROCEDURE DIVISION.
+       A100.
+           STOP RUN.
+`, "CP-RPL.cbl");
+      return extractModel(ast);
+    }
+
+    it("plain COPY (no REPLACING) leaves c.replacing undefined", () => {
+      const model = copyModel("           COPY CUSTID.");
+      expect(model.copies).toHaveLength(1);
+      expect(model.copies[0].replacing).toBeUndefined();
+    });
+
+    it("COPY ... REPLACING X BY Y (single-token) populates c.replacing", () => {
+      const model = copyModel("           COPY CUSTID REPLACING CUST-ID BY ORDER-ID.");
+      expect(model.copies).toHaveLength(1);
+      expect(model.copies[0].replacing).toBeDefined();
+      expect(model.copies[0].replacing!.length).toBeGreaterThan(0);
+      // Single-token form tokenizes cleanly: ["CUST-ID", "BY", "ORDER-ID"]
+      expect(model.copies[0].replacing).toContain("CUST-ID");
+      expect(model.copies[0].replacing).toContain("ORDER-ID");
+    });
+
+    it("COPY ... REPLACING ==X== BY ==Y== (pseudo-text) produces non-empty array", () => {
+      // Pseudo-text form shatters because `=` lexes as a single-char
+      // operator. The resulting array is messy but length > 0, which is
+      // what consumers (field-lineage exact-program filter, graph reason
+      // marker, plugin metadata flag, db2-table-lineage rationale gate)
+      // need to detect REPLACING presence. Fully structured pseudo-text
+      // parsing is out of scope.
+      const model = copyModel("           COPY CUSTID REPLACING ==CUST-== BY ==ORDER-==.");
+      expect(model.copies).toHaveLength(1);
+      expect(model.copies[0].replacing).toBeDefined();
+      expect(model.copies[0].replacing!.length).toBeGreaterThan(0);
+    });
+
+    it("multiple REPLACING pairs in one COPY all surface in c.replacing", () => {
+      const model = copyModel(
+        "           COPY CUSTID REPLACING A BY X B BY Y."
+      );
+      expect(model.copies[0].replacing).toContain("A");
+      expect(model.copies[0].replacing).toContain("X");
+      expect(model.copies[0].replacing).toContain("B");
+      expect(model.copies[0].replacing).toContain("Y");
+    });
+  });
+
   describe("CALL USING arg extraction", () => {
     it("returns empty usingArgs when CALL has no USING clause", () => {
       const src = `

--- a/src/cobol/__tests__/extractors.test.ts
+++ b/src/cobol/__tests__/extractors.test.ts
@@ -180,6 +180,31 @@ describe("COBOL extractors", () => {
       expect(model.copies[0].replacing).toContain("B");
       expect(model.copies[0].replacing).toContain("Y");
     });
+
+    it("copybook names containing 'REPLACING' do not false-positive (#25 review fix)", () => {
+      // The lexer types `REPLACING-UTIL` as a single IDENTIFIER (hyphens
+      // are word chars), so a substring `indexOf("REPLACING")` would
+      // find the embedded match and falsely flag the COPY as using
+      // REPLACING. The split-on-whitespace + exact-element match avoids
+      // this — REPLACING-UTIL is one token, doesn't equal "REPLACING".
+      const model = copyModel("           COPY REPLACING-UTIL.");
+      expect(model.copies).toHaveLength(1);
+      expect(model.copies[0].copybook).toBe("REPLACING-UTIL");
+      expect(model.copies[0].replacing).toBeUndefined();
+    });
+
+    it("copybook name containing 'REPLACING' AND an actual REPLACING clause both work", () => {
+      // Belt-and-suspenders: the embedded REPLACING in the copybook
+      // name should be ignored; the actual REPLACING keyword should be
+      // detected. Asserts the split-based match locates the real
+      // keyword, not the embedded substring.
+      const model = copyModel(
+        "           COPY REPLACING-UTIL REPLACING X BY Y."
+      );
+      expect(model.copies[0].copybook).toBe("REPLACING-UTIL");
+      expect(model.copies[0].replacing).toContain("X");
+      expect(model.copies[0].replacing).toContain("Y");
+    });
   });
 
   describe("CALL USING arg extraction", () => {

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -367,12 +367,15 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
           const dedupeKey = `${programId}|${name}`;
           if (!seenUnresolved.has(dedupeKey)) {
             seenUnresolved.add(dedupeKey);
-            // Only mention REPLACING when the program actually uses COPY at
-            // all — otherwise the note is misleading noise on programs that
-            // typo'd a pure-inline-WS field. We can't yet detect REPLACING
-            // specifically (parser doesn't surface it through `c.replacing`,
-            // see follow-up issue), so this is a conservative best-effort.
-            const replacingClause = program.copies.length > 0
+            // Mention REPLACING only when the program actually uses
+            // `COPY ... REPLACING` somewhere — the resolver doesn't apply
+            // the substitution, so a renamed field surfaces as unresolved
+            // and the user needs the breadcrumb. Now that the parser
+            // populates `c.replacing` correctly (#21), this gate is
+            // accurate per-program (was: heuristic on `copies.length > 0`).
+            const replacingClause = program.copies.some(
+              (c) => c.replacing && c.replacing.length > 0,
+            )
               ? ` \`COPY ... REPLACING\` renames are not yet applied during `
                 + `resolution and may also surface here.`
               : "";

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -359,18 +359,32 @@ function extractStatementRelations(
   }
 
   if (verb === "COPY") {
-    // COPY copybook-name [REPLACING ...]
+    // COPY copybook-name [REPLACING <pair>+]
     const copybook = stmt.operands[0];
     if (copybook) {
+      // #21 fix: extract REPLACING pairs from rawText, NOT stmt.operands.
+      // The parser's parseStatement only pushes IDENTIFIER/LITERAL/NUMERIC
+      // tokens to operands; REPLACING and BY have their own typed token
+      // types (KEYWORD_MAP), so they never appear in operands. The old
+      // code's `stmt.operands.indexOf("REPLACING")` always returned -1,
+      // leaving `c.replacing` undefined for every program with COPY
+      // REPLACING — silently disabling the field-lineage exact-program
+      // filter, the graph reason marker, and plugin metadata.
+      //
+      // Best-effort tokenization: take everything after REPLACING in
+      // rawText and split on whitespace. Single-token form
+      // (`REPLACING X BY Y`) tokenizes cleanly; pseudo-text form
+      // (`REPLACING ==X== BY ==Y==`) shatters because `=` lexes as a
+      // single-char operator, but the resulting array is non-empty so
+      // consumers checking `length > 0` get the correct boolean signal.
+      // Fully structured pseudo-text parsing is out of scope.
       const replacing: string[] = [];
       const raw = stmt.rawText.toUpperCase();
-      if (raw.includes("REPLACING")) {
-        // Collect replacement pairs from operands after REPLACING
-        const replIdx = stmt.operands.indexOf("REPLACING");
-        if (replIdx >= 0) {
-          for (let i = replIdx + 1; i < stmt.operands.length; i++) {
-            replacing.push(stmt.operands[i]);
-          }
+      const replIdx = raw.indexOf("REPLACING");
+      if (replIdx >= 0) {
+        const after = raw.substring(replIdx + "REPLACING".length).trim();
+        if (after) {
+          replacing.push(...after.split(/\s+/));
         }
       }
       model.copies.push({

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -371,21 +371,21 @@ function extractStatementRelations(
       // REPLACING — silently disabling the field-lineage exact-program
       // filter, the graph reason marker, and plugin metadata.
       //
-      // Best-effort tokenization: take everything after REPLACING in
-      // rawText and split on whitespace. Single-token form
-      // (`REPLACING X BY Y`) tokenizes cleanly; pseudo-text form
-      // (`REPLACING ==X== BY ==Y==`) shatters because `=` lexes as a
-      // single-char operator, but the resulting array is non-empty so
-      // consumers checking `length > 0` get the correct boolean signal.
-      // Fully structured pseudo-text parsing is out of scope.
+      // Tokenize rawText on whitespace and match REPLACING as an exact
+      // array element rather than a substring. This avoids false
+      // positives when a copybook name happens to contain "REPLACING"
+      // (e.g., `COPY REPLACING-UTIL` lexes as one IDENTIFIER because
+      // hyphens are word chars). Single-token form `REPLACING X BY Y`
+      // tokenizes cleanly; pseudo-text form `REPLACING ==X== BY ==Y==`
+      // shatters because `=` lexes as a single-char operator, but the
+      // post-REPLACING slice is still non-empty so consumers checking
+      // `length > 0` get the correct boolean signal. Fully structured
+      // pseudo-text parsing is out of scope.
       const replacing: string[] = [];
-      const raw = stmt.rawText.toUpperCase();
-      const replIdx = raw.indexOf("REPLACING");
+      const rawTokens = stmt.rawText.toUpperCase().split(/\s+/);
+      const replIdx = rawTokens.indexOf("REPLACING");
       if (replIdx >= 0) {
-        const after = raw.substring(replIdx + "REPLACING".length).trim();
-        if (after) {
-          replacing.push(...after.split(/\s+/));
-        }
+        replacing.push(...rawTokens.slice(replIdx + 1).filter((t) => t.length > 0));
       }
       model.copies.push({
         copybook: copybook.replace(/['"]/g, ""),


### PR DESCRIPTION
## Summary

Closes #21. Surgical fix for a parser bug that has been silently disabling REPLACING-aware behavior across four consumers since the COBOL pipeline shipped.

## Root cause

`extractors.ts:367-374` tried to detect REPLACING with:

```ts
if (raw.includes("REPLACING")) {
  const replIdx = stmt.operands.indexOf("REPLACING");
  if (replIdx >= 0) { ... }
}
```

But `parseStatement` (parser.ts:574-577) only pushes `IDENTIFIER` / `LITERAL` / `NUMERIC` tokens to `stmt.operands`. `REPLACING` and `BY` are typed keyword tokens (KEYWORD_MAP), so they never appear in `operands`. The `indexOf` always returned `-1`, the for-loop never ran, and `c.replacing` ended up `undefined` for every parsed program.

## Affected consumers (all silently broken pre-fix)

| Callsite | Behavior pre-fix |
|---|---|
| `field-lineage.ts:426` | exact-program filter `!program.replacing \|\| program.replacing.length === 0` always evaluated true → all COPY consumers treated as exact, inflating shared-lineage confidence on programs that actually rename via REPLACING |
| `graph.ts:475` | reason text `\`COPY ${name}${copy.replacing ? \" REPLACING ...\" : \"\"}\`` never showed the REPLACING marker |
| `plugin.ts:199` | metadata `c.replacing ? { replacing: c.replacing } : undefined` always undefined → external consumers reading the plugin output never saw REPLACING info |
| `db2-table-lineage.ts` host-var rationale gate | downgraded to `program.copies.length > 0` heuristic in PR #24 because the proper signal was unreliable; surfaced REPLACING breadcrumb even for plain COPY without REPLACING |

## Fix

Switch detection from `stmt.operands.indexOf` to `rawText.indexOf`, and tokenize the post-REPLACING portion by whitespace:

```ts
const raw = stmt.rawText.toUpperCase();
const replIdx = raw.indexOf("REPLACING");
if (replIdx >= 0) {
  const after = raw.substring(replIdx + "REPLACING".length).trim();
  if (after) {
    replacing.push(...after.split(/\s+/));
  }
}
```

| Form | rawText after REPLACING | Tokenization |
|---|---|---|
| `REPLACING X BY Y` | `\"X BY Y\"` | `[\"X\", \"BY\", \"Y\"]` ✓ clean |
| `REPLACING ==X== BY ==Y==` | `\"= = X = = BY = = Y = =\"` (because `=` lexes as a single-char operator) | non-empty messy array — boolean signal works, structured pairs don't |

Both forms produce a non-empty `replacing` array on detection, which is exactly what every consumer checks (`.length > 0` or truthy). Fully structured pseudo-text parsing would require lexer changes; explicitly out of scope.

## Bonus cleanup

`db2-table-lineage.ts` host-var rationale gate now uses the accurate per-copy REPLACING signal (`program.copies.some(c => c.replacing && c.replacing.length > 0)`) instead of the `program.copies.length > 0` heuristic added in #24 as a workaround. The breadcrumb now appears only on programs that actually use REPLACING — not every program that uses any COPY.

## Tests (5 new + 1 updated)

**`extractors.test.ts` — direct parser-output assertions:**
- Plain COPY (no REPLACING) → `c.replacing === undefined`
- `COPY X REPLACING A BY B` → `c.replacing` contains `[\"A\", \"B\"]` (and \"BY\")
- `COPY X REPLACING ==A== BY ==B==` → `c.replacing.length > 0` (non-empty signal, no shape assertion)
- Multiple pairs `REPLACING A BY X B BY Y` → all four tokens present

**`db2-table-lineage.test.ts` — gate accuracy:**
- Updated existing rationale test: fixture now uses `COPY CUSTID REPLACING CUST-ID BY ORDER-ID` (was: plain COPY, which used to satisfy the loose heuristic)
- New companion test: `COPY CUSTID` (no REPLACING) → rationale OMITS the REPLACING note (locks the per-copy accuracy)

1637 / 1637 passing.

## Out of scope

- Lexer/parser fix to surface REPLACING/BY as operand-eligible tokens. Would be cleaner but invasive (other statements with typed keyword tokens might break or shift behavior). The rawText approach is surgical, contained to extractors.ts, and unblocks all four consumers without touching the parser.
- Fully structured pseudo-text pair extraction. The `==X==` syntax requires the lexer to merge consecutive `=` characters into a `PSEUDO_TEXT` token type; non-trivial. Pseudo-text in real corpora is uncommon; the boolean signal is enough for current consumers.

## Refs

Closes #21.