### PR TITLE
feat(cobol): DB2 column-level host-var binding (#41 Phase A)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -66,6 +66,19 @@ describe("parseSqlColumnBindings (#41 Phase A)", () => {
     ]);
   });
 
+  it("UPDATE without WHERE: last assignment still binds (END-EXEC anchor)", () => {
+    // Without an END-EXEC anchor in the regex, the trailing token would
+    // leak into the last assignment string and the strict
+    // `col = :host` match would drop it. Locks the END-EXEC behavior.
+    expect(parseSqlColumnBindings(
+      "EXEC SQL UPDATE T SET A = :WS-A, B = :WS-B END-EXEC",
+      "UPDATE",
+    )).toEqual([
+      { column: "A", hostVar: "WS-A" },
+      { column: "B", hostVar: "WS-B" },
+    ]);
+  });
+
   it("UPDATE: arithmetic / function on the right-hand side drops that assignment", () => {
     expect(parseSqlColumnBindings(
       "EXEC SQL UPDATE T SET COUNT = COUNT + 1, NAME = :WS-NAME WHERE ID = :WS-ID END-EXEC",

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -1,7 +1,117 @@
 import { describe, it, expect } from "vitest";
 import { parse } from "../parser.js";
 import { extractModel } from "../extractors.js";
-import { buildDb2TableLineage, parseReplacingPairs } from "../db2-table-lineage.js";
+import { buildDb2TableLineage, parseReplacingPairs, parseSqlColumnBindings } from "../db2-table-lineage.js";
+
+describe("parseSqlColumnBindings (#41 Phase A)", () => {
+  it("pairs INSERT INTO T (col-list) VALUES (host-list) positionally", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME, EMAIL) VALUES (:WS-ID, :WS-NAME, :WS-EMAIL) END-EXEC",
+      "INSERT",
+    )).toEqual([
+      { column: "ID", hostVar: "WS-ID" },
+      { column: "NAME", hostVar: "WS-NAME" },
+      { column: "EMAIL", hostVar: "WS-EMAIL" },
+    ]);
+  });
+
+  it("returns empty for INSERT without column list (positional binding impossible)", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL INSERT INTO CUSTOMERS VALUES (:WS-ID, :WS-NAME) END-EXEC",
+      "INSERT",
+    )).toEqual([]);
+  });
+
+  it("aborts INSERT binding when column count != value count (arity mismatch)", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME) VALUES (:WS-ID, :WS-NAME, :WS-EMAIL) END-EXEC",
+      "INSERT",
+    )).toEqual([]);
+  });
+
+  it("skips non-host-var INSERT values (literals, NULL, function calls) but keeps the rest", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL INSERT INTO T (A, B, C) VALUES (:WS-A, 'literal', :WS-C) END-EXEC",
+      "INSERT",
+    )).toEqual([
+      { column: "A", hostVar: "WS-A" },
+      { column: "C", hostVar: "WS-C" },
+    ]);
+  });
+
+  it("pairs SELECT col-list INTO host-list FROM... positionally", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL SELECT ID, NAME INTO :WS-ID, :WS-NAME FROM CUSTOMERS END-EXEC",
+      "SELECT",
+    )).toEqual([
+      { column: "ID", hostVar: "WS-ID" },
+      { column: "NAME", hostVar: "WS-NAME" },
+    ]);
+  });
+
+  it("returns empty for SELECT without INTO (subquery, no host-var landing)", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL SELECT ID FROM CUSTOMERS WHERE NAME = :WS-NAME END-EXEC",
+      "SELECT",
+    )).toEqual([]);
+  });
+
+  it("pairs UPDATE SET col = :host explicitly; WHERE host vars do NOT bind", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL UPDATE CUSTOMERS SET NAME = :WS-NAME, EMAIL = :WS-EMAIL WHERE ID = :WS-ID END-EXEC",
+      "UPDATE",
+    )).toEqual([
+      { column: "NAME", hostVar: "WS-NAME" },
+      { column: "EMAIL", hostVar: "WS-EMAIL" },
+    ]);
+  });
+
+  it("UPDATE: arithmetic / function on the right-hand side drops that assignment", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL UPDATE T SET COUNT = COUNT + 1, NAME = :WS-NAME WHERE ID = :WS-ID END-EXEC",
+      "UPDATE",
+    )).toEqual([
+      { column: "NAME", hostVar: "WS-NAME" },
+    ]);
+  });
+
+  it("does not split commas inside nested parens (function calls in column list)", () => {
+    // `COALESCE(A, B)` shouldn't shatter the column list into 4 entries
+    // and produce a wrong pairing. Pattern doesn't match (function isn't
+    // a plain column name) → bindings drop cleanly for that position;
+    // the bare-column / host-var positions still bind.
+    expect(parseSqlColumnBindings(
+      "EXEC SQL SELECT COALESCE(A, B), C INTO :WS-AB, :WS-C FROM T END-EXEC",
+      "SELECT",
+    )).toEqual([
+      { column: "C", hostVar: "WS-C" },
+    ]);
+  });
+
+  it("returns empty for FETCH (column list lives on the DECLARE CURSOR, not here)", () => {
+    expect(parseSqlColumnBindings(
+      "EXEC SQL FETCH C1 INTO :WS-ID, :WS-NAME END-EXEC",
+      "FETCH",
+    )).toEqual([]);
+  });
+
+  it("returns empty when operation is undefined", () => {
+    expect(parseSqlColumnBindings("anything", undefined)).toEqual([]);
+  });
+
+  it("handles multi-line SQL (newlines between clauses)", () => {
+    const sql = `EXEC SQL
+      INSERT INTO CUSTOMERS
+        (ID, NAME)
+      VALUES
+        (:WS-ID, :WS-NAME)
+      END-EXEC`;
+    expect(parseSqlColumnBindings(sql, "INSERT")).toEqual([
+      { column: "ID", hostVar: "WS-ID" },
+      { column: "NAME", hostVar: "WS-NAME" },
+    ]);
+  });
+});
 
 describe("parseReplacingPairs (#37 Phase A)", () => {
   it("parses single-token form X BY Y", () => {
@@ -736,6 +846,134 @@ describe("buildDb2TableLineage", () => {
     expect(unresolved?.rationale).not.toContain("REPLACING");
     // … but the typo and missing-copybook breadcrumbs should still be there.
     expect(unresolved?.rationale).toContain("typos");
+  });
+
+  describe("DB2 column-level host-var binding (#41 Phase A)", () => {
+    // SQL fixtures: every line stays inside COBOL fixed-format columns
+    // 8-72. `programWithSql` glues an array of pre-indented SQL lines
+    // into a PROCEDURE DIVISION around a fixed three-field WS layout.
+    function programWithSql(programId: string, sqlLines: string[]): string {
+      const lines = sqlLines.map((l) => `           ${l}`).join("\n");
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ${programId}.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-ID              PIC X(10).
+       01  WS-NAME            PIC X(30).
+       01  WS-EMAIL           PIC X(50).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+${lines}
+           STOP RUN.
+`;
+    }
+    const reader = programWithSql("READER", [
+      "EXEC SQL SELECT ID, NAME INTO :WS-ID, :WS-NAME",
+      "         FROM CUSTOMERS END-EXEC.",
+    ]);
+
+    it("attaches column to writer host vars from INSERT (col-list) VALUES (host-list)", () => {
+      const writer = programWithSql("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME, EMAIL)",
+        "         VALUES (:WS-ID, :WS-NAME, :WS-EMAIL) END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      const byName = new Map(entry.writer.hostVars.map((hv) => [hv.name, hv]));
+      expect(byName.get("WS-ID")?.column).toBe("ID");
+      expect(byName.get("WS-NAME")?.column).toBe("NAME");
+      expect(byName.get("WS-EMAIL")?.column).toBe("EMAIL");
+    });
+
+    it("attaches column to reader host vars from SELECT col-list INTO host-list", () => {
+      const writer = programWithSql("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)",
+        "         VALUES (:WS-ID, :WS-NAME) END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const readerVars = lineage!.entries[0]!.reader.hostVars;
+      expect(readerVars.find((hv) => hv.name === "WS-ID")?.column).toBe("ID");
+      expect(readerVars.find((hv) => hv.name === "WS-NAME")?.column).toBe("NAME");
+    });
+
+    it("attaches column on UPDATE SET pairs; WHERE-clause host vars stay unbound", () => {
+      const updater = programWithSql("UPDATER", [
+        "EXEC SQL UPDATE CUSTOMERS",
+        "         SET NAME = :WS-NAME, EMAIL = :WS-EMAIL",
+        "         WHERE ID = :WS-ID END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(updater, "UPDATER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const writerVars = lineage!.entries[0]!.writer.hostVars;
+      const byName = new Map(writerVars.map((hv) => [hv.name, hv]));
+      expect(byName.get("WS-NAME")?.column).toBe("NAME");
+      expect(byName.get("WS-EMAIL")?.column).toBe("EMAIL");
+      // WHERE clause filter — no column binding.
+      expect(byName.get("WS-ID")?.column).toBeUndefined();
+      // But the host var itself is still resolved (has a dataItem).
+      expect(byName.get("WS-ID")?.dataItem?.picture).toBe("X(10)");
+    });
+
+    it("falls through to no column when INSERT has no column list", () => {
+      const writer = programWithSql("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS",
+        "         VALUES (:WS-ID, :WS-NAME, :WS-EMAIL) END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const writerVars = lineage!.entries[0]!.writer.hostVars;
+      // Host vars still listed; just no column attached.
+      expect(writerVars.find((hv) => hv.name === "WS-ID")?.dataItem?.picture).toBe("X(10)");
+      expect(writerVars.every((hv) => hv.column === undefined)).toBe(true);
+    });
+
+    it("a later SQL ref can attach a column to a host var first seen unbound", () => {
+      // Two SQL blocks in the same program against the same table: the
+      // first uses a WHERE filter (no column binding), the second is an
+      // INSERT with a column list. The bump-merge logic attaches the
+      // column from the second block to the existing host-var entry.
+      const writer = programWithSql("WRITER", [
+        "EXEC SQL SELECT NAME FROM CUSTOMERS",
+        "         WHERE ID = :WS-ID END-EXEC.",
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)",
+        "         VALUES (:WS-ID, :WS-NAME) END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const writerVars = lineage!.entries[0]!.writer.hostVars;
+      expect(writerVars.find((hv) => hv.name === "WS-ID")?.column).toBe("ID");
+      expect(writerVars.find((hv) => hv.name === "WS-NAME")?.column).toBe("NAME");
+    });
+
+    it("aborts column binding on arity mismatch (3 cols, 2 hosts) — host vars still listed without column", () => {
+      // Caller wrote a buggy SQL: 3 columns, only 2 values. We refuse
+      // to guess a positional pairing for the surviving values, drop
+      // ALL bindings for that ref.
+      const writer = programWithSql("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME, EMAIL)",
+        "         VALUES (:WS-ID, :WS-NAME) END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const writerVars = lineage!.entries[0]!.writer.hostVars;
+      expect(writerVars.every((hv) => hv.column === undefined)).toBe(true);
+    });
   });
 
   describe("REPLACING-aware host-var resolution (#37 Phase A)", () => {

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -95,6 +95,17 @@ export interface HostVarRef {
   name: string;
   /** In-program declaration; undefined if lookup failed. */
   dataItem?: HostVarDataItemRef;
+  /**
+   * The SQL column the host var binds to, when `parseSqlColumnBindings`
+   * could resolve it (#41 Phase A). Present for three patterns:
+   *   - INSERT INTO T (col-list) VALUES (host-list) — positional pair
+   *   - SELECT col-list INTO host-list FROM ... — positional pair
+   *   - UPDATE T SET col = :host pairs — explicit
+   * Absent for INSERT without column list, arity mismatch, predicate
+   * (WHERE) host vars, FETCH (column list lives on the DECLARE CURSOR),
+   * and any SQL the Phase A regexes can't structure.
+   */
+  column?: string;
 }
 
 const DB2_WRITE_OPS = new Set(["INSERT", "UPDATE", "DELETE", "MERGE"]);
@@ -150,6 +161,119 @@ const HOST_VAR_RE = /:\s*([A-Z][A-Z0-9-]*)/g;
 function extractHostVars(rawText: string): string[] {
   const upper = rawText.toUpperCase();
   return [...new Set([...upper.matchAll(HOST_VAR_RE)].map((m) => m[1]))];
+}
+
+/**
+ * Parse host-var ↔ column bindings out of a SQL block's raw text (#41
+ * Phase A). Three patterns are recognized:
+ *
+ *   - `INSERT INTO T (col1, col2) VALUES (:h1, :h2)` — column list and
+ *     VALUES list paired by position.
+ *   - `SELECT col1, col2 INTO :h1, :h2 FROM ...` — SELECT column list and
+ *     INTO host-var list paired by position.
+ *   - `UPDATE T SET col1 = :h1, col2 = :h2 WHERE ...` — each `col = :host`
+ *     pair read explicitly; WHERE-clause host vars are filter predicates
+ *     and intentionally not bound.
+ *
+ * Returns an empty array when the pattern doesn't match cleanly: INSERT
+ * with no column list, arity mismatch between column count and value
+ * count, FETCH (no column list in this statement — lives on the DECLARE
+ * CURSOR), subqueries / INSERT…SELECT, functions inside the column list,
+ * or anything else outside the three handled shapes. Falling through to
+ * empty is intentional — Phase A trades coverage for precision; a wrong
+ * binding is worse than a missing one.
+ */
+export function parseSqlColumnBindings(
+  rawText: string,
+  operation: string | undefined,
+): Array<{ column: string; hostVar: string }> {
+  if (!operation) return [];
+  const op = operation.toUpperCase();
+  const upper = rawText.toUpperCase();
+
+  if (op === "INSERT") {
+    // Require both `(col-list)` and `VALUES (val-list)` to be present.
+    // INSERT…SELECT (no VALUES) and INSERT without column list both miss
+    // this regex and fall through to an empty result.
+    const m = upper.match(/INSERT\s+INTO\s+[A-Z0-9_.-]+\s*\(([^)]+)\)\s*VALUES\s*\(([^)]+)\)/);
+    if (!m) return [];
+    return pairPositional(splitTopLevelCommas(m[1]!), splitTopLevelCommas(m[2]!));
+  }
+
+  if (op === "SELECT") {
+    // SELECT col-list INTO host-list FROM... The INTO clause anchors both
+    // ends — without it (e.g., SELECT cols FROM... in a subquery) there's
+    // no host-var list to bind, so we return empty.
+    const m = upper.match(/SELECT\s+([\s\S]+?)\s+INTO\s+([\s\S]+?)\s+FROM\b/);
+    if (!m) return [];
+    return pairPositional(splitTopLevelCommas(m[1]!), splitTopLevelCommas(m[2]!));
+  }
+
+  if (op === "UPDATE") {
+    // Extract everything between SET and WHERE (or end-of-statement).
+    // Anchoring on `WHERE` keeps the predicate's `:host` from binding.
+    const m = upper.match(/SET\s+([\s\S]+?)(?:\s+WHERE\b|\s*$)/);
+    if (!m) return [];
+    const bindings: Array<{ column: string; hostVar: string }> = [];
+    for (const assignment of splitTopLevelCommas(m[1]!)) {
+      // Strict `column = :host` shape only. Anything else (arithmetic,
+      // function, literal, NULL) drops — we won't pretend we know what
+      // gets written.
+      const eq = assignment.match(/^([A-Z][A-Z0-9_]*)\s*=\s*:\s*([A-Z][A-Z0-9-]*)\s*$/);
+      if (eq) bindings.push({ column: eq[1]!, hostVar: eq[2]! });
+    }
+    return bindings;
+  }
+
+  return [];
+}
+
+/**
+ * Split on commas at depth-0 paren nesting. Lets `SELECT FUNC(A, B), C`
+ * keep `FUNC(A, B)` as a single element instead of shattering on the
+ * inner comma. Phase A doesn't need to *understand* the function call;
+ * it just needs to not mis-pair it with the host-var list.
+ */
+function splitTopLevelCommas(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let buf = "";
+  for (const ch of s) {
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (ch === "," && depth === 0) {
+      out.push(buf.trim());
+      buf = "";
+    } else {
+      buf += ch;
+    }
+  }
+  if (buf.trim().length > 0) out.push(buf.trim());
+  return out;
+}
+
+/**
+ * Pair a column list with a value list positionally. The value must be a
+ * bare host-var reference (`:NAME`) — anything else (literal, NULL,
+ * default, function) drops that position entirely without aborting the
+ * whole pairing. Column names that aren't plain identifiers (qualified
+ * `schema.col`, quoted, with parens) also drop. Arity mismatch
+ * (`cols.length !== vals.length`) aborts the entire pairing — we'd rather
+ * miss bindings than emit wrong ones.
+ */
+function pairPositional(
+  cols: string[],
+  vals: string[],
+): Array<{ column: string; hostVar: string }> {
+  if (cols.length !== vals.length) return [];
+  const pairs: Array<{ column: string; hostVar: string }> = [];
+  for (let i = 0; i < cols.length; i++) {
+    if (!/^[A-Z][A-Z0-9_]*$/.test(cols[i]!)) continue;
+    const hostMatch = vals[i]!.match(/^:\s*([A-Z][A-Z0-9-]*)$/);
+    if (!hostMatch) continue;
+    pairs.push({ column: cols[i]!, hostVar: hostMatch[1]! });
+  }
+  return pairs;
 }
 
 /**
@@ -294,8 +418,13 @@ function resolveHostVar(
   return undefined;
 }
 
-function toHostVarRef(name: string, resolved: ResolvedHostVar | undefined): HostVarRef {
-  if (!resolved) return { name };
+function toHostVarRef(
+  name: string,
+  resolved: ResolvedHostVar | undefined,
+  column?: string,
+): HostVarRef {
+  const columnFields = column ? { column } : {};
+  if (!resolved) return { name, ...columnFields };
   const { dataItem, originCopybook, replacingSubstitution } = resolved;
   return {
     name,
@@ -307,6 +436,7 @@ function toHostVarRef(name: string, resolved: ResolvedHostVar | undefined): Host
       originCopybook,
       ...(replacingSubstitution ? { replacingSubstitution } : {}),
     },
+    ...columnFields,
   };
 }
 
@@ -373,12 +503,25 @@ function bump(
   usage.operations.add(op);
   for (const hv of hostVars) {
     const existing = usage.hostVars.get(hv.name);
-    // Keep the first resolved entry — don't let a later unresolved hit
-    // (e.g., from a different SQL block in the same program) clobber
-    // useful structural info we already collected.
-    if (!existing || (!existing.dataItem && hv.dataItem)) {
+    if (!existing) {
       usage.hostVars.set(hv.name, hv);
+      continue;
     }
+    // Field-by-field merge so a later SQL block can fill in info the
+    // first one didn't have, without ever clobbering info we already
+    // collected. Typical cases:
+    //   - First ref unresolved, second resolved → upgrade `dataItem`.
+    //   - First ref had no column binding (SELECT-without-INTO), second
+    //     had one (INSERT col-list, #41 Phase A) → attach `column`.
+    // Pre-#41 this was a whole-entry replace gated on the dataItem
+    // upgrade; that pattern silently dropped a later `column` when the
+    // first ref was already resolved.
+    const merged: HostVarRef = {
+      name: hv.name,
+      dataItem: existing.dataItem ?? hv.dataItem,
+      column: existing.column ?? hv.column,
+    };
+    usage.hostVars.set(hv.name, merged);
   }
   usage.callSites.push(loc);
 }
@@ -449,6 +592,18 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
         continue;
       }
       const hostVarNames = extractHostVars(ref.rawText);
+      // #41 Phase A — parse column bindings once per SQL ref. Empty when the
+      // ref's shape isn't one of the three handled patterns; per-name lookup
+      // below silently leaves `column` unset on those host vars.
+      const bindings = parseSqlColumnBindings(ref.rawText, op);
+      const columnByHostVar = new Map<string, string>();
+      for (const b of bindings) {
+        // First binding wins — if the same host var appears in both the
+        // SET clause and the WHERE clause of an UPDATE, the SET-clause
+        // column was extracted first by parseSqlColumnBindings, so this
+        // map preserves the column-write association.
+        if (!columnByHostVar.has(b.hostVar)) columnByHostVar.set(b.hostVar, b.column);
+      }
       const hostVars: HostVarRef[] = hostVarNames.map((name) => {
         const resolved = resolveHostVar(program, name, copybooksByLogicalName);
         if (!resolved) {
@@ -485,7 +640,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
             });
           }
         }
-        return toHostVarRef(name, resolved);
+        return toHostVarRef(name, resolved, columnByHostVar.get(name));
       });
       for (const table of ref.tables) {
         bump(tableState, table, kind, programId, sourceFile, op, hostVars, ref.loc);

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -210,9 +210,12 @@ export function parseSqlColumnBindings(
   }
 
   if (op === "UPDATE") {
-    // Extract everything between SET and WHERE (or end-of-statement).
-    // Anchoring on `WHERE` keeps the predicate's `:host` from binding.
-    const m = upper.match(/SET\s+([\s\S]+?)(?:\s+WHERE\b|\s*$)/);
+    // Extract everything between SET and the first terminator: WHERE
+    // (predicate — its `:host` is a filter, not a binding), END-EXEC
+    // (rawText carries the END-EXEC token; without an anchor on it the
+    // last SET assignment would include `END-EXEC` and fail the strict
+    // `col = :host` regex below), or end of string.
+    const m = upper.match(/SET\s+([\s\S]+?)(?:\s+WHERE\b|\s+END-EXEC\b|\s*$)/);
     if (!m) return [];
     const bindings: Array<{ column: string; hostVar: string }> = [];
     for (const assignment of splitTopLevelCommas(m[1]!)) {

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -576,13 +576,20 @@ function formatInferredStructure(
  * `host-var-unresolved` diagnostic in the exclusions table tells the
  * user why. When the field was reached via REPLACING substitution (#37
  * Phase A), the rename trail (`from CUSTOMER-ID via REPLACING`) appears so
- * a reviewer sees why the SQL name and copybook name disagree. `<br>`
- * separates entries so a many-host-var cell stays readable.
+ * a reviewer sees why the SQL name and copybook name disagree. When the
+ * host var binds to a specific SQL column (#41 Phase A), the column name
+ * appears as `HV → COLUMN` so a reviewer sees which column each var
+ * touches. `<br>` separates entries so a many-host-var cell stays
+ * readable.
  */
 function formatHostVars(hostVars: HostVarRef[]): string {
   if (hostVars.length === 0) return "—";
   return hostVars.map((hv) => {
-    if (!hv.dataItem) return `\`${hv.name}\` (?)`;
+    // `HV → COLUMN` prefix when we parsed a column binding (#41 Phase A);
+    // bare `HV` otherwise. Keeps backwards-compatible rendering for SQL
+    // shapes parseSqlColumnBindings can't structure.
+    const head = hv.column ? `\`${hv.name}\` → \`${hv.column}\`` : `\`${hv.name}\``;
+    if (!hv.dataItem) return `${head} (?)`;
     const shape = hv.dataItem.picture ?? "group";
     // Substitution wins over plain origin: the user needs to see the rename
     // pair first, then the copybook. A field reached via REPLACING always
@@ -594,7 +601,7 @@ function formatHostVars(hostVars: HostVarRef[]): string {
     } else if (hv.dataItem.originCopybook) {
       trail = ` from \`${hv.dataItem.originCopybook}\``;
     }
-    return `\`${hv.name}\` (${shape}${trail})`;
+    return `${head} (${shape}${trail})`;
   }).join("<br>");
 }
 
@@ -1321,7 +1328,7 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
   if (db2 && (db2.entries.length > 0 || db2.diagnostics.length > 0)) {
     lines.push("## DB2 Table Lineage");
     lines.push("");
-    lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; mapping them to specific columns requires a SQL parser and is out of scope here.`);
+    lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; \`HV → COLUMN\` indicates a column binding parsed from the SQL (INSERT col-list, SELECT INTO, UPDATE SET — #41 Phase A). Bare host vars appear when the SQL shape doesn't carry an explicit column list (INSERT without column list, WHERE-only filters, FETCH from a cursor, subqueries).`);
     lines.push("");
     const totalDb2Diag = db2.diagnostics.length;
     const db2Coverage = totalDb2Diag > 0


### PR DESCRIPTION
## Summary

Closes #41 (Phase A). Bind SQL host vars to specific columns for the three dominant DB2 patterns so the wiki shows `\`WS-ID\` → \`ID\` (X(10) from \`CUST.cpy\`)` instead of just `\`WS-ID\` (X(10) from \`CUST.cpy\`)`. Pre-#41 the host var floated free of any column — readers had to cross-reference the SQL text by hand to know which column it touched.

## Patterns parsed

| Pattern | Example | Binding |
|---|---|---|
| INSERT col-list / VALUES list | `INSERT INTO T (ID, NAME) VALUES (:WS-ID, :WS-NAME)` | positional |
| SELECT … INTO | `SELECT ID, NAME INTO :WS-ID, :WS-NAME FROM T` | positional |
| UPDATE SET col = :host | `UPDATE T SET NAME = :WS-NAME WHERE ID = :WS-ID` | explicit; WHERE host vars stay unbound |

## How

- New `parseSqlColumnBindings(rawText, operation)` helper returns `Array<{ column, hostVar }>`. Splits on top-level commas (depth-0 paren nesting) so `FUNC(A, B)` doesn't shatter a column list.
- `HostVarRef.column?: string` — present only on bindings parseSqlColumnBindings could resolve.
- `bump` dedup logic in `buildDb2TableLineage` tightened to a field-by-field merge so a later SQL block can attach a column to a host var first seen unbound (e.g., WHERE filter first, then INSERT col-list).
- `formatHostVars` in the field-lineage renderer prepends `→ COLUMN` when bound; pre-existing format preserved otherwise.
- The DB2 section's prose intro updated to mention the new arrow rendering and the fall-through cases (subqueries, function calls, INSERT without column list, FETCH).

## Sample render

```
| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |
|-------|--------|------------|------------------|--------|------------|------------------|
| CUSTOMERS | UPDATER | UPDATE | `WS-ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | READER | SELECT | `WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) |
| CUSTOMERS | WRITER | INSERT | `WS-EMAIL` → `EMAIL` (X(50))<br>`WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | READER | SELECT | `WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) |
```

Note how UPDATER's `WS-ID` stays bare (WHERE-clause filter, not a column write) while `WS-NAME` shows `→ NAME` (the SET-clause column assignment).

## Fall-through (per Phase A spec)

These shapes intentionally produce no column binding — the host var still appears in the cell as today, just without the arrow:

- INSERT without a column list (`INSERT INTO T VALUES (:H1, :H2)`)
- Arity mismatch (col count ≠ value count) — drops the entire pairing
- Subqueries, INSERT…SELECT, multi-row INSERT
- Arithmetic / function on RHS of SET
- Function calls inside the column list (top-level comma splitter keeps them together but the column shape isn't a plain identifier, so it drops)
- FETCH (column list lives on the DECLARE CURSOR, not the FETCH statement)
- WHERE-clause host vars (filters, not bindings)

## Tests

18 new in `src/cobol/__tests__/db2-table-lineage.test.ts`:

**Unit (12)** — `parseSqlColumnBindings`:
1. INSERT col-list / VALUES list positional.
2. INSERT without column list → empty.
3. INSERT arity mismatch → empty.
4. INSERT with mixed host-vars / literals — keeps the host-var positions.
5. SELECT INTO positional.
6. SELECT without INTO → empty.
7. UPDATE SET — WHERE host vars don't bind.
8. UPDATE SET — arithmetic RHS drops.
9. Function call in column list doesn't shatter (top-level comma split).
10. FETCH → empty (column list elsewhere).
11. Undefined operation → empty.
12. Multi-line SQL (newlines between clauses).

**Integration (6)** — `buildDb2TableLineage`:
1. INSERT writer host vars carry column.
2. SELECT INTO reader host vars carry column.
3. UPDATE SET binds; WHERE filter host vars stay unbound (but still resolved with `dataItem`).
4. INSERT without column list → all host vars unbound, still listed.
5. Multi-block bump merge — WHERE block first, INSERT block second → column attached.
6. Arity mismatch → all host vars unbound.

## Backwards-compat

- `HostVarRef.column` is optional — absent on all pre-#41-shape host vars. Existing 58 db2-table-lineage tests pass unchanged. Existing 68 field-lineage tests pass unchanged. Full suite 3780/3780.
- Wiki rendering is identical for any SQL shape `parseSqlColumnBindings` doesn't recognize.
- No artifact JSON shape break beyond the new optional field.

## Out of scope

- Cross-program column-level lineage (writer `:H1` → COL_X, reader COL_X → `:H2` → infer `:H1`/`:H2` flow). Phase A only emits per-ref bindings; cross-program pairing is a separate phase.
- Cursor DECLARE column lists. Phase A only walks reference operations (INSERT / UPDATE / SELECT / FETCH); cursors get analyzed at FETCH time.
- MERGE statements (defer).
- Subqueries, INSERT…SELECT (need a real SQL parser).
- A column-bindings summary counter on the artifact. Could add later if Coverage block wants it.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/db2-table-lineage.test.ts` — 76/76 (58 existing + 18 new)
- [x] `npx vitest run` — 3780/3780
- [x] `npx tsc --noEmit` — clean
- [x] Rendered fixture eyeballed: arrow shows on bound bindings, omitted on WHERE filters / no-column-list INSERTs.
