### PR TITLE
feat(wiki): coverage summary at top of field-lineage.md (#31)

### DIFF
--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -10,6 +10,7 @@ import {
   type SerializedFieldLineage,
 } from "../field-lineage.js";
 import { buildCallBoundLineage } from "../call-boundary-lineage.js";
+import { buildDb2TableLineage } from "../db2-table-lineage.js";
 
 function model(source: string, filename: string) {
   return extractModel(parse(source, filename));
@@ -627,6 +628,191 @@ describe("COBOL field lineage", () => {
     expect(normalized.diagnostics).toEqual([]);
     expect(normalized.summary.diagnosticsByKind).toEqual({ "parsed-zero-data-items": 0 });
     expect(normalized.summary.deterministic.fields).toBe(3);
+  });
+
+  describe("Coverage section (#31)", () => {
+    it("renders ## Coverage as the first section after the frontmatter", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      const page = generateFieldLineagePage(lineage!);
+      const frontmatterEnd = page.content.indexOf("---", page.content.indexOf("---") + 3) + 3;
+      const coverageAt = page.content.indexOf("## Coverage");
+      const overviewAt = page.content.indexOf("## Overview");
+      expect(coverageAt).toBeGreaterThan(frontmatterEnd);
+      expect(coverageAt).toBeLessThan(overviewAt);
+      expect(page.content).toContain("| Family | Indexed | Yielding lineage | Excluded (top reasons) |");
+    });
+
+    it("renders only the Copybook row when callBound and db2 are absent", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      const page = generateFieldLineagePage(lineage!);
+      expect(page.content).toContain("| Copybook |");
+      expect(page.content).not.toContain("| Call boundary |");
+      expect(page.content).not.toContain("| DB2 |");
+    });
+
+    it("renders Call boundary and DB2 rows when those sections are present", () => {
+      const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-REC.
+           05  WS-FIELD-A      PIC X(5).
+           05  WS-OTHER        PIC X(5).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "CALLEE" USING WS-REC.
+           STOP RUN.
+`;
+      const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-REC.
+           05  LK-FIELD-A      PIC X(5).
+           05  LK-OTHER        PIC X(5).
+       PROCEDURE DIVISION USING LK-REC.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+      const writerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-ID              PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID) VALUES (:WS-ID) END-EXEC.
+           STOP RUN.
+`;
+      const readerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. READER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-ID              PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL SELECT ID INTO :WS-ID FROM CUSTOMERS END-EXEC.
+           STOP RUN.
+`;
+      const models = [
+        model(callerSrc, "CALLER.cbl"),
+        model(calleeSrc, "CALLEE.cbl"),
+        model(writerSrc, "WRITER.cbl"),
+        model(readerSrc, "READER.cbl"),
+      ];
+      const callBound = buildCallBoundLineage(models);
+      const db2 = buildDb2TableLineage(models);
+      const lineage = combineFieldLineage(null, { callBound, db2 });
+      expect(lineage).not.toBeNull();
+      const page = generateFieldLineagePage(lineage!);
+      expect(page.content).toContain("## Coverage");
+      expect(page.content).not.toContain("| Copybook |");
+      expect(page.content).toMatch(/\| Call boundary \| \d+ call sites \| \d+ pairs \|/);
+      expect(page.content).toMatch(/\| DB2 \| \d+ tables \| \d+ writer→reader \|/);
+    });
+
+    it("Excluded column lists top-2 reasons (count desc, kind asc tiebreak) and — when none", () => {
+      // Call boundary with three diagnostic kinds at known counts.
+      // Construct two unresolved-callee, two dynamic-call, one arity-mismatch.
+      // Expected order in cell: 2 dynamic-call (kind asc on tie), 2 unresolved-callee.
+      const callerSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-A              PIC X(5).
+       01  WS-B              PIC X(5).
+       01  WS-CALLEE         PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL "MISSING1" USING WS-A.
+           CALL "MISSING2" USING WS-A.
+           CALL WS-CALLEE USING WS-A.
+           CALL WS-CALLEE USING WS-A.
+           CALL "CALLEE" USING WS-A WS-B.
+           STOP RUN.
+`;
+      const calleeSrc = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLEE.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-A              PIC X(5).
+       PROCEDURE DIVISION USING LK-A.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+      const callBound = buildCallBoundLineage([
+        model(callerSrc, "CALLER.cbl"),
+        model(calleeSrc, "CALLEE.cbl"),
+      ]);
+      expect(callBound).not.toBeNull();
+      expect(callBound!.summary.diagnosticsByKind["unresolved-callee"]).toBe(2);
+      expect(callBound!.summary.diagnosticsByKind["dynamic-call"]).toBe(2);
+      expect(callBound!.summary.diagnosticsByKind["arity-mismatch"]).toBe(1);
+
+      const lineage = combineFieldLineage(null, { callBound });
+      const page = generateFieldLineagePage(lineage!);
+
+      // Find the Call boundary row inside the Coverage table.
+      const coverageStart = page.content.indexOf("## Coverage");
+      const overviewStart = page.content.indexOf("## Overview");
+      const coverageBlock = page.content.slice(
+        coverageStart,
+        overviewStart > 0 ? overviewStart : page.content.length,
+      );
+      // dynamic-call sorts before unresolved-callee alphabetically; both have
+      // count 2 so tiebreak is alphabetical asc. arity-mismatch (count 1) drops.
+      expect(coverageBlock).toContain("2 dynamic-call, 2 unresolved-callee");
+      expect(coverageBlock).not.toContain("arity-mismatch");
+    });
+
+    it("renders — in the Excluded column when a family has no diagnostics", () => {
+      // Clean copybook lineage, no parsed-zero-data-items diagnostics.
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      const page = generateFieldLineagePage(lineage!);
+      const coverageStart = page.content.indexOf("## Coverage");
+      const overviewStart = page.content.indexOf("## Overview");
+      const coverageBlock = page.content.slice(coverageStart, overviewStart);
+      expect(coverageBlock).toMatch(/\| Copybook \|[^|]+\|[^|]+\| — \|/);
+    });
+
+    it("reflects parsed-zero-data-items in the Copybook row's Excluded cell (#30 + #31)", () => {
+      const emptyCopybook = "      *> placeholder\n";
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(emptyCopybook, "EMPTY.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      const page = generateFieldLineagePage(lineage!);
+      const coverageStart = page.content.indexOf("## Coverage");
+      const overviewStart = page.content.indexOf("## Overview");
+      const coverageBlock = page.content.slice(coverageStart, overviewStart);
+      expect(coverageBlock).toContain("1 parsed-zero-data-items");
+    });
   });
 
   it("generates a lineage wiki summary page", () => {

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -723,8 +723,8 @@ describe("COBOL field lineage", () => {
       const page = generateFieldLineagePage(lineage!);
       expect(page.content).toContain("## Coverage");
       expect(page.content).not.toContain("| Copybook |");
-      expect(page.content).toMatch(/\| Call boundary \| \d+ call sites \| \d+ pairs \|/);
-      expect(page.content).toMatch(/\| DB2 \| \d+ tables \| \d+ writer→reader \|/);
+      expect(page.content).toMatch(/\| Call boundary \| \d+ call site\(s\) \| \d+ pair\(s\) \|/);
+      expect(page.content).toMatch(/\| DB2 \| \d+ table\(s\) \| \d+ writer→reader pair\(s\) \|/);
     });
 
     it("Excluded column lists top-2 reasons (count desc, kind asc tiebreak) and — when none", () => {
@@ -783,6 +783,9 @@ describe("COBOL field lineage", () => {
       // count 2 so tiebreak is alphabetical asc. arity-mismatch (count 1) drops.
       expect(coverageBlock).toContain("2 dynamic-call, 2 unresolved-callee");
       expect(coverageBlock).not.toContain("arity-mismatch");
+      // All 5 CALLs failed at the site gate, so callSites=0, pairs=0,
+      // siteDropped=5 → Indexed = 5 call sites.
+      expect(coverageBlock).toMatch(/\| Call boundary \| 5 call site\(s\) \| 0 pair\(s\) \|/);
     });
 
     it("renders — in the Excluded column when a family has no diagnostics", () => {
@@ -812,6 +815,8 @@ describe("COBOL field lineage", () => {
       const overviewStart = page.content.indexOf("## Overview");
       const coverageBlock = page.content.slice(coverageStart, overviewStart);
       expect(coverageBlock).toContain("1 parsed-zero-data-items");
+      // Indexed math: 1 participating copybook + 1 zero-data = 2 total.
+      expect(coverageBlock).toMatch(/\| Copybook \| 2 \| 1 deterministic, 0 inferred \|/);
     });
   });
 

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -1128,11 +1128,11 @@ function renderCoverageSection(
   callBound: CallBoundLineage | null,
   db2: Db2Lineage | null,
 ): void {
-  // Pre-#30 in-memory shapes may lack diagnosticsByKind; mirror the
-  // defensive `?.` already used at the Overview row for the zero-data-items
-  // counter. `lineage.diagnostics ?? []` covers the same pre-#30 gap.
-  const copybookDiagByKind = lineage.summary.diagnosticsByKind ?? {} as Record<string, number>;
-  const zeroDataItemsCount = (copybookDiagByKind as Record<string, number>)["parsed-zero-data-items"] ?? 0;
+  // Pre-#30 in-memory shapes may lack diagnosticsByKind; declaring as
+  // Record<string, number> means the `?? 0` reads on known keys are
+  // defensible even if the field is absent.
+  const copybookDiagByKind: Record<string, number> = lineage.summary.diagnosticsByKind ?? {};
+  const zeroDataItemsCount = copybookDiagByKind["parsed-zero-data-items"] ?? 0;
   const copybookHasContent = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0
     || lineage.inferredHighConfidence.length > 0
@@ -1141,19 +1141,42 @@ function renderCoverageSection(
 
   const rows: string[] = [];
   if (copybookHasContent) {
+    // Indexed = universe of copybooks observed = participating (yielded
+    // lineage) + zero-data-items drops. Single-consumer / REPLACING-only
+    // copybooks aren't currently tracked as diagnostics so they don't
+    // appear; once added, sum their counter in here.
+    const indexed = lineage.copybookUsage.length + zeroDataItemsCount;
     const yielding = `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred`;
     rows.push(
-      `| Copybook | ${lineage.copybookUsage.length} | ${yielding} | ${topExclusionReasons(copybookDiagByKind)} |`,
+      `| Copybook | ${indexed} | ${yielding} | ${topExclusionReasons(copybookDiagByKind)} |`,
     );
   }
   if (callBound) {
+    // Indexed = total CALL ... USING sites attempted = resolved sites
+    // (`summary.callSites`) + per-site drops. shape-mismatch and
+    // caller-arg-not-top-level are per-arg drops *within* a resolved
+    // site, so they don't add to the site total.
+    const cbd = callBound.summary.diagnosticsByKind;
+    const siteDropped =
+      cbd["unresolved-callee"]
+      + cbd["dynamic-call"]
+      + cbd["arity-mismatch"]
+      + cbd["system-call"];
+    const totalSites = callBound.summary.callSites + siteDropped;
     rows.push(
-      `| Call boundary | ${callBound.summary.callSites} call sites | ${callBound.summary.pairs} pairs | ${topExclusionReasons(callBound.summary.diagnosticsByKind)} |`,
+      `| Call boundary | ${totalSites} call site(s) | ${callBound.summary.pairs} pair(s) | ${topExclusionReasons(callBound.summary.diagnosticsByKind)} |`,
     );
   }
   if (db2) {
+    // Indexed = all distinct DB2 tables touched by ≥1 program =
+    // sharedTables (had both writer and reader) + writer-only +
+    // reader-only. non-classifiable-op is per-reference, not per-table,
+    // and self-loop is per-pair within a shared table — neither adds to
+    // the table total.
+    const dbd = db2.summary.diagnosticsByKind;
+    const totalTables = db2.summary.sharedTables + dbd["writer-only"] + dbd["reader-only"];
     rows.push(
-      `| DB2 | ${db2.summary.sharedTables} tables | ${db2.summary.pairs} writer→reader | ${topExclusionReasons(db2.summary.diagnosticsByKind)} |`,
+      `| DB2 | ${totalTables} table(s) | ${db2.summary.pairs} writer→reader pair(s) | ${topExclusionReasons(db2.summary.diagnosticsByKind)} |`,
     );
   }
   if (rows.length === 0) return;

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -776,6 +776,8 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
   lines.push("---");
   lines.push("");
 
+  renderCoverageSection(lines, lineage, callBound, db2);
+
   const overviewHasCopybook = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0
     || lineage.inferredHighConfidence.length > 0
@@ -1095,6 +1097,72 @@ function renderDb2Exclusions(
     if (known.has(kind)) continue;
     renderRow(kind, count, sample);
   }
+  lines.push("");
+}
+
+/**
+ * Compact "top N excluded reasons" for a coverage-row cell. Kinds with
+ * zero counts are dropped first so the cell never renders a noise entry
+ * like `0 system-call`. Sort is count desc, kind asc on tie — pinning the
+ * tie-break gives byte-stable output across rebuilds when two kinds have
+ * the same count.
+ */
+function topExclusionReasons(byKind: Record<string, number>, limit = 2): string {
+  const ranked = Object.entries(byKind)
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  if (ranked.length === 0) return "—";
+  return ranked.slice(0, limit).map(([kind, count]) => `${count} ${kind}`).join(", ");
+}
+
+/**
+ * Coverage gauge rendered at the top of `field-lineage.md`. Three rows —
+ * Copybook / Call boundary / DB2 — each showing what was indexed, what
+ * yielded lineage, and the top excluded reasons. Empty families omit their
+ * row. All counts derive from existing summary fields on the artifact; no
+ * new aggregation logic.
+ */
+function renderCoverageSection(
+  lines: string[],
+  lineage: SerializedFieldLineage,
+  callBound: CallBoundLineage | null,
+  db2: Db2Lineage | null,
+): void {
+  // Pre-#30 in-memory shapes may lack diagnosticsByKind; mirror the
+  // defensive `?.` already used at the Overview row for the zero-data-items
+  // counter. `lineage.diagnostics ?? []` covers the same pre-#30 gap.
+  const copybookDiagByKind = lineage.summary.diagnosticsByKind ?? {} as Record<string, number>;
+  const zeroDataItemsCount = (copybookDiagByKind as Record<string, number>)["parsed-zero-data-items"] ?? 0;
+  const copybookHasContent = lineage.copybookUsage.length > 0
+    || lineage.deterministic.length > 0
+    || lineage.inferredHighConfidence.length > 0
+    || lineage.inferredAmbiguous.length > 0
+    || zeroDataItemsCount > 0;
+
+  const rows: string[] = [];
+  if (copybookHasContent) {
+    const yielding = `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred`;
+    rows.push(
+      `| Copybook | ${lineage.copybookUsage.length} | ${yielding} | ${topExclusionReasons(copybookDiagByKind)} |`,
+    );
+  }
+  if (callBound) {
+    rows.push(
+      `| Call boundary | ${callBound.summary.callSites} call sites | ${callBound.summary.pairs} pairs | ${topExclusionReasons(callBound.summary.diagnosticsByKind)} |`,
+    );
+  }
+  if (db2) {
+    rows.push(
+      `| DB2 | ${db2.summary.sharedTables} tables | ${db2.summary.pairs} writer→reader | ${topExclusionReasons(db2.summary.diagnosticsByKind)} |`,
+    );
+  }
+  if (rows.length === 0) return;
+
+  lines.push("## Coverage");
+  lines.push("");
+  lines.push("| Family | Indexed | Yielding lineage | Excluded (top reasons) |");
+  lines.push("|--------|---------|------------------|------------------------|");
+  lines.push(...rows);
   lines.push("");
 }
 


### PR DESCRIPTION
## Summary

Closes #31. Adds a `## Coverage` block at the top of `cobol/field-lineage.md` that surfaces, at a glance, how many copybooks / call sites / DB2 tables were indexed vs how many yielded lineage, plus the top-2 reasons for exclusion per family.

## Change

- New helper `renderCoverageSection` in `src/cobol/field-lineage.ts`, called right after the frontmatter, before `## Overview`.
- Three rows — Copybook / Call boundary / DB2 — each rendered only when that family has content. The Copybook row shows up when `copybookUsage` is non-empty OR `parsed-zero-data-items > 0`; Call boundary / DB2 rows render whenever the artifact carries `callBoundLineage` / `db2Lineage`.
- "Excluded (top reasons)" — `topExclusionReasons` ranks `summary.diagnosticsByKind` by count desc, kind asc on tie. Drops zero-count kinds. Renders `—` when none.
- All counts derive from existing summary fields. No new aggregation logic, no shape change to the JSON.

## Tests

Five new tests under `Coverage section (#31)` in `src/cobol/__tests__/field-lineage.test.ts`:

1. `## Coverage` sits between the frontmatter and `## Overview`.
2. Only Copybook row appears when callBound/db2 are absent.
3. Call boundary and DB2 rows appear when those sections are present.
4. Top-2 reasons format with proper tiebreak ordering (2 dynamic-call before 2 unresolved-callee; arity-mismatch=1 drops out).
5. `—` rendered when a family has no diagnostics.
6. `parsed-zero-data-items` surfaces in the Copybook row's Excluded cell (#30 + #31 interaction).

## Test plan

- [x] `npx vitest run` — all 3672 tests pass
- [x] `npx tsc --noEmit` — clean
