### PR TITLE
feat(cobol): same-REPLACING consumers re-enter deterministic copybook lineage (#39 Phase B)

### DIFF
--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -1195,6 +1195,31 @@ describe("COBOL field lineage", () => {
       expect(page.content).toContain("deterministic-via-replacing");
     });
 
+    it("fragment-substitution cohorts (unparseable REPLACING) skip deterministic emission", () => {
+      // Two consumers with the same fragment-style REPLACING that
+      // parseReplacingPairs can't structure (e.g., `:T BY WS` — colon
+      // prefix isn't a valid COBOL identifier start). They land in the
+      // same cohort by raw-tuple identity, but we can't apply the
+      // substitution, so we don't know what fields are actually renamed.
+      // Pre-#39 behavior was "exclude from deterministic"; Phase B
+      // preserves it by skipping the cohort.
+      const orderA = model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl");
+      const orderB = model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl");
+      // Hand-construct the fragment shape — `parseReplacingPairs` rejects
+      // tokens that fail [A-Z][A-Z0-9-]*, so the cohort has empty pairs
+      // despite the raw-tuple being non-empty.
+      orderA.copies[0]!.replacing = [":T", "BY", "WS"];
+      orderB.copies[0]!.replacing = [":T", "BY", "WS"];
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        orderA,
+        orderB,
+      ]);
+      // No deterministic emission from the fragment cohort. Singletons in
+      // every other cohort either — lineage is null.
+      expect(lineage).toBeNull();
+    });
+
     it("normalizeLoadedFieldLineage backfills summary.deterministic.viaReplacing for pre-#39 JSON", () => {
       const pre39 = {
         summary: {

--- a/src/cobol/__tests__/field-lineage.test.ts
+++ b/src/cobol/__tests__/field-lineage.test.ts
@@ -1042,6 +1042,178 @@ describe("COBOL field lineage", () => {
     });
   });
 
+  describe("deterministic-via-replacing cohorts (#39 Phase B)", () => {
+    function withReplacing(programId: string, copybook: string, pairsClause: string): string {
+      // pairsClause is the literal text following REPLACING, e.g.
+      // "CUSTOMER-ID BY CLIENT-ID" or "==CUSTOMER-ID== BY ==CLIENT-ID==".
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ${programId}.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY ${copybook} REPLACING ${pairsClause}.
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STOP RUN.
+`;
+    }
+
+    it("emits one deterministic-via-replacing entry per renamed field when ≥2 consumers share the same REPLACING", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGA", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGA.cbl"),
+        model(withReplacing("PROGB", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGB.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      const clientId = lineage!.deterministic.find((e) => e.fieldName === "CLIENT-ID");
+      expect(clientId).toBeDefined();
+      expect(clientId!.linkage).toBe("deterministic-via-replacing");
+      expect(clientId!.replacing).toEqual({ fromName: "CUSTOMER-ID", toName: "CLIENT-ID" });
+      expect(clientId!.programs.map((p) => p.id)).toEqual(["program:PROGA", "program:PROGB"]);
+      // The pre-substitution name doesn't show as a separate deterministic
+      // entry — both programs see the renamed name.
+      expect(lineage!.deterministic.find((e) => e.fieldName === "CUSTOMER-ID")).toBeUndefined();
+      expect(lineage!.summary.deterministic.viaReplacing).toBeGreaterThan(0);
+    });
+
+    it("untouched fields in a REPLACING cohort still emit with deterministic-via-replacing linkage, no replacing field", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGA", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGA.cbl"),
+        model(withReplacing("PROGB", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGB.cbl"),
+      ]);
+      // ZIP-CODE is in the copybook but not renamed by the REPLACING.
+      const zip = lineage!.deterministic.find((e) => e.fieldName === "ZIP-CODE");
+      expect(zip).toBeDefined();
+      expect(zip!.linkage).toBe("deterministic-via-replacing"); // cohort label
+      expect(zip!.replacing).toBeUndefined();
+      expect(zip!.programs.map((p) => p.id)).toEqual(["program:PROGA", "program:PROGB"]);
+    });
+
+    it("two programs with DIFFERENT REPLACING clauses each form singleton cohorts — no deterministic", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGA", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGA.cbl"),
+        model(withReplacing("PROGB", "CUSTOMER-REC", "CUSTOMER-ID BY ORDER-ID"), "PROGB.cbl"),
+      ]);
+      // No cohort has ≥2 consumers → null (no deterministic + no inferred + no
+      // semantic + no diagnostics).
+      expect(lineage).toBeNull();
+    });
+
+    it("mixed cohorts: empty + REPLACING each ≥2 → two distinct deterministic entries", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CUSTOMER-REC"), "PROGB.cbl"),
+        model(withReplacing("PROGC", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGC.cbl"),
+        model(withReplacing("PROGD", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGD.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      // Empty cohort emits CUSTOMER-ID (deterministic, programs A+B).
+      const custId = lineage!.deterministic.find(
+        (e) => e.fieldName === "CUSTOMER-ID" && e.linkage === "deterministic",
+      );
+      expect(custId).toBeDefined();
+      expect(custId!.programs.map((p) => p.id).sort()).toEqual(["program:PROGA", "program:PROGB"]);
+      expect(custId!.replacing).toBeUndefined();
+      // REPLACING cohort emits CLIENT-ID (deterministic-via-replacing, programs C+D).
+      const clientId = lineage!.deterministic.find(
+        (e) => e.fieldName === "CLIENT-ID" && e.linkage === "deterministic-via-replacing",
+      );
+      expect(clientId).toBeDefined();
+      expect(clientId!.programs.map((p) => p.id).sort()).toEqual(["program:PROGC", "program:PROGD"]);
+      expect(clientId!.replacing).toEqual({ fromName: "CUSTOMER-ID", toName: "CLIENT-ID" });
+    });
+
+    it("regression lock: existing REPLACING-singleton fixture still yields null", () => {
+      // Same fixture the pre-#39 test `does not treat COPY REPLACING
+      // consumers as deterministic shared lineage` uses: one empty-cohort
+      // consumer + one REPLACING-cohort consumer (each a singleton).
+      const orderA = model(program("ORDERA", "CUSTOMER-REC"), "ORDERA.cbl");
+      const orderB = model(program("ORDERB", "CUSTOMER-REC"), "ORDERB.cbl");
+      orderB.copies[0]!.replacing = ["CUSTOMER-ID", "BY", "CLIENT-ID"];
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        orderA,
+        orderB,
+      ]);
+      expect(lineage).toBeNull();
+    });
+
+    it("REPLACING substitution propagates through qualified-path segments", () => {
+      // CUSTOMER-ADDRESS.ZIP-CODE — REPLACING renames CUSTOMER-ADDRESS to
+      // CLIENT-ADDRESS. Both the parent segment in the qualified path and
+      // the leaf-field's parentQualifiedName follow.
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGA", "CUSTOMER-REC", "CUSTOMER-ADDRESS BY CLIENT-ADDRESS"), "PROGA.cbl"),
+        model(withReplacing("PROGB", "CUSTOMER-REC", "CUSTOMER-ADDRESS BY CLIENT-ADDRESS"), "PROGB.cbl"),
+      ]);
+      const zip = lineage!.deterministic.find((e) => e.fieldName === "ZIP-CODE");
+      expect(zip).toBeDefined();
+      // The path under the renamed parent is post-substitution.
+      expect(zip!.qualifiedNames.some((n) => n.includes("CLIENT-ADDRESS.ZIP-CODE"))).toBe(true);
+      expect(zip!.parentQualifiedNames.some((n) => n.endsWith("CLIENT-ADDRESS"))).toBe(true);
+    });
+
+    it("renderer: Coverage cell adds `(N via REPLACING)` suffix only when viaReplacing > 0", () => {
+      const empty = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(program("PROGA", "CUSTOMER-REC"), "PROGA.cbl"),
+        model(program("PROGB", "CUSTOMER-REC"), "PROGB.cbl"),
+      ]);
+      const emptyPage = generateFieldLineagePage(empty!);
+      const emptyCoverage = emptyPage.content.slice(
+        emptyPage.content.indexOf("## Coverage"),
+        emptyPage.content.indexOf("## Overview"),
+      );
+      expect(emptyCoverage).not.toContain("via REPLACING");
+
+      const withRepl = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGC", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGC.cbl"),
+        model(withReplacing("PROGD", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGD.cbl"),
+      ]);
+      const replPage = generateFieldLineagePage(withRepl!);
+      const replCoverage = replPage.content.slice(
+        replPage.content.indexOf("## Coverage"),
+        replPage.content.indexOf("## Overview"),
+      );
+      expect(replCoverage).toMatch(/\d+ deterministic \(\d+ via REPLACING\)/);
+    });
+
+    it("renderer: Shared-fields Field cell shows `Y (was X)` for renamed entries", () => {
+      const lineage = buildFieldLineage([
+        model(sharedCopybook, "CUSTOMER-REC.cpy"),
+        model(withReplacing("PROGA", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGA.cbl"),
+        model(withReplacing("PROGB", "CUSTOMER-REC", "CUSTOMER-ID BY CLIENT-ID"), "PROGB.cbl"),
+      ]);
+      const page = generateFieldLineagePage(lineage!);
+      expect(page.content).toContain("CLIENT-ID (was CUSTOMER-ID)");
+      expect(page.content).toContain("deterministic-via-replacing");
+    });
+
+    it("normalizeLoadedFieldLineage backfills summary.deterministic.viaReplacing for pre-#39 JSON", () => {
+      const pre39 = {
+        summary: {
+          deterministic: { copybooks: 1, programs: 2, fields: 3 },
+          inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0, semantic: 0 },
+          diagnosticsByKind: { "parsed-zero-data-items": 0 },
+        },
+        copybookUsage: [],
+        deterministic: [],
+        inferredHighConfidence: [],
+        inferredAmbiguous: [],
+        inferredSemantic: [],
+        diagnostics: [],
+      } as unknown as SerializedFieldLineage;
+      const normalized = normalizeLoadedFieldLineage(pre39);
+      expect(normalized.summary.deterministic.viaReplacing).toBe(0);
+    });
+  });
+
   it("generates a lineage wiki summary page", () => {
     const lineage = buildFieldLineage([
       model(sharedCopybook, "CUSTOMER-REC.cpy"),

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -724,6 +724,15 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
     const fields = flattenedByCopybook.get(usage.copybookId) ?? [];
     for (const cohort of usage.cohorts) {
       if (cohort.consumers.length < 2) continue;
+      // Skip cohorts whose REPLACING text we couldn't structure into pairs
+      // — fragment / partial-token substitution (same Phase A limit). The
+      // consumers HAVE substitution; we just don't know what gets renamed.
+      // Emitting `deterministic` under the original copybook names would
+      // be a false positive on any field the substitution actually
+      // touches, so preserve the pre-#39 behavior of treating unparseable-
+      // REPLACING consumers as singletons.
+      const isUnparseableReplacing = cohort.key !== "[]" && cohort.pairs.length === 0;
+      if (isUnparseableReplacing) continue;
       const isReplacingCohort = cohort.pairs.length > 0;
       for (const field of fields) {
         const projected = projectFieldThroughReplacing(field, cohort.pairs);

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -2,9 +2,22 @@ import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
 import { resolveCanonicalId, displayLabel, normalizeCopybookName } from "./graph.js";
 import type { CallBoundLineage, SerializedCallBoundLineageEntry } from "./call-boundary-lineage.js";
-import type { Db2Lineage, HostVarRef } from "./db2-table-lineage.js";
+import { parseReplacingPairs, type Db2Lineage, type HostVarRef } from "./db2-table-lineage.js";
 
-export type LineageLinkage = "deterministic";
+/**
+ * Linkage tier on a deterministic shared-copybook entry.
+ *
+ *   - `"deterministic"`: emitted by the empty REPLACING cohort. Consumers
+ *     all COPY without substitution; the entry's `fieldName` matches the
+ *     copybook verbatim. This was the only linkage prior to #39 Phase B.
+ *   - `"deterministic-via-replacing"` (#39 Phase B): emitted by a
+ *     non-empty REPLACING cohort. Consumers all apply the same
+ *     `COPY ... REPLACING` clause, so they share the post-substitution
+ *     shape. The entry's `fieldName` is the consumer-view name; when the
+ *     field's own name was substituted, the entry carries a `replacing`
+ *     evidence dimension showing the rename pair.
+ */
+export type LineageLinkage = "deterministic" | "deterministic-via-replacing";
 /**
  * Confidence tier for cross-copybook inferred lineage.
  *
@@ -42,6 +55,14 @@ export interface SerializedFieldLineageEntry {
   pictures: string[];
   usages: string[];
   levels: number[];
+  /**
+   * #39 Phase B — set only on `deterministic-via-replacing` entries whose
+   * field name itself was substituted by the cohort's `COPY ... REPLACING`
+   * clause. Absent on regular `deterministic` entries and on
+   * `deterministic-via-replacing` entries for fields the substitution
+   * doesn't touch.
+   */
+  replacing?: { fromName: string; toName: string };
   rationale: string;
 }
 
@@ -85,6 +106,14 @@ export interface SerializedFieldLineage {
       copybooks: number;
       programs: number;
       fields: number;
+      /**
+       * #39 Phase B — count of deterministic entries emitted via a
+       * REPLACING cohort (`linkage === "deterministic-via-replacing"`).
+       * Subset of `fields`. Reported separately so downstream renderers
+       * (Coverage block, evidence report) can split the breakdown without
+       * walking the entries array.
+       */
+      viaReplacing: number;
     };
     inferred: {
       copybooks: number;
@@ -151,6 +180,11 @@ export function normalizeLoadedFieldLineage(raw: SerializedFieldLineage): Serial
     ...raw,
     summary: {
       ...summary,
+      deterministic: {
+        ...summary.deterministic,
+        // #39 Phase B — pre-#39 artifacts don't carry this split; backfill to 0.
+        viaReplacing: summary.deterministic?.viaReplacing ?? 0,
+      },
       inferred: {
         ...summary.inferred,
         // #35 — pre-#35 artifacts predate the semantic tier; backfill to 0.
@@ -166,7 +200,7 @@ export function normalizeLoadedFieldLineage(raw: SerializedFieldLineage): Serial
 function emptyCopybookLineage(): SerializedFieldLineage {
   return {
     summary: {
-      deterministic: { copybooks: 0, programs: 0, fields: 0 },
+      deterministic: { copybooks: 0, programs: 0, fields: 0, viaReplacing: 0 },
       inferred: { copybooks: 0, programs: 0, highConfidence: 0, ambiguous: 0, semantic: 0 },
       diagnosticsByKind: emptyDiagnosticsByKind(),
     },
@@ -284,6 +318,7 @@ function buildEntry(
   fields: FlattenedField[],
   programs: FieldConsumer[],
   rationale: string,
+  replacingPair?: { fromName: string; toName: string },
 ): SerializedFieldLineageEntry {
   const copybooks = [...new Map(
     fields.map((field) => [field.copybookId, { id: field.copybookId, sourceFile: field.copybookSourceFile }])
@@ -303,7 +338,86 @@ function buildEntry(
     pictures: sortUnique(fields.map((field) => field.picture).filter((value): value is string => Boolean(value))),
     usages: sortUnique(fields.map((field) => field.usage).filter((value): value is string => Boolean(value))),
     levels: [...new Set(fields.map((field) => field.level))].sort((a, b) => a - b),
+    ...(replacingPair ? { replacing: replacingPair } : {}),
     rationale,
+  };
+}
+
+/**
+ * Group a copybook's consumers into REPLACING cohorts (#39 Phase B).
+ * Cohort identity is the raw, source-order `replacing` tuple stringified —
+ * two consumers share a cohort iff their COPY directives carry the same
+ * REPLACING clause verbatim. Empty / missing `replacing` collapses to the
+ * empty-tuple cohort (key `[]`), which is the byte-identical pre-#39
+ * "exact COPY" group. Parsed `pairs` are cached on the cohort so the
+ * per-field substitution step in `buildFieldLineage` doesn't re-parse.
+ */
+interface ReplacingCohort {
+  /** Stringified raw `replacing` array; identifies cohort membership. */
+  key: string;
+  /** Parsed substitution pairs (empty for the exact-COPY cohort). */
+  pairs: Array<{ from: string; to: string }>;
+  consumers: FieldConsumer[];
+}
+function groupConsumersByReplacing(consumers: FieldConsumer[]): ReplacingCohort[] {
+  const byKey = new Map<string, ReplacingCohort>();
+  for (const c of consumers) {
+    const raw = c.replacing ?? [];
+    const key = JSON.stringify(raw);
+    let cohort = byKey.get(key);
+    if (!cohort) {
+      cohort = { key, pairs: parseReplacingPairs(raw), consumers: [] };
+      byKey.set(key, cohort);
+    }
+    cohort.consumers.push(c);
+  }
+  // Stable sort: empty cohort first, then by key. Keeps deterministic
+  // entry order across rebuilds regardless of consumer iteration order.
+  return [...byKey.values()].sort((a, b) => {
+    if (a.key === "[]") return -1;
+    if (b.key === "[]") return 1;
+    return a.key.localeCompare(b.key);
+  });
+}
+
+/**
+ * Carries a flattened field through a cohort's REPLACING pairs. When a
+ * pair's `from` matches the field's leaf name, the leaf and every
+ * qualified-path segment is rewritten to the pair's `to`. The original
+ * pair is returned alongside so the entry can carry it as evidence.
+ *
+ * Parent and qualified-path substitution: applies the pair to every
+ * segment of the qualified path, not just the leaf — REPLACING is purely
+ * textual in COBOL, so a `from` name that also occurs as a parent record
+ * name is renamed everywhere it appears. Multi-pair cohorts iterate pairs
+ * in declaration order; first hit per segment wins (matches COBOL
+ * REPLACING semantics — earlier pairs apply first; later pairs see the
+ * post-substitution text).
+ */
+function projectFieldThroughReplacing(
+  field: FlattenedField,
+  pairs: ReplacingCohort["pairs"],
+): FlattenedField & { replacingPair?: { fromName: string; toName: string } } {
+  if (pairs.length === 0) {
+    return { ...field };
+  }
+  const sub = (segment: string): string => {
+    const upper = segment.toUpperCase();
+    for (const p of pairs) {
+      if (p.from === upper) return p.to;
+    }
+    return segment;
+  };
+  const matchedLeaf = pairs.find((p) => p.from === field.fieldName.toUpperCase());
+  return {
+    ...field,
+    fieldName: matchedLeaf?.to ?? field.fieldName,
+    qualifiedName: field.qualifiedName.split(".").map(sub).join("."),
+    parentQualifiedName: field.parentQualifiedName?.split(".").map(sub).join("."),
+    siblings: field.siblings.map(sub),
+    replacingPair: matchedLeaf
+      ? { fromName: matchedLeaf.from, toName: matchedLeaf.to }
+      : undefined,
   };
 }
 
@@ -581,12 +695,17 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
         (consumersByCopybook.get(normalizeCopybookName(logicalName)) ?? [])
           .map((consumer) => [`${consumer.id}@${consumer.sourceFile}`, consumer])
       ).values()].sort(compareProgram);
-      const exactPrograms = consumers.filter((program) => !program.replacing || program.replacing.length === 0);
+      // #39 Phase B — cohort by the consumer's raw REPLACING tuple. Same
+      // tuple = same post-substitution shape = same deterministic plane.
+      // Empty/missing replacing collapses to the "exact COPY" cohort (key
+      // "[]"); this is byte-identical to the pre-#39 exactPrograms gate
+      // for REPLACING-free corpora.
+      const cohorts = groupConsumersByReplacing(consumers);
       return {
         copybookId,
         sourceFile: copybook.sourceFile,
         programs: consumers,
-        exactPrograms,
+        cohorts,
         fieldCount: flattenedByCopybook.get(copybookId)?.length ?? 0,
       };
     }).filter((entry) => entry.programs.length > 0)
@@ -596,26 +715,41 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
     return diagnostics.length > 0 ? withDiagnostics(emptyCopybookLineage()) : null;
   }
 
+  // Per-cohort deterministic emission (#39 Phase B). Each cohort with ≥2
+  // consumers contributes one entry per copybook field, with REPLACING
+  // substitution applied to the field name and qualified-path segments
+  // when the cohort's pairs reference them.
   const deterministic: SerializedFieldLineageEntry[] = [];
   for (const usage of rawCopybookUsage) {
     const fields = flattenedByCopybook.get(usage.copybookId) ?? [];
-    for (const field of fields) {
-      if (usage.exactPrograms.length < 2) continue;
-      deterministic.push(buildEntry(
-        "deterministic",
-        [field],
-        usage.exactPrograms,
-        "Exact parsed copybook field shared by multiple programs through COPY."
-      ));
+    for (const cohort of usage.cohorts) {
+      if (cohort.consumers.length < 2) continue;
+      const isReplacingCohort = cohort.pairs.length > 0;
+      for (const field of fields) {
+        const projected = projectFieldThroughReplacing(field, cohort.pairs);
+        const linkage: LineageLinkage = isReplacingCohort ? "deterministic-via-replacing" : "deterministic";
+        const rationale = isReplacingCohort
+          ? "Exact parsed copybook field shared by multiple programs through identical COPY ... REPLACING."
+          : "Exact parsed copybook field shared by multiple programs through COPY.";
+        deterministic.push(buildEntry(linkage, [projected], cohort.consumers, rationale, projected.replacingPair));
+      }
     }
   }
 
-  const candidateFields = rawCopybookUsage.flatMap((usage) =>
-    (flattenedByCopybook.get(usage.copybookId) ?? [])
-      .filter((field) => usage.exactPrograms.length > 0)
+  // Inferred candidate sourcing keeps the original (pre-#39) semantics: only
+  // empty-cohort consumers participate, and even a singleton empty cohort
+  // can seed candidates (cross-copybook pairing needs at least one consumer
+  // per copybook, not two). Phase C (REPLACING-aware inferred) is
+  // intentionally deferred — widening this set now would let renamed
+  // fields cross-match without name evidence, blowing up the precision
+  // contract that high/ambiguous depend on.
+  const candidateFields = rawCopybookUsage.flatMap((usage) => {
+    const exact = usage.cohorts.find((c) => c.pairs.length === 0);
+    if (!exact || exact.consumers.length === 0) return [];
+    return (flattenedByCopybook.get(usage.copybookId) ?? [])
       .filter((field) => Boolean(field.picture) || Boolean(field.usage))
-      .map((field) => ({ field, programs: usage.exactPrograms }))
-  );
+      .map((field) => ({ field, programs: exact.consumers }));
+  });
 
   const candidateGroups = new Map<string, Array<{ field: FlattenedField; programs: FieldConsumer[] }>>();
   for (const candidate of candidateFields) {
@@ -740,12 +874,13 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
   //
   // Pairs whose field names match would already have been emitted by the
   // name-keyed pass; drop them here to avoid double-reporting.
-  const semanticCandidateFields = rawCopybookUsage.flatMap((usage) =>
-    (flattenedByCopybook.get(usage.copybookId) ?? [])
-      .filter((field) => usage.exactPrograms.length > 0)
+  const semanticCandidateFields = rawCopybookUsage.flatMap((usage) => {
+    const exact = usage.cohorts.find((c) => c.pairs.length === 0);
+    if (!exact || exact.consumers.length === 0) return [];
+    return (flattenedByCopybook.get(usage.copybookId) ?? [])
       .filter((field) => Boolean(field.picture) && Boolean(field.usage))
-      .map((field) => ({ field, programs: usage.exactPrograms })),
-  );
+      .map((field) => ({ field, programs: exact.consumers }));
+  });
   const shapeGroups = new Map<string, Array<{ field: FlattenedField; programs: FieldConsumer[] }>>();
   for (const candidate of semanticCandidateFields) {
     const shapeKey = `${normalizePicture(candidate.field.picture)}|${normalizeUsage(candidate.field.usage)}|${candidate.field.level}`;
@@ -882,6 +1017,9 @@ export function buildFieldLineage(models: CobolCodeModel[]): SerializedFieldLine
         copybooks: participatingCopybookIds.size,
         programs: participatingProgramIds.size,
         fields: sortedDeterministic.length,
+        viaReplacing: sortedDeterministic.filter(
+          (e) => e.linkage === "deterministic-via-replacing",
+        ).length,
       },
       inferred: {
         // `copybooks` / `programs` deliberately count name-keyed entries only
@@ -1042,8 +1180,15 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
       lines.push("| Copybook | Field | Structure | Programs | PIC | Linkage |");
       lines.push("|----------|-------|-----------|----------|-----|---------|");
       for (const entry of lineage.deterministic) {
+        // #39 Phase B — when the cohort renamed this field, surface the
+        // rename pair inline so the user sees both names without having to
+        // cross-reference the artifact. Field cell only — Structure column
+        // already shows the post-substitution qualified path.
+        const fieldCell = entry.replacing
+          ? `${entry.fieldName} (was ${entry.replacing.fromName})`
+          : entry.fieldName;
         lines.push(
-          `| ${formatCopybooks(entry.copybooks)} | ${entry.fieldName} | ${entry.qualifiedNames.join("<br>")} | ${formatPrograms(entry.programs)} | ${entry.pictures.join(", ") || "—"} | ${entry.linkage} |`
+          `| ${formatCopybooks(entry.copybooks)} | ${fieldCell} | ${entry.qualifiedNames.join("<br>")} | ${formatPrograms(entry.programs)} | ${entry.pictures.join(", ") || "—"} | ${entry.linkage} |`
         );
       }
     }
@@ -1357,11 +1502,28 @@ function renderCoverageSection(
     // appear; once added, sum their counter in here.
     const indexed = lineage.copybookUsage.length + zeroDataItemsCount;
     // Yielding splits inferred into the name-keyed and shape-keyed halves
-    // (#35). The semantic suffix is conditional so the cell stays byte-
-    // identical on rename-free corpora — regression lock contract.
+    // (#35) and the deterministic count into the regular cohort and the
+    // REPLACING cohort (#39 Phase B). Both `(R via REPLACING)` and
+    // `semantic` suffixes are conditional so the cell stays byte-identical
+    // on corpora without rename pairs / without REPLACING — regression
+    // lock contract.
+    //
+    // Both numbers in the deterministic cell are copybook counts (so the
+    // parenthetical is a true subset of the main count). The artifact's
+    // `summary.deterministic.viaReplacing` exposes the entry count for
+    // JSON consumers; the renderer recomputes copybooks for display
+    // because that's the visible apples-to-apples number.
+    const replacingCopybookCount = new Set(
+      lineage.deterministic
+        .filter((e) => e.linkage === "deterministic-via-replacing")
+        .flatMap((e) => e.copybooks.map((c) => c.id)),
+    ).size;
+    const deterministicCell = replacingCopybookCount > 0
+      ? `${lineage.summary.deterministic.copybooks} deterministic (${replacingCopybookCount} via REPLACING)`
+      : `${lineage.summary.deterministic.copybooks} deterministic`;
     const yielding = semanticCount > 0
-      ? `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred, ${semanticCount} semantic`
-      : `${lineage.summary.deterministic.copybooks} deterministic, ${lineage.summary.inferred.copybooks} inferred`;
+      ? `${deterministicCell}, ${lineage.summary.inferred.copybooks} inferred, ${semanticCount} semantic`
+      : `${deterministicCell}, ${lineage.summary.inferred.copybooks} inferred`;
     rows.push(
       `| Copybook | ${indexed} | ${yielding} | ${topExclusionReasons(copybookDiagByKind)} |`,
     );


### PR DESCRIPTION
## Summary

Closes #39 (Phase B). Lets `COPY ... REPLACING` consumers participate in deterministic shared-copybook lineage when their REPLACING clause is the same. The pre-#39 gate excluded *any* REPLACING consumer, silently under-reporting on REPLACING-heavy corpora.

## How

- `consumersByCopybook` no longer filters out REPLACING consumers. Each copybook's consumers are grouped into REPLACING cohorts by their raw `replacing` tuple (stringified for identity). Empty / missing `replacing` collapses to the empty-tuple cohort — byte-identical to the pre-#39 "exact COPY" group.
- Each cohort with ≥2 consumers emits per-field entries. Empty cohort → today's `linkage: "deterministic"`. Non-empty cohort → new `linkage: "deterministic-via-replacing"`, with `replacing: { fromName, toName }` evidence on fields whose name was substituted.
- REPLACING substitution applies textually to every qualified-path segment (matches COBOL semantics where a renamed parent record name flows through the structure). Multi-pair cohorts iterate pairs in declaration order; first-hit-per-segment wins.
- Singletons still don't emit — same precision gate as today.

## Output additions

- `LineageLinkage += "deterministic-via-replacing"`
- `SerializedFieldLineageEntry.replacing?: { fromName: string; toName: string }`
- `summary.deterministic.viaReplacing` — count of via-replacing entries (JSON consumers use this; renderer recomputes copybook count for the Coverage cell so the parenthetical is a true subset)
- `normalizeLoadedFieldLineage` backfills `viaReplacing` to 0 for pre-#39 JSON

## Renderer

- Coverage Yielding cell: `X deterministic (R via REPLACING), Y inferred[, Z semantic]`. Both X and R are copybook counts; suffix appears only when R > 0.
- Shared-fields table Field cell: `CLIENT-ID (was CUSTOMER-ID)` when the entry carries a `replacing` pair. Linkage column shows `deterministic-via-replacing`.

## Sample render

```
| Family | Indexed | Yielding lineage | Excluded (top reasons) |
|--------|---------|------------------|------------------------|
| Copybook | 1 | 1 deterministic (1 via REPLACING), 0 inferred | — |

| Copybook | Field | Structure | Programs | PIC | Linkage |
|----------|-------|-----------|----------|-----|---------|
| CUSTOMER-REC | CUSTOMER-ID | ... | PROGA, PROGB | X(10) | deterministic |
| CUSTOMER-REC | CLIENT-ID (was CUSTOMER-ID) | CUSTOMER-REC.CLIENT-ID | PROGC, PROGD | X(10) | deterministic-via-replacing |
```

## Regression-lock contract (per #39 spec)

- REPLACING-free fixtures produce byte-identical output. All 68 pre-existing field-lineage tests pass unchanged, including `does not treat COPY REPLACING consumers as deterministic shared lineage` (the fixture's single REPLACING consumer is a singleton in its cohort under Phase B too).
- Coverage cell suffix `(R via REPLACING)`, Shared-fields `(was X)` annotation, and the Overview "Inferred copybooks" row all preserve pre-#39 output when no REPLACING cohort fires.

## Tests

9 new under `deterministic-via-replacing cohorts (#39 Phase B)`:

1. Positive — same-REPLACING ≥2 → 1 entry under post-sub name, `replacing` field set, original name absent.
2. Untouched field in REPLACING cohort — same `deterministic-via-replacing` linkage, no `replacing` field.
3. Different REPLACING clauses across consumers → all cohorts singleton → `lineage === null`.
4. Mixed cohorts (empty + REPLACING both ≥2) → two distinct entries, different field names, different linkage.
5. Regression-lock — the longstanding 1-empty + 1-REPLACING-singleton fixture still produces null.
6. Parent-segment substitution — REPLACING applied to a parent record name propagates through `qualifiedNames` / `parentQualifiedNames`.
7. Renderer — Coverage `(N via REPLACING)` suffix conditional on R > 0.
8. Renderer — Shared-fields Field cell shows `Y (was X)` when `entry.replacing` set.
9. `normalizeLoadedFieldLineage` backfills `summary.deterministic.viaReplacing` to 0 for pre-#39 JSON.

## Out of scope

- Cross-group correlation (`CLIENT-ID` and `CUSTOMER-ID` entries are not linked as "the same underlying field via REPLACING"). The `replacing` evidence is the only breadcrumb.
- REPLACING applied to the root record name (qualified-path substitution handles intermediate segments; root-record renaming changes qualified-path semantics in a way that warrants its own design).
- Phase C: REPLACING-aware inferred matching (high / ambiguous / semantic tiers). Deferred — would let renamed fields cross-match without name evidence and blow up the precision contract.
- Fragment / partial-token substitution. `parseReplacingPairs` returns zero pairs for those shapes, so cohorts based on them collapse to singletons — same as Phase A.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/field-lineage.test.ts` — 77/77 (68 existing + 9 new)
- [x] `npx vitest run` — 3742/3742
- [x] `npx tsc --noEmit` — clean
- [x] Rendered eyeball confirmed: Coverage cell + Shared-fields table both show the expected format with mixed cohorts.
