### PR TITLE
feat(cobol): semantic-inferred field-lineage tier (#35)

### DIFF
--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -843,8 +843,8 @@ describe("COBOL field lineage", () => {
       const lineage = buildFieldLineage([
         model(customerNested, "CUSTOMER-REC.cpy"),
         model(clientNested, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       expect(lineage).not.toBeNull();
       expect(lineage!.inferredSemantic).toHaveLength(1);
@@ -876,8 +876,8 @@ describe("COBOL field lineage", () => {
       const lineage = buildFieldLineage([
         model(customerThin, "CUSTOMER-REC.cpy"),
         model(clientThin, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       // STREET name-matches and emits as high-confidence inferred, so the
       // lineage is non-null; the *semantic* tier specifically must be empty.
@@ -904,8 +904,8 @@ describe("COBOL field lineage", () => {
       const lineage = buildFieldLineage([
         model(customerNoUsage, "CUSTOMER-REC.cpy"),
         model(clientNoUsage, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       expect(lineage).not.toBeNull();
       expect(lineage!.inferredSemantic).toHaveLength(0);
@@ -928,8 +928,8 @@ describe("COBOL field lineage", () => {
       const lineage = buildFieldLineage([
         model(customerTopLevel, "CUSTOMER-REC.cpy"),
         model(clientTopLevel, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       expect(lineage).not.toBeNull();
       expect(lineage!.inferredSemantic).toHaveLength(0);
@@ -950,9 +950,9 @@ describe("COBOL field lineage", () => {
         model(customerNested, "CUSTOMER-REC.cpy"),
         model(clientNested, "CLIENT-REC.cpy"),
         model(partyRec, "PARTY-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
-        model(program("PROG_C", "PARTY-REC"), "PROG_C.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
+        model(program("PROGC", "PARTY-REC"), "PROGC.cbl"),
       ]);
       expect(lineage).not.toBeNull();
       expect(lineage!.inferredSemantic).toHaveLength(0);
@@ -987,8 +987,8 @@ describe("COBOL field lineage", () => {
       const withRename = buildFieldLineage([
         model(customerNested, "CUSTOMER-REC.cpy"),
         model(clientNested, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       const page = generateFieldLineagePage(withRename!);
       expect(page.content).toContain("### Semantic-Inferred");
@@ -1012,8 +1012,8 @@ describe("COBOL field lineage", () => {
       const withRename = buildFieldLineage([
         model(customerNested, "CUSTOMER-REC.cpy"),
         model(clientNested, "CLIENT-REC.cpy"),
-        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
-        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CLIENT-REC"), "PROGB.cbl"),
       ]);
       const renamePage = generateFieldLineagePage(withRename!);
       const renameCoverage = renamePage.content.slice(

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -820,6 +820,228 @@ describe("COBOL field lineage", () => {
     });
   });
 
+  describe("Semantic-Inferred tier (#35)", () => {
+    // Renamed scalar at depth 3 with matching parent path + 2 shared siblings.
+    // The depth is important: at depth ≤ 2, parentContextMatch collapses to
+    // "top-level" and gate 3 rejects the pair.
+    const customerNested = `
+       01  CUSTOMER-REC.
+           05  ADDRESS.
+               10  CUSTOMER-ID  PIC X(10) USAGE DISPLAY.
+               10  STREET       PIC X(30) USAGE DISPLAY.
+               10  ZIP          PIC X(5)  USAGE DISPLAY.
+`;
+    const clientNested = `
+       01  CLIENT-REC.
+           05  ADDRESS.
+               10  CUST-ID      PIC X(10) USAGE DISPLAY.
+               10  STREET       PIC X(30) USAGE DISPLAY.
+               10  ZIP          PIC X(5)  USAGE DISPLAY.
+`;
+
+    it("emits a semantic entry for a renamed scalar under matching parent + ≥2 siblings", () => {
+      const lineage = buildFieldLineage([
+        model(customerNested, "CUSTOMER-REC.cpy"),
+        model(clientNested, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toHaveLength(1);
+      const entry = lineage!.inferredSemantic[0]!;
+      expect(entry.confidence).toBe("semantic");
+      const leftLeaf = entry.left.qualifiedName.split(".").pop();
+      const rightLeaf = entry.right.qualifiedName.split(".").pop();
+      expect([leftLeaf, rightLeaf].sort()).toEqual(["CUST-ID", "CUSTOMER-ID"]);
+      expect(entry.evidence.qualifiedNameMatch).toBe("renamed");
+      expect(entry.evidence.parentContextMatch).toBe("exact");
+      expect(entry.evidence.siblingOverlap.length).toBeGreaterThanOrEqual(2);
+      expect(entry.rationale).toContain("Renamed field");
+      expect(lineage!.summary.inferred.semantic).toBe(1);
+    });
+
+    it("Gate 4: drops the pair when shared siblings < 2", () => {
+      const customerThin = `
+       01  CUSTOMER-REC.
+           05  ADDRESS.
+               10  CUSTOMER-ID  PIC X(10) USAGE DISPLAY.
+               10  STREET       PIC X(30) USAGE DISPLAY.
+`;
+      const clientThin = `
+       01  CLIENT-REC.
+           05  ADDRESS.
+               10  CUST-ID      PIC X(10) USAGE DISPLAY.
+               10  STREET       PIC X(30) USAGE DISPLAY.
+`;
+      const lineage = buildFieldLineage([
+        model(customerThin, "CUSTOMER-REC.cpy"),
+        model(clientThin, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      // STREET name-matches and emits as high-confidence inferred, so the
+      // lineage is non-null; the *semantic* tier specifically must be empty.
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toHaveLength(0);
+      expect(lineage!.summary.inferred.semantic).toBe(0);
+    });
+
+    it("Gate 2: drops the pair when USAGE is missing on either side", () => {
+      const customerNoUsage = `
+       01  CUSTOMER-REC.
+           05  ADDRESS.
+               10  CUSTOMER-ID  PIC X(10).
+               10  STREET       PIC X(30).
+               10  ZIP          PIC X(5).
+`;
+      const clientNoUsage = `
+       01  CLIENT-REC.
+           05  ADDRESS.
+               10  CUST-ID      PIC X(10).
+               10  STREET       PIC X(30).
+               10  ZIP          PIC X(5).
+`;
+      const lineage = buildFieldLineage([
+        model(customerNoUsage, "CUSTOMER-REC.cpy"),
+        model(clientNoUsage, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toHaveLength(0);
+    });
+
+    it("Gate 3: drops the pair when parent context collapses to top-level", () => {
+      // Depth 2 fields → parent suffix is empty on both sides → "top-level".
+      const customerTopLevel = `
+       01  CUSTOMER-REC.
+           05  CUSTOMER-ID  PIC X(10) USAGE DISPLAY.
+           05  STREET       PIC X(30) USAGE DISPLAY.
+           05  ZIP          PIC X(5)  USAGE DISPLAY.
+`;
+      const clientTopLevel = `
+       01  CLIENT-REC.
+           05  CUST-ID      PIC X(10) USAGE DISPLAY.
+           05  STREET       PIC X(30) USAGE DISPLAY.
+           05  ZIP          PIC X(5)  USAGE DISPLAY.
+`;
+      const lineage = buildFieldLineage([
+        model(customerTopLevel, "CUSTOMER-REC.cpy"),
+        model(clientTopLevel, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toHaveLength(0);
+    });
+
+    it("Gate 5: drops the pair when a competing semantic match exists", () => {
+      // Three rec types with three differently-named ID fields. Each ID has
+      // two semantic candidates → every pair has competingMatches > 0 → all
+      // drop. The semantic tier never emits an ambiguous companion.
+      const partyRec = `
+       01  PARTY-REC.
+           05  ADDRESS.
+               10  CLIENT-ID    PIC X(10) USAGE DISPLAY.
+               10  STREET       PIC X(30) USAGE DISPLAY.
+               10  ZIP          PIC X(5)  USAGE DISPLAY.
+`;
+      const lineage = buildFieldLineage([
+        model(customerNested, "CUSTOMER-REC.cpy"),
+        model(clientNested, "CLIENT-REC.cpy"),
+        model(partyRec, "PARTY-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+        model(program("PROG_C", "PARTY-REC"), "PROG_C.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toHaveLength(0);
+    });
+
+    it("regression lock: rename-free corpus produces byte-identical name-keyed output", () => {
+      // Snapshot inferredHighConfidence / inferredAmbiguous / summary.inferred
+      // for a fixture that doesn't carry any rename pair. The new tier must
+      // be purely additive — these arrays should not shift.
+      const lineage = buildFieldLineage([
+        model(customerA, "CUSTOMER-A.cpy"),
+        model(customerB, "CUSTOMER-B.cpy"),
+        model(program("BILLINGA", "CUSTOMER-A"), "BILLINGA.cbl"),
+        model(program("BILLINGB", "CUSTOMER-B"), "BILLINGB.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      expect(lineage!.inferredSemantic).toEqual([]);
+      expect(lineage!.summary.inferred.semantic).toBe(0);
+      // Spot-check name-matched output hasn't shifted: CUSTOMER-ID is the
+      // canonical inferred-high case for this fixture and must still emit.
+      expect(lineage!.inferredHighConfidence.some((e) => e.fieldName === "CUSTOMER-ID")).toBe(true);
+    });
+
+    it("renderer: shows the ### Semantic-Inferred subsection only when entries exist", () => {
+      const empty = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      expect(generateFieldLineagePage(empty!).content).not.toContain("### Semantic-Inferred");
+
+      const withRename = buildFieldLineage([
+        model(customerNested, "CUSTOMER-REC.cpy"),
+        model(clientNested, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      const page = generateFieldLineagePage(withRename!);
+      expect(page.content).toContain("### Semantic-Inferred");
+      expect(page.content).toContain("CUSTOMER-ID");
+      expect(page.content).toContain("CUST-ID");
+    });
+
+    it("renderer: Coverage Yielding cell adds the semantic suffix only when count > 0", () => {
+      const empty = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl"),
+        model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl"),
+      ]);
+      const emptyPage = generateFieldLineagePage(empty!);
+      const emptyCoverage = emptyPage.content.slice(
+        emptyPage.content.indexOf("## Coverage"),
+        emptyPage.content.indexOf("## Overview"),
+      );
+      expect(emptyCoverage).not.toContain("semantic");
+
+      const withRename = buildFieldLineage([
+        model(customerNested, "CUSTOMER-REC.cpy"),
+        model(clientNested, "CLIENT-REC.cpy"),
+        model(program("PROG_A", "CUSTOMER-REC"), "PROG_A.cbl"),
+        model(program("PROG_B", "CLIENT-REC"), "PROG_B.cbl"),
+      ]);
+      const renamePage = generateFieldLineagePage(withRename!);
+      const renameCoverage = renamePage.content.slice(
+        renamePage.content.indexOf("## Coverage"),
+        renamePage.content.indexOf("## Overview"),
+      );
+      expect(renameCoverage).toMatch(/\d+ deterministic, \d+ inferred, 1 semantic/);
+    });
+
+    it("normalizeLoadedFieldLineage backfills inferredSemantic + summary.inferred.semantic for pre-#35 JSON", () => {
+      const pre35 = {
+        summary: {
+          deterministic: { copybooks: 1, programs: 2, fields: 3 },
+          inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0 },
+          diagnosticsByKind: { "parsed-zero-data-items": 0 },
+        },
+        copybookUsage: [],
+        deterministic: [],
+        inferredHighConfidence: [],
+        inferredAmbiguous: [],
+        diagnostics: [],
+      } as unknown as SerializedFieldLineage;
+      const normalized = normalizeLoadedFieldLineage(pre35);
+      expect(normalized.inferredSemantic).toEqual([]);
+      expect(normalized.summary.inferred.semantic).toBe(0);
+    });
+  });
+
   it("generates a lineage wiki summary page", () => {
     const lineage = buildFieldLineage([
       model(sharedCopybook, "CUSTOMER-REC.cpy"),

--- a/src/cobol/evidence-mapping.ts
+++ b/src/cobol/evidence-mapping.ts
@@ -30,7 +30,12 @@ export type CobolLineageTier =
   | "high"
   | "ambiguous"
   | "inferredHighConfidence"
-  | "inferredAmbiguous";
+  | "inferredAmbiguous"
+  // #35 — shape-keyed match across renamed fields. Confidence collapses to
+  // `weak` like `high`, but the domain-level tier label is what distinguishes
+  // the two: a `semantic` entry has no name-alignment evidence at all, so
+  // human reviewers should treat it as the lowest-trust inferred surface.
+  | "semantic";
 
 export function cobolTierToEvidence(
   tier: CobolLineageTier,
@@ -40,6 +45,7 @@ export function cobolTierToEvidence(
       return { confidence: "strong", basis: "deterministic" };
     case "high":
     case "inferredHighConfidence":
+    case "semantic":
       return { confidence: "weak", basis: "inferred" };
     case "ambiguous":
     case "inferredAmbiguous":

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -5,7 +5,18 @@ import type { CallBoundLineage, SerializedCallBoundLineageEntry } from "./call-b
 import type { Db2Lineage, HostVarRef } from "./db2-table-lineage.js";
 
 export type LineageLinkage = "deterministic";
-export type InferredLineageConfidence = "high" | "ambiguous";
+/**
+ * Confidence tier for cross-copybook inferred lineage.
+ *
+ *   - `high` / `ambiguous`: emitted by the name-keyed matcher. Pairs share
+ *     a field name (after stripping a short prefix) plus PIC, USAGE, level,
+ *     and parent context.
+ *   - `semantic` (#35): emitted by the shape-keyed matcher with no name
+ *     alignment at all. Pairs share `(PIC, USAGE, level)` plus an exact
+ *     parent path plus ≥2 sibling overlap. Always the weakest inferred
+ *     surface — review one-by-one before trusting.
+ */
+export type InferredLineageConfidence = "high" | "ambiguous" | "semantic";
 
 /**
  * Reasons a parsed COBOL model was flagged at lineage-build time. Distinct from
@@ -48,7 +59,12 @@ export interface SerializedInferredFieldEvidence {
   pictureMatch: boolean;
   usageEvidence: "explicit-match" | "both-missing";
   levelMatch: boolean;
-  qualifiedNameMatch: "exact";
+  /**
+   * `"exact"` for name-keyed matcher entries (high / ambiguous), `"renamed"`
+   * for the shape-keyed semantic tier where the two fields have different
+   * names but identical shape + context (#35).
+   */
+  qualifiedNameMatch: "exact" | "renamed";
   parentContextMatch: "exact" | "suffix" | "top-level";
   siblingOverlap: string[];
   competingMatches: number;
@@ -75,6 +91,13 @@ export interface SerializedFieldLineage {
       programs: number;
       highConfidence: number;
       ambiguous: number;
+      /**
+       * #35 — count of shape-keyed semantic pairs. Reported separately from
+       * `copybooks` / `programs` (which still tally name-keyed entries only)
+       * so the per-tier breakdown is byte-stable on corpora that don't carry
+       * rename pairs.
+       */
+      semantic: number;
     };
     diagnosticsByKind: Record<FieldLineageDiagnosticKind, number>;
   };
@@ -87,6 +110,13 @@ export interface SerializedFieldLineage {
   deterministic: SerializedFieldLineageEntry[];
   inferredHighConfidence: SerializedInferredFieldLineageEntry[];
   inferredAmbiguous: SerializedInferredFieldLineageEntry[];
+  /**
+   * #35 — semantic-inferred entries (shape-keyed, renamed fields). Empty
+   * array when no pairs survive the five gates. Always present on freshly
+   * built artifacts; backfilled by `normalizeLoadedFieldLineage` for
+   * pre-#35 JSON loaded from disk.
+   */
+  inferredSemantic: SerializedInferredFieldLineageEntry[];
   diagnostics: FieldLineageDiagnostic[];
   callBoundLineage?: CallBoundLineage | null;
   db2Lineage?: Db2Lineage | null;
@@ -121,9 +151,15 @@ export function normalizeLoadedFieldLineage(raw: SerializedFieldLineage): Serial
     ...raw,
     summary: {
       ...summary,
+      inferred: {
+        ...summary.inferred,
+        // #35 — pre-#35 artifacts predate the semantic tier; backfill to 0.
+        semantic: summary.inferred?.semantic ?? 0,
+      },
       diagnosticsByKind: summary.diagnosticsByKind ?? emptyDiagnosticsByKind(),
     },
     diagnostics: raw.diagnostics ?? [],
+    inferredSemantic: raw.inferredSemantic ?? [],
   };
 }
 
@@ -131,13 +167,14 @@ function emptyCopybookLineage(): SerializedFieldLineage {
   return {
     summary: {
       deterministic: { copybooks: 0, programs: 0, fields: 0 },
-      inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0 },
+      inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0, semantic: 0 },
       diagnosticsByKind: emptyDiagnosticsByKind(),
     },
     copybookUsage: [],
     deterministic: [],
     inferredHighConfidence: [],
     inferredAmbiguous: [],
+    inferredSemantic: [],
     diagnostics: [],
   };
 }
@@ -355,8 +392,18 @@ function buildInferredEntry(
     competingMatches,
   };
 
+  // For semantic entries the two fields have intentionally different names —
+  // start the rationale with the rename pair so a human reviewer sees the gap
+  // up front, instead of the misleading "Same field name" prefix that's
+  // accurate for the name-keyed tiers. Participant carries the qualified
+  // path; the leaf segment is the field name.
+  const leftLeaf = ordered.left.qualifiedName.split(".").pop() ?? "";
+  const rightLeaf = ordered.right.qualifiedName.split(".").pop() ?? "";
+  const namePart = confidence === "semantic"
+    ? `Renamed field (${leftLeaf} ↔ ${rightLeaf})`
+    : "Same field name";
   const rationaleParts = [
-    "Same field name",
+    namePart,
     evidence.pictureMatch ? "matching PIC" : undefined,
     evidence.usageEvidence === "explicit-match" ? "matching USAGE" : undefined,
     evidence.levelMatch ? `same level ${ordered.left.level}` : undefined,
@@ -671,12 +718,116 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
       || a.right.qualifiedName.localeCompare(b.right.qualifiedName)
     );
 
+  // #35 — second pass: shape-keyed matcher for renamed-field detection.
+  // Groups candidates by `(PIC, USAGE, level)` instead of field name and
+  // emits a pair only when *all five* gates hold:
+  //   1. picture match — implicit in the shape-key grouping
+  //   2. usage explicit on both sides — `both-missing` doesn't qualify;
+  //      losing the name signal AND missing USAGE leaves too little
+  //   3. parent context exact — top-level / suffix don't qualify
+  //   4. ≥ 2 shared siblings — one is too weak without name alignment
+  //   5. zero competing matches inside the semantic pool — no
+  //      `semantic-ambiguous` companion tier in this iteration
+  //
+  // Pairs whose field names match would already have been emitted by the
+  // name-keyed pass; drop them here to avoid double-reporting.
+  const semanticCandidateFields = rawCopybookUsage.flatMap((usage) =>
+    (flattenedByCopybook.get(usage.copybookId) ?? [])
+      .filter((field) => usage.exactPrograms.length > 0)
+      .filter((field) => Boolean(field.picture) && Boolean(field.usage))
+      .map((field) => ({ field, programs: usage.exactPrograms })),
+  );
+  const shapeGroups = new Map<string, Array<{ field: FlattenedField; programs: FieldConsumer[] }>>();
+  for (const candidate of semanticCandidateFields) {
+    const shapeKey = `${normalizePicture(candidate.field.picture)}|${normalizeUsage(candidate.field.usage)}|${candidate.field.level}`;
+    const list = shapeGroups.get(shapeKey) ?? [];
+    list.push(candidate);
+    shapeGroups.set(shapeKey, list);
+  }
+
+  const semanticCandidatesRaw: InferredCandidate[] = [];
+  for (const [, fields] of shapeGroups.entries()) {
+    for (let i = 0; i < fields.length; i++) {
+      for (let j = i + 1; j < fields.length; j++) {
+        const left = fields[i]!;
+        const right = fields[j]!;
+        if (left.field.copybookId === right.field.copybookId) continue;
+        if (compareField(left.field, right.field) > 0) continue;
+        // Name-matched pairs belong to the high / ambiguous tier — exclude
+        // them here so they don't double up.
+        if (left.field.fieldName.toUpperCase() === right.field.fieldName.toUpperCase()) continue;
+
+        const parentContextMatch = determineParentContextMatch(left.field, right.field);
+        if (parentContextMatch !== "exact") continue; // Gate 3
+
+        const siblingOverlap = sortUnique(
+          left.field.siblings.filter((sibling) => right.field.siblings.includes(sibling)),
+        );
+        if (siblingOverlap.length < 2) continue; // Gate 4
+
+        // Gates 1, 2, and level match are guaranteed by the shape-key grouping.
+        semanticCandidatesRaw.push({
+          fieldName: left.field.fieldName, // display value; left/right names actually differ
+          left: left.field,
+          right: right.field,
+          leftPrograms: left.programs,
+          rightPrograms: right.programs,
+          evidence: {
+            pictureMatch: true,
+            usageEvidence: "explicit-match",
+            levelMatch: true,
+            qualifiedNameMatch: "renamed",
+            parentContextMatch,
+            siblingOverlap,
+          },
+        });
+      }
+    }
+  }
+
+  // Competing-match count is local to the semantic pool — a field that's
+  // also in a name-keyed pair doesn't count as "competing" with its
+  // semantic peers, and vice-versa.
+  const semanticCounts = new Map<string, number>();
+  for (const candidate of semanticCandidatesRaw) {
+    semanticCounts.set(
+      inferredCandidateKey(candidate.left),
+      (semanticCounts.get(inferredCandidateKey(candidate.left)) ?? 0) + 1,
+    );
+    semanticCounts.set(
+      inferredCandidateKey(candidate.right),
+      (semanticCounts.get(inferredCandidateKey(candidate.right)) ?? 0) + 1,
+    );
+  }
+
+  const inferredSemantic = semanticCandidatesRaw
+    .map((candidate) => {
+      const competingMatches = Math.max(
+        (semanticCounts.get(inferredCandidateKey(candidate.left)) ?? 1) - 1,
+        (semanticCounts.get(inferredCandidateKey(candidate.right)) ?? 1) - 1,
+      );
+      return { candidate, competingMatches };
+    })
+    .filter(({ competingMatches }) => competingMatches === 0) // Gate 5
+    .map(({ candidate, competingMatches }) => buildInferredEntry(candidate, "semantic", competingMatches))
+    .sort((a, b) =>
+      compareCopybook(a.left.copybook, b.left.copybook)
+      || a.left.qualifiedName.localeCompare(b.left.qualifiedName)
+      || compareCopybook(a.right.copybook, b.right.copybook)
+      || a.right.qualifiedName.localeCompare(b.right.qualifiedName)
+    );
+
   const sortedDeterministic = deterministic.sort((a, b) =>
     a.copybooks[0]!.id.localeCompare(b.copybooks[0]!.id) ||
     a.qualifiedNames[0]!.localeCompare(b.qualifiedNames[0]!)
   );
 
-  if (sortedDeterministic.length === 0 && inferredHighConfidence.length === 0 && inferredAmbiguous.length === 0) {
+  if (
+    sortedDeterministic.length === 0
+    && inferredHighConfidence.length === 0
+    && inferredAmbiguous.length === 0
+    && inferredSemantic.length === 0
+  ) {
     return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
   }
 
@@ -724,10 +875,15 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
         fields: sortedDeterministic.length,
       },
       inferred: {
+        // `copybooks` / `programs` deliberately count name-keyed entries only
+        // (high + ambiguous). Excluding semantic keeps this counter byte-
+        // stable on corpora without rename pairs — the regression-lock
+        // contract from #35.
         copybooks: inferredCopybookIds.size,
         programs: inferredProgramIds.size,
         highConfidence: inferredHighConfidence.length,
         ambiguous: inferredAmbiguous.length,
+        semantic: inferredSemantic.length,
       },
       diagnosticsByKind: countDiagnosticsByKind(diagnostics),
     },
@@ -735,6 +891,7 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
     deterministic: sortedDeterministic,
     inferredHighConfidence,
     inferredAmbiguous,
+    inferredSemantic,
     diagnostics,
   };
 }
@@ -753,6 +910,12 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
       ...entry.right.programs.map((program) => `"raw/${program.sourceFile}"`),
     ]),
     ...lineage.inferredAmbiguous.flatMap((entry) => [
+      `"raw/${entry.left.copybook.sourceFile}"`,
+      `"raw/${entry.right.copybook.sourceFile}"`,
+      ...entry.left.programs.map((program) => `"raw/${program.sourceFile}"`),
+      ...entry.right.programs.map((program) => `"raw/${program.sourceFile}"`),
+    ]),
+    ...(lineage.inferredSemantic ?? []).flatMap((entry) => [
       `"raw/${entry.left.copybook.sourceFile}"`,
       `"raw/${entry.right.copybook.sourceFile}"`,
       ...entry.left.programs.map((program) => `"raw/${program.sourceFile}"`),
@@ -778,10 +941,12 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
 
   renderCoverageSection(lines, lineage, callBound, db2);
 
+  const semanticCount = lineage.summary.inferred?.semantic ?? 0;
   const overviewHasCopybook = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0
     || lineage.inferredHighConfidence.length > 0
-    || lineage.inferredAmbiguous.length > 0;
+    || lineage.inferredAmbiguous.length > 0
+    || semanticCount > 0;
   lines.push("## Overview");
   lines.push("");
   lines.push("| Metric | Count |");
@@ -794,6 +959,11 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
     lines.push(`| Inferred programs | ${lineage.summary.inferred.programs} |`);
     lines.push(`| Inferred high-confidence candidates | ${lineage.summary.inferred.highConfidence} |`);
     lines.push(`| Inferred ambiguous candidates | ${lineage.summary.inferred.ambiguous} |`);
+    // Only surface the semantic row when there's content — keeps Overview
+    // byte-identical for rename-free corpora (#35 regression-lock contract).
+    if (semanticCount > 0) {
+      lines.push(`| Semantic-inferred candidates | ${semanticCount} |`);
+    }
   }
   if (callBound) {
     lines.push(`| Call sites with USING args | ${callBound.summary.callSites} |`);
@@ -835,7 +1005,8 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
   const hasCopybookContent = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0
     || lineage.inferredHighConfidence.length > 0
-    || lineage.inferredAmbiguous.length > 0;
+    || lineage.inferredAmbiguous.length > 0
+    || (lineage.inferredSemantic ?? []).length > 0;
 
   if (hasCopybookContent) {
     lines.push("## Copybook Usage");
@@ -907,6 +1078,34 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
       }
     }
     lines.push("");
+
+    // Semantic-inferred (#35) — only render when present. Keeping the
+    // subsection conditional preserves byte-identical output on rename-free
+    // corpora (regression lock from the issue).
+    const semanticEntries = lineage.inferredSemantic ?? [];
+    if (semanticEntries.length > 0) {
+      lines.push("### Semantic-Inferred");
+      lines.push("");
+      lines.push("Pairs matched on shape `(PIC, USAGE, level)` plus exact parent path plus ≥2 sibling overlap. **No name alignment** — the two fields have different names. Lower trust than high-confidence; review one-by-one before relying on these.");
+      lines.push("");
+      lines.push("| Left field | Right field | Left | Right | Programs | Evidence |");
+      lines.push("|------------|-------------|------|-------|----------|----------|");
+      for (const entry of semanticEntries) {
+        const leftLeaf = entry.left.qualifiedName.split(".").pop() ?? entry.fieldName;
+        const rightLeaf = entry.right.qualifiedName.split(".").pop() ?? entry.fieldName;
+        const evidence = [
+          `PIC ${entry.left.picture ?? "—"}`,
+          `USAGE ${entry.left.usage ?? "—"}`,
+          entry.evidence.siblingOverlap.length > 0
+            ? `siblings: ${entry.evidence.siblingOverlap.join(", ")}`
+            : undefined,
+        ].filter((v): v is string => Boolean(v)).join("; ");
+        lines.push(
+          `| ${leftLeaf} | ${rightLeaf} | ${displayLabel(entry.left.copybook.id)}<br>${formatInferredStructure(entry.left)} | ${displayLabel(entry.right.copybook.id)}<br>${formatInferredStructure(entry.right)} | ${formatInferredPrograms(entry.left, entry.right)} | ${evidence} |`,
+        );
+      }
+      lines.push("");
+    }
   }
 
   if (callBound && (callBound.entries.length > 0 || callBound.diagnostics.length > 0)) {
@@ -1133,10 +1332,12 @@ function renderCoverageSection(
   // defensible even if the field is absent.
   const copybookDiagByKind: Record<string, number> = lineage.summary.diagnosticsByKind ?? {};
   const zeroDataItemsCount = copybookDiagByKind["parsed-zero-data-items"] ?? 0;
+  const semanticCount = lineage.summary.inferred?.semantic ?? 0;
   const copybookHasContent = lineage.copybookUsage.length > 0
     || lineage.deterministic.length > 0
     || lineage.inferredHighConfidence.length > 0
     || lineage.inferredAmbiguous.length > 0
+    || semanticCount > 0
     || zeroDataItemsCount > 0;
 
   const rows: string[] = [];
@@ -1146,7 +1347,12 @@ function renderCoverageSection(
     // copybooks aren't currently tracked as diagnostics so they don't
     // appear; once added, sum their counter in here.
     const indexed = lineage.copybookUsage.length + zeroDataItemsCount;
-    const yielding = `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred`;
+    // Yielding splits inferred into the name-keyed and shape-keyed halves
+    // (#35). The semantic suffix is conditional so the cell stays byte-
+    // identical on rename-free corpora — regression lock contract.
+    const yielding = semanticCount > 0
+      ? `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred, ${semanticCount} semantic`
+      : `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred`;
     rows.push(
       `| Copybook | ${indexed} | ${yielding} | ${topExclusionReasons(copybookDiagByKind)} |`,
     );


### PR DESCRIPTION
## Summary

Closes #35. Adds a third inferred field-lineage tier — `semantic` — that matches **renamed fields** across copybooks by shape rather than name. Tackles the gap where `CUSTOMER-ID` / `CUST-ID` / `CLIENT-ID` are semantically the same but the current name-keyed matcher refuses to pair them.

## Five gates (every pair must pass)

1. **Picture match** — implicit in the `(PIC, USAGE, level)` shape-key grouping.
2. **USAGE explicit on both sides** — `both-missing` from the name-keyed tier doesn't qualify here; losing the name signal AND missing USAGE leaves too little.
3. **Parent context exact** — top-level / suffix don't qualify. The pair must live under structurally identical parent paths (after stripping the root record name).
4. **≥ 2 sibling overlap** — one shared sibling is too weak without name alignment.
5. **Zero competing matches** — no `semantic-ambiguous` companion tier in this iteration. If field X has more than one shape-matched peer in another copybook, all of X's pairs drop silently.

Pairs whose field names already match are excluded from this pass (those belong in the existing high/ambiguous tier).

## Output

- `SerializedFieldLineage.inferredSemantic: SerializedInferredFieldLineageEntry[]`
- `summary.inferred.semantic: number`
- Wiki page: `### Semantic-Inferred` subsection under "Inferred Cross-Copybook Candidates", **only when entries exist**.
- Coverage block Copybook row's "Yielding" cell becomes `X deterministic, Y inferred, Z semantic` **only when Z > 0**.
- Overview metric row `| Semantic-inferred candidates | Z |` **only when Z > 0**.
- `EvidenceEnvelope` maps `semantic` → `weak`/`inferred` (same as high). The domain tier label is what distinguishes them — the rationale string starts with `Renamed field (LEFT ↔ RIGHT)` so the rename pair is the first thing a reviewer reads.

## Regression-lock contract (per #35 spec)

The issue explicitly asks for the new tier to be **purely additive**:

- `summary.inferred.copybooks` / `programs` still count name-keyed entries only — byte-stable for rename-free corpora.
- Renderer subsection, Overview row, Coverage Yielding suffix all conditional on `semantic > 0` — fixtures without rename pairs produce byte-identical wiki output.
- All 59 existing field-lineage tests pass unchanged.

## Tests

9 new under `Semantic-Inferred tier (#35)`:

1. Positive — renamed scalar at depth 3 with matching parent + 2 shared siblings → 1 entry, rationale starts with "Renamed field".
2. Gate 4 (siblings < 2) drops.
3. Gate 2 (both sides lack USAGE) drops.
4. Gate 3 (depth-2 fields → top-level parent) drops.
5. Gate 5 (3 same-shape variants → competing → all drop, no ambiguous companion).
6. Regression lock — rename-free corpus produces `inferredSemantic: []`, `summary.inferred.semantic: 0`, name-keyed output unchanged.
7. Renderer presence/absence — `### Semantic-Inferred` only when entries exist.
8. Renderer Coverage cell — `Z semantic` suffix only when Z > 0.
9. `normalizeLoadedFieldLineage` backfills `inferredSemantic`/`summary.inferred.semantic` for pre-#35 JSON loaded from disk.

## Out of scope (deferred per issue)

- LLM / embedding-based semantic similarity. This stays deterministic and reproducible — "semantic" here means "shape-keyed", not "model-judged".
- Auto-promoting `semantic` to deterministic / high.
- Multi-side (>2-copybook) matches.
- `COPY REPLACING`-aware renaming — separate gap, separate issue.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/field-lineage.test.ts` — 68 / 68 (59 existing + 9 new)
- [x] `npx vitest run` — 3686 / 3686
- [x] `npx tsc --noEmit` — clean
