### PR TITLE
feat(cobol): REPLACING-aware DB2 host-var resolution (#37 Phase A)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -1,7 +1,44 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "../parser.js";
 import { extractModel } from "../extractors.js";
-import { buildDb2TableLineage } from "../db2-table-lineage.js";
+import { buildDb2TableLineage, parseReplacingPairs } from "../db2-table-lineage.js";
+
+describe("parseReplacingPairs (#37 Phase A)", () => {
+  it("parses single-token form X BY Y", () => {
+    expect(parseReplacingPairs(["X", "BY", "Y"])).toEqual([{ from: "X", to: "Y" }]);
+  });
+
+  it("parses pseudo-text form ==X== BY ==Y== as the COBOL lexer shatters it", () => {
+    // The actual parser output for `REPLACING ==X== BY ==Y==` because `=`
+    // lexes as a single-character operator and shatters the `==` markers.
+    const shattered = ["=", "=", "X", "=", "=", "BY", "=", "=", "Y", "=", "="];
+    expect(parseReplacingPairs(shattered)).toEqual([{ from: "X", to: "Y" }]);
+  });
+
+  it("also accepts pre-joined ==X== tokens (defensive — in case upstream doesn't shatter)", () => {
+    expect(parseReplacingPairs(["==X==", "BY", "==Y=="])).toEqual([{ from: "X", to: "Y" }]);
+  });
+
+  it("parses multi-pair form X BY Y Z BY W", () => {
+    expect(parseReplacingPairs(["X", "BY", "Y", "Z", "BY", "W"])).toEqual([
+      { from: "X", to: "Y" },
+      { from: "Z", to: "W" },
+    ]);
+  });
+
+  it("drops pairs whose tokens aren't valid identifiers (shattered pseudo-text)", () => {
+    // Lexer-shattered tokens that aren't legal COBOL identifiers must not
+    // produce substitutions — Phase A treats them as unrecognized and falls
+    // through to host-var-unresolved.
+    expect(parseReplacingPairs(["=", "BY", "="])).toEqual([]);
+    expect(parseReplacingPairs([":T", "BY", "WS"])).toEqual([]); // fragment prefix
+  });
+
+  it("returns empty array when REPLACING token list lacks BY entirely", () => {
+    expect(parseReplacingPairs(["X", "Y"])).toEqual([]);
+    expect(parseReplacingPairs([])).toEqual([]);
+  });
+});
 
 function model(source: string, filename: string) {
   return extractModel(parse(source, filename));
@@ -699,6 +736,185 @@ describe("buildDb2TableLineage", () => {
     expect(unresolved?.rationale).not.toContain("REPLACING");
     // … but the typo and missing-copybook breadcrumbs should still be there.
     expect(unresolved?.rationale).toContain("typos");
+  });
+
+  describe("REPLACING-aware host-var resolution (#37 Phase A)", () => {
+    const customerCopybook = `
+       01  CUSTOMER-REC.
+           05  CUSTOMER-ID       PIC X(10).
+           05  CUSTOMER-NAME     PIC X(30).
+`;
+
+    function writerWithCopy(copyDirective: string, hostVar: string): string {
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           ${copyDirective}
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID) VALUES (:${hostVar}) END-EXEC.
+           STOP RUN.
+`;
+    }
+
+    const reader = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. READER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-ID              PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL SELECT ID INTO :WS-ID FROM CUSTOMERS END-EXEC.
+           STOP RUN.
+`;
+
+    it("resolves single-token REPLACING (CUSTOMER-ID BY CLIENT-ID)", () => {
+      const writer = writerWithCopy(
+        "COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID.",
+        "CLIENT-ID",
+      );
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      const entry = lineage!.entries[0]!;
+      const clientId = entry.writer.hostVars.find((hv) => hv.name === "CLIENT-ID");
+      expect(clientId?.dataItem).toBeDefined();
+      expect(clientId?.dataItem?.name).toBe("CUSTOMER-ID");
+      expect(clientId?.dataItem?.picture).toBe("X(10)");
+      expect(clientId?.dataItem?.originCopybook).toBe("CUSTOMER-REC");
+      expect(clientId?.dataItem?.replacingSubstitution).toEqual({
+        fromName: "CUSTOMER-ID",
+        toName: "CLIENT-ID",
+      });
+      // No host-var-unresolved diagnostic for CLIENT-ID after Phase A.
+      expect(
+        lineage!.diagnostics.some(
+          (d) => d.kind === "host-var-unresolved" && d.hostVar === "CLIENT-ID",
+        ),
+      ).toBe(false);
+    });
+
+    it("resolves pseudo-text REPLACING (==CUSTOMER-ID== BY ==CLIENT-ID==)", () => {
+      const writer = writerWithCopy(
+        "COPY CUSTOMER-REC REPLACING ==CUSTOMER-ID== BY ==CLIENT-ID==.",
+        "CLIENT-ID",
+      );
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      const clientId = entry.writer.hostVars.find((hv) => hv.name === "CLIENT-ID");
+      expect(clientId?.dataItem?.name).toBe("CUSTOMER-ID");
+      expect(clientId?.dataItem?.replacingSubstitution?.fromName).toBe("CUSTOMER-ID");
+    });
+
+    it("resolves multi-pair REPLACING (two pairs in one COPY)", () => {
+      const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+           COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID
+                                       CUSTOMER-NAME BY CLIENT-NAME.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)
+              VALUES (:CLIENT-ID, :CLIENT-NAME) END-EXEC.
+           STOP RUN.
+`;
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const writerVars = lineage!.entries[0]!.writer.hostVars;
+      const clientId = writerVars.find((hv) => hv.name === "CLIENT-ID");
+      const clientName = writerVars.find((hv) => hv.name === "CLIENT-NAME");
+      expect(clientId?.dataItem?.name).toBe("CUSTOMER-ID");
+      expect(clientName?.dataItem?.name).toBe("CUSTOMER-NAME");
+      expect(clientId?.dataItem?.replacingSubstitution?.fromName).toBe("CUSTOMER-ID");
+      expect(clientName?.dataItem?.replacingSubstitution?.fromName).toBe("CUSTOMER-NAME");
+    });
+
+    it("falls through to host-var-unresolved when the SQL name doesn't match any REPLACING target", () => {
+      // REPLACING is present (CUSTOMER-ID BY CLIENT-ID) but the SQL
+      // references a third name — neither a copybook field nor a `to`
+      // value. Phase A must not promote this to "resolved".
+      const writer = writerWithCopy(
+        "COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID.",
+        "STRAY-NAME",
+      );
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      const stray = entry.writer.hostVars.find((hv) => hv.name === "STRAY-NAME");
+      expect(stray?.dataItem).toBeUndefined();
+      expect(
+        lineage!.diagnostics.some(
+          (d) => d.kind === "host-var-unresolved" && d.hostVar === "STRAY-NAME",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not attach replacingSubstitution when resolution succeeded via direct copybook lookup", () => {
+      // SQL references a name that's actually in the copybook — Phase A
+      // fallback must not run. replacingSubstitution stays undefined.
+      const writer = writerWithCopy(
+        "COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID.",
+        "CUSTOMER-NAME",
+      );
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      const custName = entry.writer.hostVars.find((hv) => hv.name === "CUSTOMER-NAME");
+      expect(custName?.dataItem?.name).toBe("CUSTOMER-NAME");
+      expect(custName?.dataItem?.replacingSubstitution).toBeUndefined();
+    });
+
+    it("inline WS declaration shadows REPLACING substitution (precedence preserved)", () => {
+      // Program has BOTH a REPLACING that would resolve CLIENT-ID and
+      // an inline WS declaration of CLIENT-ID. Inline must win — same
+      // precedence rule the rest of the resolver uses.
+      const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  CLIENT-ID            PIC X(99).
+           COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (ID) VALUES (:CLIENT-ID) END-EXEC.
+           STOP RUN.
+`;
+      const lineage = buildDb2TableLineage([
+        model(customerCopybook, "CUSTOMER-REC.cpy"),
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const clientId = lineage!.entries[0]!.writer.hostVars.find((hv) => hv.name === "CLIENT-ID");
+      expect(clientId?.dataItem?.picture).toBe("X(99)"); // inline WS, not the copybook
+      expect(clientId?.dataItem?.replacingSubstitution).toBeUndefined();
+      expect(clientId?.dataItem?.originCopybook).toBeUndefined();
+    });
   });
 
   it("originCopybook is deterministic across input orders when copybooks share a logical name", () => {

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -72,6 +72,16 @@ export interface HostVarDataItemRef {
    * unresolved, absence = "this field doesn't trace back to a copybook".
    */
   originCopybook?: string;
+  /**
+   * Present when the field was reached only after applying a
+   * `COPY ... REPLACING` substitution (#37 Phase A): the SQL block
+   * referenced `toName`, but no data item by that name existed; we
+   * matched `toName` against a `BY` target in the program's REPLACING
+   * pair list, looked up `fromName` in the copybook, and that succeeded.
+   * Lets the renderer surface the rename trail so a reviewer can see
+   * why a host var maps to an unexpected field name.
+   */
+  replacingSubstitution?: { fromName: string; toName: string };
 }
 
 /**
@@ -170,6 +180,53 @@ interface ResolvedHostVar {
   dataItem: DataItemNode;
   /** Set when the field was found in a copybook the program COPYs. */
   originCopybook?: string;
+  /** Set when the lookup succeeded only via REPLACING fallback (#37 Phase A). */
+  replacingSubstitution?: { fromName: string; toName: string };
+}
+
+/**
+ * Parse the parser's raw `replacing` token array into structured `{ from, to }`
+ * substitution pairs (#37 Phase A).
+ *
+ * The parser records `replacing` as the whitespace-tokenized slice of rawText
+ * that follows `REPLACING`. The COBOL lexer treats `=` as a single-character
+ * operator, so pseudo-text `==X==` arrives **shattered** as individual `=`
+ * tokens around the identifier. Three surface forms this function handles:
+ *
+ *   - Single-token:    `["X", "BY", "Y"]`                                 → 1 pair
+ *   - Pseudo-text:     `["=","=","X","=","=","BY","=","=","Y","=","="]`   → 1 pair
+ *   - Multi-pair:      `["X","BY","Y","Z","BY","W"]`                      → 2 pairs
+ *
+ * Algorithm: drop standalone `=` tokens (the shattered pseudo-text markers),
+ * then walk the remainder for `ID BY ID` triplets. Identifier tokens that
+ * don't match `[A-Z][A-Z0-9-]*` (fragment substitution, partial-token
+ * substring patterns, anything we can't trust as a COBOL identifier) are
+ * dropped from the trigger set so they fall through to `host-var-unresolved`.
+ */
+export function parseReplacingPairs(tokens: readonly string[]): Array<{ from: string; to: string }> {
+  const IDENT = /^[A-Z][A-Z0-9-]*$/;
+  // Strip the lexer's shattered `=` markers; keep BY and identifier candidates.
+  // Also strip pre-shattered `==X==` if it ever arrives as one token (defensive
+  // — the COBOL lexer normally shatters, but a different upstream might not).
+  const cleaned: string[] = [];
+  for (const tok of tokens) {
+    if (tok === "=" || tok === "==") continue;
+    if (tok.startsWith("==") && tok.endsWith("==") && tok.length >= 4) {
+      cleaned.push(tok.slice(2, -2));
+    } else {
+      cleaned.push(tok);
+    }
+  }
+  const pairs: Array<{ from: string; to: string }> = [];
+  for (let i = 0; i < cleaned.length; i++) {
+    if (cleaned[i] !== "BY") continue;
+    const from = cleaned[i - 1];
+    const to = cleaned[i + 1];
+    if (!from || !to) continue;
+    if (!IDENT.test(from) || !IDENT.test(to)) continue;
+    pairs.push({ from, to });
+  }
+  return pairs;
 }
 
 /**
@@ -180,12 +237,18 @@ interface ResolvedHostVar {
  *   3. Any copybook the program COPYs (the parser does NOT inline-expand
  *      COPY, so copybook fields aren't in `program.dataItems` even though
  *      they're visible to SQL)
+ *   4. (#37 Phase A) REPLACING-aware fallback: for each copy carrying a
+ *      `REPLACING` pair list, look up `from` in the copybook for any pair
+ *      whose `to` equals the requested name. Catches the common case where
+ *      the SQL references the substituted name but the copybook still
+ *      contains the original.
  *
  * Inline (#1) takes precedence over a copybook field of the same name —
  * the program's own declaration shadows what's COPY'd in. Returns the
- * matching data item plus, when found via #3, the canonical (uppercased)
- * copybook name as the lexer captured it. COPY REPLACING-aware lookup is
- * not yet implemented: a renamed field still surfaces as unresolved.
+ * matching data item plus, when found via #3 or #4, the canonical
+ * (uppercased) copybook name as the lexer captured it. Step #4 also
+ * attaches `replacingSubstitution` so the renderer can show the rename
+ * trail.
  */
 function resolveHostVar(
   program: CobolCodeModel,
@@ -204,12 +267,36 @@ function resolveHostVar(
       if (item) return { dataItem: item, originCopybook: copy.copybook };
     }
   }
+  // #37 Phase A — REPLACING-aware fallback. Only entered when every direct
+  // lookup above failed; programs without REPLACING never run this loop
+  // (`replacing` is undefined and skipped). For each pair whose `to` matches
+  // the host-var name we couldn't find, look up `from` in the corresponding
+  // copybook. First match wins — the same ordering as the direct path.
+  const upperName = name.toUpperCase();
+  for (const copy of program.copies) {
+    if (!copy.replacing || copy.replacing.length === 0) continue;
+    const pairs = parseReplacingPairs(copy.replacing);
+    const match = pairs.find((p) => p.to === upperName);
+    if (!match) continue;
+    const copybooks = copybooksByLogicalName.get(normalizeCopybookName(copy.copybook));
+    if (!copybooks) continue;
+    for (const cpy of copybooks) {
+      const item = findDataItemByName(cpy.dataItems, match.from);
+      if (item) {
+        return {
+          dataItem: item,
+          originCopybook: copy.copybook,
+          replacingSubstitution: { fromName: match.from, toName: upperName },
+        };
+      }
+    }
+  }
   return undefined;
 }
 
 function toHostVarRef(name: string, resolved: ResolvedHostVar | undefined): HostVarRef {
   if (!resolved) return { name };
-  const { dataItem, originCopybook } = resolved;
+  const { dataItem, originCopybook, replacingSubstitution } = resolved;
   return {
     name,
     dataItem: {
@@ -218,6 +305,7 @@ function toHostVarRef(name: string, resolved: ResolvedHostVar | undefined): Host
       picture: dataItem.picture,
       usage: dataItem.usage,
       originCopybook,
+      ...(replacingSubstitution ? { replacingSubstitution } : {}),
     },
   };
 }
@@ -367,17 +455,20 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
           const dedupeKey = `${programId}|${name}`;
           if (!seenUnresolved.has(dedupeKey)) {
             seenUnresolved.add(dedupeKey);
-            // Mention REPLACING only when the program actually uses
-            // `COPY ... REPLACING` somewhere — the resolver doesn't apply
-            // the substitution, so a renamed field surfaces as unresolved
-            // and the user needs the breadcrumb. Now that the parser
-            // populates `c.replacing` correctly (#21), this gate is
-            // accurate per-program (was: heuristic on `copies.length > 0`).
+            // Surface REPLACING as a possible cause only when the program
+            // uses it AND the resolver couldn't apply its Phase A fallback.
+            // After #37 Phase A, single-token and pseudo-text REPLACING
+            // pairs ARE applied — what falls through to this diagnostic
+            // are shapes Phase A can't structure (fragment substitution
+            // like `==:T== BY ==WS==`, or pseudo-text shattered across
+            // whitespace by the lexer). Wording reflects the narrower
+            // remaining gap so the hint stays useful instead of vestigial.
             const replacingClause = program.copies.some(
               (c) => c.replacing && c.replacing.length > 0,
             )
-              ? ` \`COPY ... REPLACING\` renames are not yet applied during `
-                + `resolution and may also surface here.`
+              ? ` Single-token and pseudo-text \`COPY ... REPLACING\` pairs `
+                + `are applied during resolution; partial-token or fragment `
+                + `substitutions are not, and may also surface here.`
               : "";
             diagnostics.push({
               kind: "host-var-unresolved",

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -460,18 +460,27 @@ function formatInferredStructure(
  * copybook, the origin is appended as `from CUSTID` so the user can trace
  * it without grepping. Unresolved vars are tagged with `(?)` — a paired
  * `host-var-unresolved` diagnostic in the exclusions table tells the
- * user why. `<br>` separates entries so a many-host-var cell stays
- * readable in the markdown table.
+ * user why. When the field was reached via REPLACING substitution (#37
+ * Phase A), the rename trail (`from CUSTOMER-ID via REPLACING`) appears so
+ * a reviewer sees why the SQL name and copybook name disagree. `<br>`
+ * separates entries so a many-host-var cell stays readable.
  */
 function formatHostVars(hostVars: HostVarRef[]): string {
   if (hostVars.length === 0) return "—";
   return hostVars.map((hv) => {
     if (!hv.dataItem) return `\`${hv.name}\` (?)`;
     const shape = hv.dataItem.picture ?? "group";
-    const origin = hv.dataItem.originCopybook
-      ? ` from \`${hv.dataItem.originCopybook}\``
-      : "";
-    return `\`${hv.name}\` (${shape}${origin})`;
+    // Substitution wins over plain origin: the user needs to see the rename
+    // pair first, then the copybook. A field reached via REPLACING always
+    // has originCopybook set (the substitution is per-COPY), so we read both
+    // out of the same HostVarRef.
+    let trail = "";
+    if (hv.dataItem.replacingSubstitution) {
+      trail = ` from \`${hv.dataItem.replacingSubstitution.fromName}\` via REPLACING in \`${hv.dataItem.originCopybook}\``;
+    } else if (hv.dataItem.originCopybook) {
+      trail = ` from \`${hv.dataItem.originCopybook}\``;
+    }
+    return `\`${hv.name}\` (${shape}${trail})`;
   }).join("<br>");
 }
 


### PR DESCRIPTION
## Summary

Closes #37 (Phase A). Resolve SQL host vars referenced by their **REPLACING-substituted** name. Today the DB2 resolver tries WS → LINKAGE → direct copybook lookup; if none match, the host var surfaces as `host-var-unresolved` even when the field exists in the copybook under its pre-REPLACING name. After this PR:

```cobol
COPY CUSTOMER-REC REPLACING CUSTOMER-ID BY CLIENT-ID.
...
EXEC SQL INSERT INTO CUSTOMERS (ID) VALUES (:CLIENT-ID) END-EXEC.
```

`CLIENT-ID` resolves to the copybook's `CUSTOMER-ID` field with a rename trail attached: `(X(10) from CUSTOMER-ID via REPLACING in CUSTOMER-REC)` in the wiki, and `replacingSubstitution: { fromName: "CUSTOMER-ID", toName: "CLIENT-ID" }` on the artifact.

## How

- New `parseReplacingPairs` helper turns the parser's raw `replacing` token array into `{ from, to }` pairs. Handles:
  - **Single-token**: `X BY Y`
  - **Pseudo-text in its actual lexer-shattered form**: `= = X = = BY = = Y = =` (the COBOL lexer breaks `==` into individual `=` chars; whitespace-tokenized rawText carries them as separate entries).
  - **Multi-pair**: `X BY Y Z BY W`
  - Tokens not matching `[A-Z][A-Z0-9-]*` drop as unrecognized → fragment / partial-token substitutions fall through to `host-var-unresolved` as documented in Phase A.
- `resolveHostVar` gains a final fallback: after direct lookup fails, walk `program.copies[]`; for each pair whose `to` matches the requested name, look up `from` in the copybook. On success return with `replacingSubstitution` attached.
- `HostVarDataItemRef.replacingSubstitution?: { fromName, toName }` — present only on Phase-A-resolved entries.
- `formatHostVars` in the DB2 table renders `from FOO via REPLACING in BAR` when the substitution fired.
- `host-var-unresolved` rationale is rewritten to reflect the narrower remaining gap (Phase A covers single-token + pseudo-text; fragment substitution still falls through).

## Backwards-compat

Programs without REPLACING never enter the new code path. Programs with REPLACING that don't reference renamed fields in SQL also don't trigger it. No artifact-shape change beyond the optional new field. All 99 pre-existing test files / 3722 tests pass unchanged. The existing test "rationale lists REPLACING as a possible cause when the program uses COPY ... REPLACING (#21)" still passes — the rewritten rationale keeps `REPLACING` as a substring.

## Tests

11 new in `src/cobol/__tests__/db2-table-lineage.test.ts`:

**Unit (5)** — `parseReplacingPairs`:
1. Single-token `X BY Y`.
2. Pseudo-text in real lexer-shattered form.
3. Pseudo-text in pre-joined `==X==` form (defensive).
4. Multi-pair.
5. Negative — shattered fragments / no `BY` keyword.

**Integration (6)** — `resolveHostVar` REPLACING path:
1. Single-token positive (`CUSTOMER-ID BY CLIENT-ID`, SQL uses `:CLIENT-ID`).
2. Pseudo-text positive.
3. Multi-pair positive (two pairs in one COPY).
4. No-match fallthrough — REPLACING present, SQL name doesn't match any `to` → still `host-var-unresolved`.
5. Direct lookup still wins — SQL references a name that exists in the copybook → no `replacingSubstitution` attached.
6. Inline WS shadows REPLACING substitution — precedence preserved.

## Out of scope

- **Phase B**: deterministic shared-copybook lineage for same-REPLACING consumers (separate, larger issue — needs `consumersByCopybook` second-level grouping by REPLACING tuple).
- Fragment / partial-token substitution (`==:T== BY ==WS==`-style prefix renames).
- Backfilling already-built artifacts (lights up on next rebuild).

## Test plan

- [x] `npx vitest run src/cobol/__tests__/db2-table-lineage.test.ts` — 58/58 (47 existing + 11 new)
- [x] `npx vitest run` — 3724/3724
- [x] `npx tsc --noEmit` — clean
- [x] Rendered fixture eyeballed: `\`CLIENT-ID\` (X(10) from \`CUSTOMER-ID\` via REPLACING in \`CUSTOMER-REC\`)`
