### PR TITLE
feat(cobol): parsed-zero-data-items diagnostic for silent copybook drops (#30)

### DIFF
--- a/docs/evidence-envelope.md
+++ b/docs/evidence-envelope.md
@@ -188,8 +188,9 @@ The 2.0 abstain floor described above still drives the per-call decision; this s
 
 ### 3. Lineage diagnostic surfacing
 
-Reads `raw/parsed/cobol/field-lineage.json` if present and pulls `summary.diagnosticsByKind` from the COBOL plugin's two cross-program lineage families:
+Reads `raw/parsed/cobol/field-lineage.json` if present and pulls diagnostics from three surfaces — two cross-program lineage families plus a top-level input-quality surface:
 
+- **`fieldLineage`** — top-level `summary.diagnosticsByKind`, flagging input models the lineage builder couldn't use (e.g. `parsed-zero-data-items` from listing-extracted copybooks whose headers escaped the col-7 comment filter). Suppressed when `totalDiagnostics === 0`.
 - **`callBound`** — caller `USING` ↔ callee `LINKAGE` flow. Surfaces `callSites`, `pairs`, and the per-kind diagnostic counts the lineage builder emitted (e.g., unresolved callee, ambiguous parameter binding).
 - **`db2`** — writer→reader flow via shared DB2 tables. Surfaces `sharedTables`, `pairs`, and per-kind diagnostic counts.
 

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "../parser.js";
 import { extractModel } from "../extractors.js";
-import { attachCallBoundLineage, buildFieldLineage, generateFieldLineagePage } from "../field-lineage.js";
+import {
+  attachCallBoundLineage,
+  buildFieldLineage,
+  combineFieldLineage,
+  generateFieldLineagePage,
+  normalizeLoadedFieldLineage,
+  type SerializedFieldLineage,
+} from "../field-lineage.js";
 import { buildCallBoundLineage } from "../call-boundary-lineage.js";
 
 function model(source: string, filename: string) {
@@ -551,6 +558,45 @@ describe("COBOL field lineage", () => {
     expect(page.content).toContain("## Excluded Inputs");
     expect(page.content).toContain("`raw/EMPTY.cpy`");
     expect(page.content).toContain("`parsed-zero-data-items`");
+  });
+
+  it("combineFieldLineage preserves new diagnostic fields when attaching family lineages (#30)", () => {
+    // Spread-based combiner could silently drop the new fields if the
+    // implementation ever stops using `...base`. Lock it.
+    const emptyCopybook = "      *> placeholder\n";
+    const lineage = buildFieldLineage([
+      model(sharedCopybook, "CUSTOMER-REC.cpy"),
+      model(emptyCopybook, "EMPTY.cpy"),
+      model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+      model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    expect(lineage!.diagnostics).toHaveLength(1);
+    const combined = combineFieldLineage(lineage, { callBound: null, db2: null });
+    expect(combined).not.toBeNull();
+    expect(combined!.diagnostics).toHaveLength(1);
+    expect(combined!.summary.diagnosticsByKind["parsed-zero-data-items"]).toBe(1);
+  });
+
+  it("normalizeLoadedFieldLineage fills defaults for pre-#30 artifacts (#30)", () => {
+    // Simulates an on-disk artifact written before this change: the new fields
+    // are absent. Loader must add empty defaults so downstream code can trust
+    // the typed shape.
+    const legacy = {
+      summary: {
+        deterministic: { copybooks: 1, programs: 2, fields: 3 },
+        inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0 },
+      },
+      copybookUsage: [],
+      deterministic: [],
+      inferredHighConfidence: [],
+      inferredAmbiguous: [],
+    } as unknown as SerializedFieldLineage;
+    const normalized = normalizeLoadedFieldLineage(legacy);
+    expect(normalized.diagnostics).toEqual([]);
+    expect(normalized.summary.diagnosticsByKind).toEqual({ "parsed-zero-data-items": 0 });
+    // Existing fields untouched.
+    expect(normalized.summary.deterministic.fields).toBe(3);
   });
 
   it("generates a lineage wiki summary page", () => {

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -474,6 +474,85 @@ describe("COBOL field lineage", () => {
     expect(page.content).not.toContain("### Excluded by diagnostic");
   });
 
+  it("emits parsed-zero-data-items diagnostic for a copybook with no data items (#30)", () => {
+    // Empty-body copybook simulates the listing-extracted header case where
+    // pre-#28, the parser produced 0 data items. The lineage builder used to
+    // drop these silently — verify the diagnostic now surfaces.
+    const emptyCopybook = "      *> placeholder, no level items\n";
+    const lineage = buildFieldLineage([
+      model(sharedCopybook, "CUSTOMER-REC.cpy"),
+      model(emptyCopybook, "EMPTY.cpy"),
+      model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+      model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    expect(lineage!.summary.diagnosticsByKind["parsed-zero-data-items"]).toBe(1);
+    expect(lineage!.diagnostics).toHaveLength(1);
+    expect(lineage!.diagnostics[0]).toMatchObject({
+      kind: "parsed-zero-data-items",
+      sourceFile: "EMPTY.cpy",
+      isCopybook: true,
+    });
+  });
+
+  it("does NOT emit parsed-zero-data-items for a .cbl program with empty WORKING-STORAGE (#30)", () => {
+    // Procedure-only programs are legitimate; the diagnostic must gate on
+    // isCopybook(sourceFile) so they don't trigger false positives.
+    const procOnlyProgram = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NODATA.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STOP RUN.
+`;
+    const lineage = buildFieldLineage([
+      model(sharedCopybook, "CUSTOMER-REC.cpy"),
+      model(procOnlyProgram, "NODATA.cbl"),
+      model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+      model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    expect(lineage!.summary.diagnosticsByKind["parsed-zero-data-items"]).toBe(0);
+    expect(lineage!.diagnostics).toHaveLength(0);
+  });
+
+  it("returns a non-null lineage with diagnostics when every copybook is zero-item (#30)", () => {
+    // Pre-#30 this corpus would return null (rawCopybookUsage filtered to
+    // empty), erasing every signal. Post-#30 the artifact is preserved so the
+    // operator can see WHY lineage is empty.
+    const emptyCopybook = "      *> placeholder\n";
+    const lineage = buildFieldLineage([
+      model(emptyCopybook, "EMPTY-A.cpy"),
+      model(emptyCopybook, "EMPTY-B.cpy"),
+      model(program("ORDERA", "EMPTY-A"), "ORDERA.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    expect(lineage!.copybookUsage).toEqual([]);
+    expect(lineage!.deterministic).toEqual([]);
+    expect(lineage!.diagnostics).toHaveLength(2);
+    expect(lineage!.diagnostics.map((d) => d.sourceFile).sort()).toEqual([
+      "EMPTY-A.cpy",
+      "EMPTY-B.cpy",
+    ]);
+  });
+
+  it("renders Excluded Inputs and zero-data-items count in the wiki page (#30)", () => {
+    const emptyCopybook = "      *> placeholder\n";
+    const lineage = buildFieldLineage([
+      model(sharedCopybook, "CUSTOMER-REC.cpy"),
+      model(emptyCopybook, "EMPTY.cpy"),
+      model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+      model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+    ]);
+    expect(lineage).not.toBeNull();
+    const page = generateFieldLineagePage(lineage!);
+    expect(page.content).toContain("| Copybooks with zero parsed data items | 1 |");
+    expect(page.content).toContain("## Excluded Inputs");
+    expect(page.content).toContain("`raw/EMPTY.cpy`");
+    expect(page.content).toContain("`parsed-zero-data-items`");
+  });
+
   it("generates a lineage wiki summary page", () => {
     const lineage = buildFieldLineage([
       model(sharedCopybook, "CUSTOMER-REC.cpy"),

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -7,6 +7,20 @@ import type { Db2Lineage, HostVarRef } from "./db2-table-lineage.js";
 export type LineageLinkage = "deterministic";
 export type InferredLineageConfidence = "high" | "ambiguous";
 
+/**
+ * Reasons a parsed COBOL model was flagged at lineage-build time. Distinct from
+ * `CallBoundDiagnosticKind` / `Db2LineageDiagnosticKind` which describe
+ * cross-program join failures — these describe the upstream inputs themselves.
+ */
+export type FieldLineageDiagnosticKind = "parsed-zero-data-items";
+
+export interface FieldLineageDiagnostic {
+  kind: FieldLineageDiagnosticKind;
+  sourceFile: string;
+  isCopybook: boolean;
+  rationale: string;
+}
+
 export interface SerializedFieldLineageEntry {
   linkage: LineageLinkage;
   fieldName: string;
@@ -62,6 +76,7 @@ export interface SerializedFieldLineage {
       highConfidence: number;
       ambiguous: number;
     };
+    diagnosticsByKind: Record<FieldLineageDiagnosticKind, number>;
   };
   copybookUsage: Array<{
     copybookId: string;
@@ -72,6 +87,7 @@ export interface SerializedFieldLineage {
   deterministic: SerializedFieldLineageEntry[];
   inferredHighConfidence: SerializedInferredFieldLineageEntry[];
   inferredAmbiguous: SerializedInferredFieldLineageEntry[];
+  diagnostics: FieldLineageDiagnostic[];
   callBoundLineage?: CallBoundLineage | null;
   db2Lineage?: Db2Lineage | null;
 }
@@ -81,16 +97,30 @@ export interface FieldLineageAttachments {
   db2?: Db2Lineage | null;
 }
 
+function emptyDiagnosticsByKind(): Record<FieldLineageDiagnosticKind, number> {
+  return { "parsed-zero-data-items": 0 };
+}
+
+function countDiagnosticsByKind(
+  diagnostics: FieldLineageDiagnostic[],
+): Record<FieldLineageDiagnosticKind, number> {
+  const counts = emptyDiagnosticsByKind();
+  for (const d of diagnostics) counts[d.kind]++;
+  return counts;
+}
+
 function emptyCopybookLineage(): SerializedFieldLineage {
   return {
     summary: {
       deterministic: { copybooks: 0, programs: 0, fields: 0 },
       inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0 },
+      diagnosticsByKind: emptyDiagnosticsByKind(),
     },
     copybookUsage: [],
     deterministic: [],
     inferredHighConfidence: [],
     inferredAmbiguous: [],
+    diagnostics: [],
   };
 }
 
@@ -383,7 +413,41 @@ function formatHostVars(hostVars: HostVarRef[]): string {
 export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLineage | null {
   const parsedCopybooks = models.filter((model) => isCopybook(model.sourceFile));
   const parsedPrograms = models.filter((model) => !isCopybook(model.sourceFile));
-  if (parsedCopybooks.length === 0 || parsedPrograms.length === 0) return null;
+
+  // #30 — surface copybooks whose parsed AST yields zero flattened fields.
+  // The canonical case is listing-extracted copybooks where header text at
+  // columns other than 7 escapes the comment filter (pre-#28). They were
+  // silently dropped from every lineage family because rawCopybookUsage
+  // filters by fieldCount; the user couldn't distinguish "no shared usage"
+  // from "the copybook itself didn't parse." Only .cpy is diagnosed — a
+  // .cbl program with zero WORKING-STORAGE data items is legitimate
+  // (PROCEDURE-only / LINKAGE-only programs).
+  const diagnostics: FieldLineageDiagnostic[] = [];
+  for (const copybook of parsedCopybooks) {
+    const copybookId = `copybook:${resolveCanonicalId(copybook)}`;
+    if (flattenDataItems(copybook.dataItems, copybookId, copybook.sourceFile).length === 0) {
+      diagnostics.push({
+        kind: "parsed-zero-data-items",
+        sourceFile: copybook.sourceFile,
+        isCopybook: true,
+        rationale:
+          "Parser produced 0 data items — listing-extracted header, "
+          + "88-level-only fragment, pure COPY chain, or unsupported format.",
+      });
+    }
+  }
+  const withDiagnostics = <T extends SerializedFieldLineage>(base: T): T => ({
+    ...base,
+    summary: {
+      ...base.summary,
+      diagnosticsByKind: countDiagnosticsByKind(diagnostics),
+    },
+    diagnostics,
+  });
+
+  if (parsedCopybooks.length === 0 || parsedPrograms.length === 0) {
+    return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
+  }
 
   const copybooksByLogicalName = new Map<string, CobolCodeModel[]>();
   for (const copybook of parsedCopybooks) {
@@ -434,7 +498,9 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
     }).filter((entry) => entry.programs.length > 0)
     .sort((a, b) => a.copybookId.localeCompare(b.copybookId));
 
-  if (rawCopybookUsage.length === 0) return null;
+  if (rawCopybookUsage.length === 0) {
+    return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
+  }
 
   const flattenedByCopybook = new Map<string, FlattenedField[]>();
   for (const copybook of parsedCopybooks.filter((entry) => !duplicateLogicalNames.has(resolveCanonicalId(entry)))) {
@@ -583,7 +649,7 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
   );
 
   if (sortedDeterministic.length === 0 && inferredHighConfidence.length === 0 && inferredAmbiguous.length === 0) {
-    return null;
+    return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
   }
 
   const participatingCopybookIds = new Set<string>();
@@ -635,11 +701,13 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
         highConfidence: inferredHighConfidence.length,
         ambiguous: inferredAmbiguous.length,
       },
+      diagnosticsByKind: countDiagnosticsByKind(diagnostics),
     },
     copybookUsage,
     deterministic: sortedDeterministic,
     inferredHighConfidence,
     inferredAmbiguous,
+    diagnostics,
   };
 }
 
@@ -705,7 +773,31 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push(`| Shared DB2 tables | ${db2.summary.sharedTables} |`);
     lines.push(`| DB2 cross-program pairs | ${db2.entries.length} |`);
   }
+  const zeroDataItemsCount = lineage.summary.diagnosticsByKind["parsed-zero-data-items"] ?? 0;
+  if (zeroDataItemsCount > 0) {
+    lines.push(`| Copybooks with zero parsed data items | ${zeroDataItemsCount} |`);
+  }
   lines.push("");
+
+  if (zeroDataItemsCount > 0) {
+    lines.push("## Excluded Inputs");
+    lines.push("");
+    lines.push(
+      "Copybooks whose parsed AST yielded no data items. Common causes: "
+      + "listing-extracted header text at columns other than 7, 88-level-only "
+      + "fragments, pure COPY chains, or unsupported formats.",
+    );
+    lines.push("");
+    lines.push("| File | Kind | Rationale |");
+    lines.push("|------|------|-----------|");
+    const sortedDiagnostics = [...lineage.diagnostics].sort((a, b) =>
+      a.sourceFile.localeCompare(b.sourceFile)
+    );
+    for (const d of sortedDiagnostics) {
+      lines.push(`| \`raw/${d.sourceFile}\` | \`${d.kind}\` | ${d.rationale} |`);
+    }
+    lines.push("");
+  }
 
   const hasCopybookContent = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -109,6 +109,24 @@ function countDiagnosticsByKind(
   return counts;
 }
 
+/**
+ * Fill in field-lineage fields that older on-disk artifacts (pre-#30) don't
+ * carry. Loaders should run any JSON parsed from `field-lineage.json` through
+ * this before treating it as a `SerializedFieldLineage` — the interface
+ * declares the new fields non-optional, so a raw cast would silently lie.
+ */
+export function normalizeLoadedFieldLineage(raw: SerializedFieldLineage): SerializedFieldLineage {
+  const summary = raw.summary;
+  return {
+    ...raw,
+    summary: {
+      ...summary,
+      diagnosticsByKind: summary.diagnosticsByKind ?? emptyDiagnosticsByKind(),
+    },
+    diagnostics: raw.diagnostics ?? [],
+  };
+}
+
 function emptyCopybookLineage(): SerializedFieldLineage {
   return {
     summary: {
@@ -414,6 +432,20 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
   const parsedCopybooks = models.filter((model) => isCopybook(model.sourceFile));
   const parsedPrograms = models.filter((model) => !isCopybook(model.sourceFile));
 
+  // Flatten every copybook once; reused for the zero-data-items diagnostic,
+  // `fieldCount` in `rawCopybookUsage`, and the inferred-candidate set below.
+  // Pre-fix we called `flattenDataItems` three times per copybook (the latter
+  // two only over the dup-filtered subset, but the diagnostic loop over all).
+  const flattenedByCopybook = new Map<string, FlattenedField[]>();
+  for (const copybook of parsedCopybooks) {
+    const copybookId = `copybook:${resolveCanonicalId(copybook)}`;
+    const rootSiblingNames = copybook.dataItems.map((item) => item.name);
+    flattenedByCopybook.set(
+      copybookId,
+      flattenDataItems(copybook.dataItems, copybookId, copybook.sourceFile, [], rootSiblingNames),
+    );
+  }
+
   // #30 — surface copybooks whose parsed AST yields zero flattened fields.
   // The canonical case is listing-extracted copybooks where header text at
   // columns other than 7 escapes the comment filter (pre-#28). They were
@@ -425,7 +457,7 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
   const diagnostics: FieldLineageDiagnostic[] = [];
   for (const copybook of parsedCopybooks) {
     const copybookId = `copybook:${resolveCanonicalId(copybook)}`;
-    if (flattenDataItems(copybook.dataItems, copybookId, copybook.sourceFile).length === 0) {
+    if ((flattenedByCopybook.get(copybookId) ?? []).length === 0) {
       diagnostics.push({
         kind: "parsed-zero-data-items",
         sourceFile: copybook.sourceFile,
@@ -436,7 +468,7 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
       });
     }
   }
-  const withDiagnostics = <T extends SerializedFieldLineage>(base: T): T => ({
+  const withDiagnostics = (base: SerializedFieldLineage): SerializedFieldLineage => ({
     ...base,
     summary: {
       ...base.summary,
@@ -493,23 +525,13 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
         sourceFile: copybook.sourceFile,
         programs: consumers,
         exactPrograms,
-        fieldCount: flattenDataItems(copybook.dataItems, copybookId, copybook.sourceFile).length,
+        fieldCount: flattenedByCopybook.get(copybookId)?.length ?? 0,
       };
     }).filter((entry) => entry.programs.length > 0)
     .sort((a, b) => a.copybookId.localeCompare(b.copybookId));
 
   if (rawCopybookUsage.length === 0) {
     return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
-  }
-
-  const flattenedByCopybook = new Map<string, FlattenedField[]>();
-  for (const copybook of parsedCopybooks.filter((entry) => !duplicateLogicalNames.has(resolveCanonicalId(entry)))) {
-    const copybookId = `copybook:${resolveCanonicalId(copybook)}`;
-    const rootSiblingNames = copybook.dataItems.map((item) => item.name);
-    flattenedByCopybook.set(
-      copybookId,
-      flattenDataItems(copybook.dataItems, copybookId, copybook.sourceFile, [], rootSiblingNames),
-    );
   }
 
   const deterministic: SerializedFieldLineageEntry[] = [];
@@ -773,7 +795,11 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push(`| Shared DB2 tables | ${db2.summary.sharedTables} |`);
     lines.push(`| DB2 cross-program pairs | ${db2.entries.length} |`);
   }
-  const zeroDataItemsCount = lineage.summary.diagnosticsByKind["parsed-zero-data-items"] ?? 0;
+  // Defensive `?.` — interface declares these non-optional, but renderer may
+  // be invoked over a pre-#30 in-memory shape (e.g. test fixture, third-party
+  // loader bypassing normalizeLoadedFieldLineage). Better to render a missing
+  // count than crash.
+  const zeroDataItemsCount = lineage.summary.diagnosticsByKind?.["parsed-zero-data-items"] ?? 0;
   if (zeroDataItemsCount > 0) {
     lines.push(`| Copybooks with zero parsed data items | ${zeroDataItemsCount} |`);
   }
@@ -790,7 +816,7 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push("");
     lines.push("| File | Kind | Rationale |");
     lines.push("|------|------|-----------|");
-    const sortedDiagnostics = [...lineage.diagnostics].sort((a, b) =>
+    const sortedDiagnostics = [...(lineage.diagnostics ?? [])].sort((a, b) =>
       a.sourceFile.localeCompare(b.sourceFile)
     );
     for (const d of sortedDiagnostics) {

--- a/src/evidence-report.test.ts
+++ b/src/evidence-report.test.ts
@@ -170,6 +170,51 @@ describe("buildEvidenceReport — COBOL lineage", () => {
     });
   });
 
+  it("surfaces top-level field-lineage diagnostics (#30)", () => {
+    const wiki = freshWiki();
+    const dir = join(wiki.config.rawDir, "parsed", "cobol");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "field-lineage.json"),
+      JSON.stringify({
+        summary: {
+          deterministic: { copybooks: 0, programs: 0, fields: 0 },
+          inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0 },
+          diagnosticsByKind: { "parsed-zero-data-items": 3 },
+        },
+        diagnostics: [
+          { kind: "parsed-zero-data-items", sourceFile: "A.cpy", isCopybook: true, rationale: "..." },
+          { kind: "parsed-zero-data-items", sourceFile: "B.cpy", isCopybook: true, rationale: "..." },
+          { kind: "parsed-zero-data-items", sourceFile: "C.cpy", isCopybook: true, rationale: "..." },
+        ],
+      }),
+    );
+    const report = buildEvidenceReport(wiki);
+    expect(report.lineage.fieldLineage).toEqual({
+      diagnosticsByKind: { "parsed-zero-data-items": 3 },
+      totalDiagnostics: 3,
+    });
+  });
+
+  it("omits fieldLineage section when diagnosticsByKind is all zero (#30)", () => {
+    // Defensive: a healthy corpus carries the field with zero counts. The
+    // report should treat it as "no findings to surface" rather than rendering
+    // an empty subsection.
+    const wiki = freshWiki();
+    const dir = join(wiki.config.rawDir, "parsed", "cobol");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "field-lineage.json"),
+      JSON.stringify({
+        summary: {
+          diagnosticsByKind: { "parsed-zero-data-items": 0 },
+        },
+      }),
+    );
+    const report = buildEvidenceReport(wiki);
+    expect(report.lineage.fieldLineage).toBeUndefined();
+  });
+
   it("tolerates malformed field-lineage.json without throwing", () => {
     const wiki = freshWiki();
     const dir = join(wiki.config.rawDir, "parsed", "cobol");

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -47,6 +47,16 @@ export interface LineageDiagnosticsSection {
   totalDiagnostics: number;
 }
 
+/**
+ * Top-level field-lineage diagnostics — flag input models that produced no
+ * usable data (e.g. listing-extracted copybooks). Distinct from `callBound` /
+ * `db2` sections which describe cross-program join failures.
+ */
+export interface FieldLineageDiagnosticsSection {
+  diagnosticsByKind: Record<string, number>;
+  totalDiagnostics: number;
+}
+
 export interface TrendBucket {
   weekStart: string;
   unsupportedOrRejected: number;
@@ -68,6 +78,7 @@ export interface EvidenceReport {
   lineage: {
     callBound?: LineageDiagnosticsSection;
     db2?: LineageDiagnosticsSection;
+    fieldLineage?: FieldLineageDiagnosticsSection;
   };
   trend: TrendBucket[];
 }
@@ -248,6 +259,24 @@ function aggregateCobolLineage(wiki: Wiki): EvidenceReport["lineage"] {
     };
   }
 
+  // #30 — top-level field-lineage diagnostics (e.g. parsed-zero-data-items).
+  // Pre-#30 artifacts won't carry summary.diagnosticsByKind, so absence here
+  // is treated as "no diagnostics" rather than a parse failure.
+  const summary = lineage.summary as
+    | { diagnosticsByKind?: Record<string, number> }
+    | null
+    | undefined;
+  if (summary?.diagnosticsByKind) {
+    const diagnosticsByKind = summary.diagnosticsByKind;
+    const totalDiagnostics = Object.values(diagnosticsByKind).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    if (totalDiagnostics > 0) {
+      out.fieldLineage = { diagnosticsByKind, totalDiagnostics };
+    }
+  }
+
   return out;
 }
 
@@ -359,12 +388,22 @@ export function renderEvidenceReport(report: EvidenceReport): string {
   // ── Section 3: Lineage diagnostic surfacing ────────────────────────
   lines.push(`## Lineage diagnostic surfacing`);
   lines.push("");
-  if (!report.lineage.callBound && !report.lineage.db2) {
+  if (!report.lineage.callBound && !report.lineage.db2 && !report.lineage.fieldLineage) {
     lines.push(
       `_No COBOL lineage artifacts found at \`raw/parsed/cobol/field-lineage.json\`. `
         + `Run \`wiki_admin --action rebuild\` after ingesting COBOL sources to populate this section._`,
     );
   } else {
+    if (report.lineage.fieldLineage) {
+      const fl = report.lineage.fieldLineage;
+      lines.push(`### COBOL field-lineage inputs`);
+      lines.push("");
+      lines.push(`- ${fl.totalDiagnostics} diagnostic(s) surfaced`);
+      for (const [kind, count] of Object.entries(fl.diagnosticsByKind)) {
+        if (count > 0) lines.push(`  - \`${kind}\`: ${count}`);
+      }
+      lines.push("");
+    }
     if (report.lineage.callBound) {
       const cb = report.lineage.callBound;
       lines.push(`### COBOL call-bound`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import { cobolPlugin } from "./cobol/plugin.js";
 import { canonicalNodeId, deserializeGraph, displayLabel, graphEdgesFrom, graphImpactOf } from "./cobol/graph.js";
 import type { CodeProcedure, CodeRelation, NormalizedCodeModel } from "./code-analysis.js";
 import type { SerializedFieldLineage, SerializedInferredFieldLineageEntry } from "./cobol/field-lineage.js";
+import { normalizeLoadedFieldLineage } from "./cobol/field-lineage.js";
 import type { GraphEdge, GraphNode, KnowledgeGraph, NodeKind, SerializedGraph } from "./cobol/graph.js";
 
 // Register built-in plugins
@@ -828,7 +829,9 @@ async function loadFieldLineageArtifact(wiki: Wiki, language: string): Promise<S
     );
   }
   try {
-    return JSON.parse(rawResult.content) as SerializedFieldLineage;
+    // Normalize pre-#30 artifacts that lack summary.diagnosticsByKind /
+    // diagnostics so the rest of the codebase can trust the typed shape.
+    return normalizeLoadedFieldLineage(JSON.parse(rawResult.content) as SerializedFieldLineage);
   } catch (err) {
     throw new Error(`Failed to parse compiled field lineage for "${plugin.id}": ${err instanceof Error ? err.message : String(err)}`);
   }


### PR DESCRIPTION
## Summary

Fixes #30. Closes the audit gap revealed by #28: listing-extracted copybooks (and any other input that produces 0 data items) were dropped silently from every lineage family. Now they surface as a structured diagnostic on a third top-level surface, visible on the wiki page and in the Phase 3 evidence dashboard.

## Change

1. **New types** in `src/cobol/field-lineage.ts`:
   - `FieldLineageDiagnosticKind = "parsed-zero-data-items"`
   - `FieldLineageDiagnostic { kind; sourceFile; isCopybook; rationale }`
   - `SerializedFieldLineage.summary.diagnosticsByKind` + top-level `diagnostics[]`
2. **Emit point**: top of `buildFieldLineage`, before any short-circuit. Gates on `isCopybook(sourceFile)` — a procedure-only `.cbl` is legitimate and must not trigger.
3. **Short-circuit handling**: the three pre-existing `return null` paths now return an `emptyCopybookLineage()` with diagnostics attached when any are present, so the artifact preserves the finding even when no lineage rows materialise.
4. **Wiki render**: one new Overview row (`| Copybooks with zero parsed data items | N |`) and an `## Excluded Inputs` table appear when count > 0; otherwise unchanged.
5. **Evidence-report Phase 3**: `EvidenceReport.lineage.fieldLineage?: FieldLineageDiagnosticsSection`, rendered as `### COBOL field-lineage inputs` ahead of the existing callBound/db2 subsections. Pre-#30 artifacts without `summary.diagnosticsByKind` degrade gracefully to "no findings."
6. **Doc**: `docs/evidence-envelope.md` Section 3 updated to describe the third surface.

## Why not attach to callBound/db2

Different category. `unresolved-callee` / `host-var-unresolved` describe cross-program join failures. `parsed-zero-data-items` describes an upstream input the lineage builder never had the data to use — it fires before any join logic runs and is just as relevant when those families are absent.

## Tests

- 4 in `field-lineage.test.ts`: emit case, `.cbl` negative, all-empty corpus preserves diagnostics, wiki render.
- 2 in `evidence-report.test.ts`: surfaces top-level field-lineage diagnostics; omits the section when all-zero.

Full suite: 49 files, 1809 tests (1801 → 1809, +8) green. `tsc --noEmit` clean.

## Out of scope

- Auto-classifying *why* a file produced zero items (per the issue's "Out of scope").
- Distinguishing intentional include stubs from broken parses — left to the rationale string and operator judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)