### PR TITLE
feat(atlassian): persist Confluence version & history in .meta.yaml (#27)

### DIFF
--- a/src/atlassian.test.ts
+++ b/src/atlassian.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Integration tests for confluenceImport that exercise the version /
+ * history persistence path added by #27. Drives the importer with mocked
+ * fetch responses; no live API calls.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import yaml from "js-yaml";
+import { confluenceImport, ATLASSIAN_DEFAULTS } from "./atlassian.js";
+
+type Route = (url: string) => Promise<Partial<Response>> | Partial<Response>;
+
+interface MockResponse {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  body: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  // Minimal Response-shaped object that satisfies the production code's
+  // .ok / .status / .statusText / .json() / .text() reads.
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function installFetchMock(routes: Array<{ match: RegExp; resp: MockResponse | Route }>): ReturnType<typeof vi.fn> {
+  const spy = vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const route of routes) {
+      if (route.match.test(url)) {
+        if (typeof route.resp === "function") {
+          const r = await route.resp(url);
+          return r as Response;
+        }
+        return jsonResponse(route.resp.body, route.resp.status ?? 200);
+      }
+    }
+    return jsonResponse({ error: `unrouted: ${url}` }, 404);
+  });
+  globalThis.fetch = spy as unknown as typeof fetch;
+  return spy;
+}
+
+function readSidecar(rawDir: string, space: string, slug: string): Record<string, any> {
+  const sidecar = join(rawDir, `confluence/${space}/${slug}.html.meta.yaml`);
+  expect(existsSync(sidecar)).toBe(true);
+  return yaml.load(readFileSync(sidecar, "utf-8")) as Record<string, any>;
+}
+
+describe("confluenceImport — version & history persistence (#27)", () => {
+  let rawDir: string;
+  let originalFetch: typeof fetch;
+  let originalToken: string | undefined;
+
+  beforeEach(() => {
+    rawDir = mkdtempSync(join(tmpdir(), "confluence-test-"));
+    originalFetch = globalThis.fetch;
+    originalToken = process.env.CONFLUENCE_API_TOKEN;
+    process.env.CONFLUENCE_API_TOKEN = "test@example.com:testtoken";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalToken === undefined) delete process.env.CONFLUENCE_API_TOKEN;
+    else process.env.CONFLUENCE_API_TOKEN = originalToken;
+    rmSync(rawDir, { recursive: true, force: true });
+  });
+
+  it("Cloud: writes version + history (with displayName via /users) into .meta.yaml", async () => {
+    const spy = installFetchMock([
+      {
+        match: /\/wiki\/api\/v2\/pages\/12345\?body-format=storage/,
+        resp: {
+          body: {
+            id: "12345",
+            title: "Architecture Overview",
+            body: { storage: { value: "<p>hello</p>" } },
+            version: { createdAt: "2026-05-01T10:00:00Z", number: 7 },
+            createdAt: "2025-12-01T08:00:00Z",
+            authorId: "557058:abcd-efgh",
+          },
+        },
+      },
+      {
+        match: /\/wiki\/api\/v2\/users\/557058:abcd-efgh/,
+        resp: { body: { displayName: "Alice Author" } },
+      },
+      { match: /\/attachments(\?|$)/, resp: { body: { results: [] } } },
+      { match: /\/children\/page(\?|$)/, resp: { body: { results: [] } } },
+    ]);
+
+    await confluenceImport(
+      "https://acme.atlassian.net/wiki/spaces/ENG/pages/12345/Architecture-Overview",
+      rawDir,
+      { ...ATLASSIAN_DEFAULTS },
+    );
+
+    const meta = readSidecar(rawDir, "ENG", "architecture-overview");
+    expect(meta.confluence).toEqual({
+      version: { when: "2026-05-01T10:00:00Z", number: 7 },
+      history: {
+        createdDate: "2025-12-01T08:00:00Z",
+        createdBy: { displayName: "Alice Author" },
+      },
+    });
+    expect(spy.mock.calls.some(([u]) => String(u).includes("/users/557058:abcd-efgh"))).toBe(true);
+  });
+
+  it("Cloud: omits createdBy when /users lookup 404s, keeps version + createdDate", async () => {
+    installFetchMock([
+      {
+        match: /\/wiki\/api\/v2\/pages\/12345\?body-format=storage/,
+        resp: {
+          body: {
+            id: "12345",
+            title: "Solo Page",
+            body: { storage: { value: "<p>x</p>" } },
+            version: { createdAt: "2026-05-01T10:00:00Z", number: 1 },
+            createdAt: "2025-12-01T08:00:00Z",
+            authorId: "missing-user",
+          },
+        },
+      },
+      { match: /\/users\//, resp: { body: { error: "not found" }, status: 404, ok: false } },
+      { match: /\/attachments(\?|$)/, resp: { body: { results: [] } } },
+      { match: /\/children\/page(\?|$)/, resp: { body: { results: [] } } },
+    ]);
+
+    await confluenceImport(
+      "https://acme.atlassian.net/wiki/spaces/ENG/pages/12345/Solo-Page",
+      rawDir,
+      { ...ATLASSIAN_DEFAULTS },
+    );
+
+    const meta = readSidecar(rawDir, "ENG", "solo-page");
+    expect(meta.confluence).toEqual({
+      version: { when: "2026-05-01T10:00:00Z", number: 1 },
+      history: { createdDate: "2025-12-01T08:00:00Z" },
+    });
+  });
+
+  it("Cloud: caches /users lookups across a recursive import", async () => {
+    const spy = installFetchMock([
+      {
+        match: /\/wiki\/api\/v2\/pages\/100\?body-format=storage/,
+        resp: {
+          body: {
+            id: "100", title: "Parent",
+            body: { storage: { value: "p" } },
+            version: { createdAt: "2026-05-01T10:00:00Z", number: 1 },
+            createdAt: "2025-12-01T00:00:00Z",
+            authorId: "shared-author",
+          },
+        },
+      },
+      {
+        match: /\/wiki\/api\/v2\/pages\/200\?body-format=storage/,
+        resp: {
+          body: {
+            id: "200", title: "Child",
+            body: { storage: { value: "c" } },
+            version: { createdAt: "2026-05-02T10:00:00Z", number: 1 },
+            createdAt: "2025-12-02T00:00:00Z",
+            authorId: "shared-author",
+          },
+        },
+      },
+      {
+        match: /\/wiki\/api\/v2\/users\/shared-author/,
+        resp: { body: { displayName: "Shared Author" } },
+      },
+      { match: /\/pages\/100\/children\/page/, resp: { body: { results: [{ id: "200", title: "Child" }] } } },
+      { match: /\/children\/page(\?|$)/, resp: { body: { results: [] } } },
+      { match: /\/attachments(\?|$)/, resp: { body: { results: [] } } },
+    ]);
+
+    await confluenceImport(
+      "https://acme.atlassian.net/wiki/spaces/ENG/pages/100/Parent",
+      rawDir,
+      { ...ATLASSIAN_DEFAULTS },
+      { recursive: true },
+    );
+
+    const userCalls = spy.mock.calls.filter(([u]) => String(u).includes("/users/shared-author"));
+    expect(userCalls.length).toBe(1);
+    expect(readSidecar(rawDir, "ENG", "parent").confluence.history.createdBy).toEqual({ displayName: "Shared Author" });
+    expect(readSidecar(rawDir, "ENG", "child").confluence.history.createdBy).toEqual({ displayName: "Shared Author" });
+  });
+
+  it("Server: writes version + history inline (no /users follow-up)", async () => {
+    const spy = installFetchMock([
+      {
+        match: /\/rest\/api\/content\/77777\?expand=body\.storage,version,history,history\.createdBy/,
+        resp: {
+          body: {
+            id: 77777,
+            title: "DC Page",
+            body: { storage: { value: "<p>server</p>" } },
+            version: { when: "2026-04-01T12:00:00Z", number: 2 },
+            history: {
+              createdDate: "2025-11-01T09:00:00Z",
+              createdBy: { displayName: "Bob Server" },
+            },
+          },
+        },
+      },
+      { match: /\/child\/attachment/, resp: { body: { results: [] } } },
+      { match: /\/child\/page/, resp: { body: { results: [] } } },
+    ]);
+
+    await confluenceImport(
+      "https://confluence.example.com/spaces/DEV/pages/77777/DC-Page",
+      rawDir,
+      { ...ATLASSIAN_DEFAULTS },
+    );
+
+    const meta = readSidecar(rawDir, "DEV", "dc-page");
+    expect(meta.confluence).toEqual({
+      version: { when: "2026-04-01T12:00:00Z", number: 2 },
+      history: {
+        createdDate: "2025-11-01T09:00:00Z",
+        createdBy: { displayName: "Bob Server" },
+      },
+    });
+    // No /users follow-up — server response carried displayName inline.
+    expect(spy.mock.calls.every(([u]) => !String(u).includes("/users/"))).toBe(true);
+  });
+
+  it("omits the confluence block entirely when the API response carries no version", async () => {
+    // Older Server responses, or a Cloud page where the body wasn't returned
+    // with expansion, still need to produce a valid sidecar.
+    installFetchMock([
+      {
+        match: /\/wiki\/api\/v2\/pages\/55555\?body-format=storage/,
+        resp: {
+          body: {
+            id: "55555",
+            title: "Legacy Page",
+            body: { storage: { value: "<p>legacy</p>" } },
+            // no version, no createdAt, no authorId
+          },
+        },
+      },
+      { match: /\/attachments(\?|$)/, resp: { body: { results: [] } } },
+      { match: /\/children\/page(\?|$)/, resp: { body: { results: [] } } },
+    ]);
+
+    await confluenceImport(
+      "https://acme.atlassian.net/wiki/spaces/ENG/pages/55555/Legacy-Page",
+      rawDir,
+      { ...ATLASSIAN_DEFAULTS },
+    );
+
+    const meta = readSidecar(rawDir, "ENG", "legacy-page");
+    expect(meta.confluence).toBeUndefined();
+    // Core sidecar fields still present so wiki_lint / integrity checks pass.
+    expect(meta.path).toBe("confluence/ENG/legacy-page.html");
+    expect(meta.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/atlassian.ts
+++ b/src/atlassian.ts
@@ -61,6 +61,28 @@ export interface JiraImportResult {
   importedCount: number;
 }
 
+/**
+ * Provenance metadata fetched from Confluence alongside the page body. Lets a
+ * downstream tool answer "who last changed this, when, and which revision is
+ * this?" without re-querying the source. Optional everywhere — older sidecars
+ * predate this block, and not every Cloud response carries `history.createdBy`
+ * cheaply (see Cloud `getPage` below for the /users follow-up cache).
+ */
+export interface ConfluenceMeta {
+  version: {
+    /** Last-modified timestamp of *this* revision, ISO 8601. */
+    when: string;
+    /** Page revision number (1-indexed). */
+    number: number;
+  };
+  history?: {
+    /** Page creation timestamp, ISO 8601. */
+    createdDate: string;
+    /** Original author. `displayName` may be absent on Cloud if the /users lookup failed. */
+    createdBy?: { displayName: string };
+  };
+}
+
 /** Metadata sidecar shape (matches RawDocument from wiki.ts). */
 interface RawMeta {
   path: string;
@@ -71,6 +93,12 @@ interface RawMeta {
   mimeType?: string;
   description?: string;
   tags?: string[];
+  /**
+   * Confluence-only provenance. Present on page sidecars when
+   * `raw_ingest --mode import_confluence` carried version / history through;
+   * absent on attachment sidecars and on legacy sidecars from pre-#27 imports.
+   */
+  confluence?: ConfluenceMeta;
 }
 
 // ── Helpers ───────────────────────────────────────────────────
@@ -167,6 +195,14 @@ interface NormalizedConfluencePage {
   id: string;
   title: string;
   html: string;
+  /**
+   * Version / history block carried into the sidecar (#27). Optional because
+   * (a) older Server responses without expand= omit the data, and (b) Cloud
+   * v2's basic page response doesn't include `history.createdBy` — the Cloud
+   * client does a follow-up /users lookup for displayName but can fall back
+   * to omitting it on auth scope or transient failure.
+   */
+  meta?: ConfluenceMeta;
 }
 interface NormalizedConfluenceAttachment {
   title: string;
@@ -183,6 +219,69 @@ interface ConfluenceClient {
   getPage(pid: string): Promise<NormalizedConfluencePage>;
   getAttachments(pid: string): Promise<NormalizedConfluenceAttachment[]>;
   getChildren(pid: string): Promise<NormalizedConfluenceChild[]>;
+}
+
+/**
+ * Project a Confluence Cloud v2 `/pages/{id}` response into the shared
+ * `ConfluenceMeta` shape. Cloud v2 returns `version.createdAt` (timestamp of
+ * the current revision) and `data.createdAt` (page creation time, the v1
+ * equivalent of `history.createdDate`), but `history.createdBy.displayName`
+ * has to be resolved through a follow-up /users call by the caller.
+ *
+ * Returns `undefined` when neither `version` nor a `createdAt` block is
+ * present so the caller can omit the field entirely instead of emitting a
+ * half-empty object.
+ */
+async function projectCloudMeta(
+  data: any,
+  resolveDisplayName: (accountId?: string) => Promise<string | undefined>,
+): Promise<ConfluenceMeta | undefined> {
+  const versionWhen = data?.version?.createdAt;
+  const versionNumber = data?.version?.number;
+  if (typeof versionWhen !== "string" || typeof versionNumber !== "number") {
+    // version is non-optional in ConfluenceMeta — without both fields we
+    // can't construct a valid block, so skip the whole sidecar addition.
+    return undefined;
+  }
+  const meta: ConfluenceMeta = {
+    version: { when: versionWhen, number: versionNumber },
+  };
+  const createdDate = data?.createdAt;
+  if (typeof createdDate === "string") {
+    const displayName = await resolveDisplayName(data?.authorId);
+    meta.history = {
+      createdDate,
+      ...(displayName ? { createdBy: { displayName } } : {}),
+    };
+  }
+  return meta;
+}
+
+/**
+ * Project a Confluence Server / Data Center v1 `/content/{id}?expand=...`
+ * response. v1 carries the full history block inline (including
+ * `history.createdBy.displayName`), so no follow-up call is needed.
+ */
+function projectServerMeta(data: any): ConfluenceMeta | undefined {
+  const versionWhen = data?.version?.when;
+  const versionNumber = data?.version?.number;
+  if (typeof versionWhen !== "string" || typeof versionNumber !== "number") {
+    return undefined;
+  }
+  const meta: ConfluenceMeta = {
+    version: { when: versionWhen, number: versionNumber },
+  };
+  const createdDate = data?.history?.createdDate;
+  if (typeof createdDate === "string") {
+    const displayName = data?.history?.createdBy?.displayName;
+    meta.history = {
+      createdDate,
+      ...(typeof displayName === "string" && displayName.length > 0
+        ? { createdBy: { displayName } }
+        : {}),
+    };
+  }
+  return meta;
 }
 
 function buildConfluenceClient(
@@ -213,13 +312,38 @@ function buildConfluenceClient(
   }
 
   if (deployment === "cloud") {
+    // Per-import cache of accountId → displayName. Confluence Cloud v2's basic
+    // page response carries `authorId` but not `displayName`, so we resolve it
+    // via /users/{accountId}. A recursive import of 100 pages by the same
+    // handful of authors collapses to a few lookups instead of 100.
+    // Misses (network failure, permission scope) cache as `null` to avoid
+    // re-firing the call repeatedly.
+    const userCache = new Map<string, string | null>();
+    async function resolveDisplayName(accountId?: string): Promise<string | undefined> {
+      if (!accountId) return undefined;
+      const cached = userCache.get(accountId);
+      if (cached !== undefined) return cached ?? undefined;
+      try {
+        const u = await api(`/users/${accountId}`);
+        const name = typeof u?.displayName === "string" ? u.displayName : null;
+        userCache.set(accountId, name);
+        return name ?? undefined;
+      } catch {
+        // Don't block the import on a user lookup; just omit displayName.
+        userCache.set(accountId, null);
+        return undefined;
+      }
+    }
+
     return {
       async getPage(pid) {
         const data = await api(`/pages/${pid}?body-format=storage`);
+        const meta = await projectCloudMeta(data, resolveDisplayName);
         return {
           id: data.id,
           title: data.title,
           html: data.body?.storage?.value ?? "",
+          ...(meta ? { meta } : {}),
         };
       },
       async getAttachments(pid) {
@@ -266,11 +390,18 @@ function buildConfluenceClient(
   // body returned via ?expand=body.storage.
   return {
     async getPage(pid) {
-      const data = await api(`/content/${pid}?expand=body.storage`);
+      // Expand version + history + history.createdBy inline (#27). v1 returns
+      // displayName directly under history.createdBy.displayName so we don't
+      // need the follow-up /users call the Cloud client does.
+      const data = await api(
+        `/content/${pid}?expand=body.storage,version,history,history.createdBy`,
+      );
+      const meta = projectServerMeta(data);
       return {
         id: String(data.id),
         title: data.title ?? "",
         html: data.body?.storage?.value ?? "",
+        ...(meta ? { meta } : {}),
       };
     },
     async getAttachments(pid) {
@@ -400,6 +531,7 @@ export async function confluenceImport(
         mimeType: "text/html",
         description: `Confluence: ${page.title}`,
         tags: ["confluence", space],
+        ...(page.meta ? { confluence: page.meta } : {}),
       });
       files.push(relPath);
     }


### PR DESCRIPTION
## Summary

Closes #27. Persists Confluence `version.{when, number}` and `history.{createdDate, createdBy.displayName}` into `.meta.yaml` sidecars so downstream tools can answer "who last changed this, when, and which revision is this?" without re-querying Confluence.

## Change

- New `ConfluenceMeta` type; optional `confluence` block on `RawMeta`. `writeMeta` serializes it when present.
- `projectCloudMeta` / `projectServerMeta` helpers project each platform's response shape into the shared metadata.
- Cloud (v2): `/pages/{id}` carries `version.{createdAt, number}` and top-level `createdAt` / `authorId`, but **not** `displayName`. The Cloud client resolves `displayName` via `/users/{accountId}` with a **per-import cache** so a recursive crawl with N pages by the same author triggers one /users call, not N. Lookup misses (404, permission, transient failure) cache as null to avoid retry storms; the page import still completes without displayName.
- Server / DC: `/content/{id}?expand=body.storage,version,history,history.createdBy` returns everything inline — no follow-up call needed.
- Backwards-compat: when the API response lacks `version` (legacy Server response, pre-expand caller, etc.), the sidecar simply omits the `confluence` key so existing lint / integrity checks keep passing.

## Tests

5 new integration tests in `src/atlassian.test.ts` with mocked `fetch`:

1. Cloud — version + history with displayName resolved via /users.
2. Cloud — /users 404 → displayName omitted, page still imports with version + createdDate.
3. Cloud — /users cache: recursive import of two pages by the same author triggers exactly one /users call.
4. Server — version + history inline, no /users follow-up.
5. Backwards-compat — API response without `version` → sidecar omits `confluence` block, core fields intact.

## Out of scope

- Backfill — confluenceImport is idempotent on `existsSync(absPath)`, so re-importing won't rewrite existing sidecars. Users wanting the new fields on already-imported pages need to delete the raw + sidecar and re-import.

## Test plan

- [x] `npx vitest run src/atlassian.test.ts` — 5/5 pass
- [x] `npx vitest run` — 3677/3677 pass
- [x] `npx tsc --noEmit` — clean
