### PR TITLE
feat(cobol): DB2 cross-program column-level pairing (#41 Phase B)

### DIFF
--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -1214,8 +1214,11 @@ ${lines}
       ]);
       // Writer's :WR-ID carries both columns.
       const wrId = lineage!.entries[0]!.writer.hostVars.find((hv) => hv.name === "WR-ID");
-      expect(wrId?.columns).toEqual(["ALT_ID", "ID"]);
-      expect(wrId?.column).toBe("ALT_ID"); // alphabetically first → primary alias
+      expect(wrId?.columns).toEqual(["ALT_ID", "ID"]); // sorted for byte-stable artifact
+      // `column` is the #41 Phase A back-compat alias — first-observed
+      // in the SQL, not alphabetically first. INSERT lists ID before
+      // ALT_ID, so column === "ID".
+      expect(wrId?.column).toBe("ID");
       // The Phase B intersection now produces the ALT_ID flow that the
       // pre-fix code silently dropped.
       expect(lineage!.entries[0]!.columnPairs).toEqual([

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -989,6 +989,226 @@ ${lines}
     });
   });
 
+  describe("DB2 cross-program column-level pairing (#41 Phase B)", () => {
+    // Reuses the column-binding writer / reader shapes from Phase A.
+    // The new assertion target is `entry.columnPairs` — each pair
+    // asserts `writerHostVar → column → readerHostVar` cross-program
+    // flow when both sides bind the same column.
+    function makeWriter(programId: string, sql: string[]): string {
+      const lines = sql.map((l) => `           ${l}`).join("\n");
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ${programId}.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WR-ID              PIC X(10).
+       01  WR-NAME            PIC X(30).
+       01  WR-EMAIL           PIC X(50).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+${lines}
+           STOP RUN.
+`;
+    }
+    function makeReader(programId: string, sql: string[]): string {
+      const lines = sql.map((l) => `           ${l}`).join("\n");
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ${programId}.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  RD-ID              PIC X(10).
+       01  RD-NAME            PIC X(30).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+${lines}
+           STOP RUN.
+`;
+    }
+
+    it("emits a column pair per shared (writer-bound, reader-bound) column", () => {
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME, EMAIL)",
+        "         VALUES (:WR-ID, :WR-NAME, :WR-EMAIL) END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT ID, NAME INTO :RD-ID, :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      // EMAIL drops because the reader doesn't bind it; ID and NAME pair.
+      expect(entry.columnPairs).toEqual([
+        { column: "ID", writerHostVar: "WR-ID", readerHostVar: "RD-ID" },
+        { column: "NAME", writerHostVar: "WR-NAME", readerHostVar: "RD-NAME" },
+      ]);
+      expect(lineage!.summary.columnPairs).toBe(2);
+    });
+
+    it("emits no column pairs when one side has no column bindings", () => {
+      // Writer uses INSERT-without-column-list → no bindings on writer side.
+      // Reader's INTO bindings exist but can't intersect.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS",
+        "         VALUES (:WR-ID, :WR-NAME, :WR-EMAIL) END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT ID, NAME INTO :RD-ID, :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      expect(lineage!.entries[0]!.columnPairs).toEqual([]);
+      expect(lineage!.summary.columnPairs).toBe(0);
+    });
+
+    it("emits no column pairs when both sides bind but on disjoint columns", () => {
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID)",
+        "         VALUES (:WR-ID) END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT NAME INTO :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      expect(lineage!.entries[0]!.columnPairs).toEqual([]);
+    });
+
+    it("handles UPDATE writer + SELECT INTO reader (SET-clause columns only)", () => {
+      // The writer's WHERE clause binds :WR-ID against ID for filtering,
+      // not column-writing, so :WR-ID has no column. The SET pairs do
+      // bind. The reader's SELECT INTO binds both columns.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL UPDATE CUSTOMERS",
+        "         SET NAME = :WR-NAME, EMAIL = :WR-EMAIL",
+        "         WHERE ID = :WR-ID END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT NAME, EMAIL INTO :RD-NAME, :RD-EMAIL",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      // RD-EMAIL needs a declaration matching the reader fixture.
+      const reader2 = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. READER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  RD-NAME            PIC X(30).
+       01  RD-EMAIL           PIC X(50).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL SELECT NAME, EMAIL INTO :RD-NAME, :RD-EMAIL
+                    FROM CUSTOMERS END-EXEC.
+           STOP RUN.
+`;
+      // Ignore reader from the helper (didn't have RD-EMAIL), use reader2.
+      void reader;
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader2, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      // WR-ID drops (no column, WHERE filter); NAME and EMAIL pair.
+      expect(entry.columnPairs).toEqual([
+        { column: "EMAIL", writerHostVar: "WR-EMAIL", readerHostVar: "RD-EMAIL" },
+        { column: "NAME", writerHostVar: "WR-NAME", readerHostVar: "RD-NAME" },
+      ]);
+    });
+
+    it("Cartesian intersection emits one pair per (writer-side, reader-side) host var when both bind the same column", () => {
+      // Writer has two host vars binding NAME via different SQL refs:
+      // INSERT NAME = :WR-NAME and UPDATE SET NAME = :WR-EMAIL. The bump
+      // merge dedupes per-host-var-name (not per-column), so both
+      // bindings survive. The reader has one host var on NAME. The
+      // Cartesian intersection therefore emits two pairs — both writer
+      // host vars feed the same column that the reader receives from.
+      // This is the documented behavior; downstream dedup is the
+      // consumer's call.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (NAME)",
+        "         VALUES (:WR-NAME) END-EXEC.",
+        "EXEC SQL UPDATE CUSTOMERS SET NAME = :WR-EMAIL",
+        "         WHERE ID = '1' END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT NAME INTO :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const pairs = lineage!.entries[0]!.columnPairs;
+      // Two writer host vars × one reader host var on the same column → 2 pairs.
+      // Sorted by writerHostVar.
+      expect(pairs).toEqual([
+        { column: "NAME", writerHostVar: "WR-EMAIL", readerHostVar: "RD-NAME" },
+        { column: "NAME", writerHostVar: "WR-NAME", readerHostVar: "RD-NAME" },
+      ]);
+    });
+
+    it("regression: column pairs are deterministically sorted", () => {
+      // Two columns bound on both sides; the sort must be stable regardless
+      // of host-var iteration order. Lock against future Map / Set order
+      // changes by asserting full equality.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (NAME, ID)",
+        "         VALUES (:WR-NAME, :WR-ID) END-EXEC.",
+      ]);
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT NAME, ID INTO :RD-NAME, :RD-ID",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      // Sort key: column → writerHostVar → readerHostVar (alphabetical).
+      expect(lineage!.entries[0]!.columnPairs).toEqual([
+        { column: "ID", writerHostVar: "WR-ID", readerHostVar: "RD-ID" },
+        { column: "NAME", writerHostVar: "WR-NAME", readerHostVar: "RD-NAME" },
+      ]);
+    });
+
+    it("summary.columnPairs sums across multiple writer-reader entries", () => {
+      // One writer, two readers — produces two entries (one per writer-
+      // reader pair). Each entry contributes its own columnPairs; the
+      // summary counter is the sum.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, NAME)",
+        "         VALUES (:WR-ID, :WR-NAME) END-EXEC.",
+      ]);
+      const reader1 = makeReader("READER1", [
+        "EXEC SQL SELECT ID, NAME INTO :RD-ID, :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const reader2 = makeReader("READER2", [
+        "EXEC SQL SELECT NAME INTO :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader1, "READER1.cbl"),
+        model(reader2, "READER2.cbl"),
+      ]);
+      // Two entries: (WRITER, READER1) → 2 pairs, (WRITER, READER2) → 1 pair.
+      expect(lineage!.entries.length).toBe(2);
+      expect(lineage!.summary.columnPairs).toBe(3);
+    });
+  });
+
   describe("REPLACING-aware host-var resolution (#37 Phase A)", () => {
     const customerCopybook = `
        01  CUSTOMER-REC.

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -898,9 +898,9 @@ ${lines}
       ]);
       const entry = lineage!.entries[0]!;
       const byName = new Map(entry.writer.hostVars.map((hv) => [hv.name, hv]));
-      expect(byName.get("WS-ID")?.column).toBe("ID");
-      expect(byName.get("WS-NAME")?.column).toBe("NAME");
-      expect(byName.get("WS-EMAIL")?.column).toBe("EMAIL");
+      expect(byName.get("WS-ID")?.columns).toEqual(["ID"]);
+      expect(byName.get("WS-NAME")?.columns).toEqual(["NAME"]);
+      expect(byName.get("WS-EMAIL")?.columns).toEqual(["EMAIL"]);
     });
 
     it("attaches column to reader host vars from SELECT col-list INTO host-list", () => {
@@ -913,8 +913,8 @@ ${lines}
         model(reader, "READER.cbl"),
       ]);
       const readerVars = lineage!.entries[0]!.reader.hostVars;
-      expect(readerVars.find((hv) => hv.name === "WS-ID")?.column).toBe("ID");
-      expect(readerVars.find((hv) => hv.name === "WS-NAME")?.column).toBe("NAME");
+      expect(readerVars.find((hv) => hv.name === "WS-ID")?.columns).toEqual(["ID"]);
+      expect(readerVars.find((hv) => hv.name === "WS-NAME")?.columns).toEqual(["NAME"]);
     });
 
     it("attaches column on UPDATE SET pairs; WHERE-clause host vars stay unbound", () => {
@@ -929,9 +929,10 @@ ${lines}
       ]);
       const writerVars = lineage!.entries[0]!.writer.hostVars;
       const byName = new Map(writerVars.map((hv) => [hv.name, hv]));
-      expect(byName.get("WS-NAME")?.column).toBe("NAME");
-      expect(byName.get("WS-EMAIL")?.column).toBe("EMAIL");
+      expect(byName.get("WS-NAME")?.columns).toEqual(["NAME"]);
+      expect(byName.get("WS-EMAIL")?.columns).toEqual(["EMAIL"]);
       // WHERE clause filter — no column binding.
+      expect(byName.get("WS-ID")?.columns).toEqual([]);
       expect(byName.get("WS-ID")?.column).toBeUndefined();
       // But the host var itself is still resolved (has a dataItem).
       expect(byName.get("WS-ID")?.dataItem?.picture).toBe("X(10)");
@@ -949,7 +950,7 @@ ${lines}
       const writerVars = lineage!.entries[0]!.writer.hostVars;
       // Host vars still listed; just no column attached.
       expect(writerVars.find((hv) => hv.name === "WS-ID")?.dataItem?.picture).toBe("X(10)");
-      expect(writerVars.every((hv) => hv.column === undefined)).toBe(true);
+      expect(writerVars.every((hv) => hv.columns.length === 0)).toBe(true);
     });
 
     it("a later SQL ref can attach a column to a host var first seen unbound", () => {
@@ -968,8 +969,8 @@ ${lines}
         model(reader, "READER.cbl"),
       ]);
       const writerVars = lineage!.entries[0]!.writer.hostVars;
-      expect(writerVars.find((hv) => hv.name === "WS-ID")?.column).toBe("ID");
-      expect(writerVars.find((hv) => hv.name === "WS-NAME")?.column).toBe("NAME");
+      expect(writerVars.find((hv) => hv.name === "WS-ID")?.columns).toEqual(["ID"]);
+      expect(writerVars.find((hv) => hv.name === "WS-NAME")?.columns).toEqual(["NAME"]);
     });
 
     it("aborts column binding on arity mismatch (3 cols, 2 hosts) — host vars still listed without column", () => {
@@ -985,7 +986,7 @@ ${lines}
         model(reader, "READER.cbl"),
       ]);
       const writerVars = lineage!.entries[0]!.writer.hostVars;
-      expect(writerVars.every((hv) => hv.column === undefined)).toBe(true);
+      expect(writerVars.every((hv) => hv.columns.length === 0)).toBe(true);
     });
   });
 
@@ -1179,6 +1180,46 @@ ${lines}
       expect(lineage!.entries[0]!.columnPairs).toEqual([
         { column: "ID", writerHostVar: "WR-ID", readerHostVar: "RD-ID" },
         { column: "NAME", writerHostVar: "WR-NAME", readerHostVar: "RD-NAME" },
+      ]);
+    });
+
+    it("multi-column binding on a single host var: each column produces its own pair (Codex review fix)", () => {
+      // The Codex review on #43 caught that the pre-fix code stored only
+      // the first column per host var, silently dropping later bindings
+      // and the Phase B intersection along with them. Concrete case:
+      // INSERT binds :WR-ID to BOTH ID and ALT_ID; a reader selecting
+      // ALT_ID INTO :RD-ALT-ID must still pair through the second
+      // column.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO CUSTOMERS (ID, ALT_ID)",
+        "         VALUES (:WR-ID, :WR-ID) END-EXEC.",
+      ]);
+      const reader = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. READER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  RD-ID              PIC X(10).
+       01  RD-ALT-ID          PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL SELECT ALT_ID INTO :RD-ALT-ID
+                    FROM CUSTOMERS END-EXEC.
+           STOP RUN.
+`;
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      // Writer's :WR-ID carries both columns.
+      const wrId = lineage!.entries[0]!.writer.hostVars.find((hv) => hv.name === "WR-ID");
+      expect(wrId?.columns).toEqual(["ALT_ID", "ID"]);
+      expect(wrId?.column).toBe("ALT_ID"); // alphabetically first → primary alias
+      // The Phase B intersection now produces the ALT_ID flow that the
+      // pre-fix code silently dropped.
+      expect(lineage!.entries[0]!.columnPairs).toEqual([
+        { column: "ALT_ID", writerHostVar: "WR-ID", readerHostVar: "RD-ALT-ID" },
       ]);
     });
 

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -1267,6 +1267,46 @@ ${lines}
       expect(ordersEntry!.columnPairs).toEqual([]);
     });
 
+    it("unresolved host vars do not produce column-flow pairs (Codex review #3 fix)", () => {
+      // Writer references :WS-MISSING (not declared anywhere) but the
+      // SQL DOES bind it to NAME. Reader's :RD-NAME is fully resolved.
+      // Pre-fix Phase B emitted `WS-MISSING → NAME → RD-NAME` despite
+      // WS-MISSING already being diagnosed as host-var-unresolved.
+      // Now: unresolved host vars are gated out of `computeColumnPairs`
+      // (no dataItem → skipped), so the pair drops cleanly. The
+      // host-var-unresolved diagnostic still fires separately.
+      const writer = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. WRITER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WR-OTHER           PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL INSERT INTO CUSTOMERS (NAME)
+                    VALUES (:WS-MISSING) END-EXEC.
+           STOP RUN.
+`;
+      const reader = makeReader("READER", [
+        "EXEC SQL SELECT NAME INTO :RD-NAME",
+        "         FROM CUSTOMERS END-EXEC.",
+      ]);
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      // The unresolved host var is still in the writer's hostVars list
+      // (with empty dataItem) so the cell can render `(?)`, but the
+      // column-flow intersection skips it.
+      expect(entry.columnPairs).toEqual([]);
+      // And the host-var-unresolved diagnostic is intact.
+      expect(lineage!.diagnostics.some(
+        (d) => d.kind === "host-var-unresolved" && d.hostVar === "WS-MISSING",
+      )).toBe(true);
+    });
+
     it("summary.columnPairs sums across multiple writer-reader entries", () => {
       // One writer, two readers — produces two entries (one per writer-
       // reader pair). Each entry contributes its own columnPairs; the

--- a/src/cobol/__tests__/db2-table-lineage.test.ts
+++ b/src/cobol/__tests__/db2-table-lineage.test.ts
@@ -1223,6 +1223,47 @@ ${lines}
       ]);
     });
 
+    it("multi-table SQL refs skip column binding to avoid false cross-table pairs (Codex review fix)", () => {
+      // The Codex review on #43 caught that a SELECT touching multiple
+      // tables (via subqueries, joins, or WHERE EXISTS) had the same
+      // column bindings attached to every table — so a writer to T2
+      // would falsely pair through a reader that actually reads from
+      // T1. Fix: when ref.tables.length > 1, parseSqlColumnBindings is
+      // skipped and no host var carries a column. The Phase B
+      // intersection therefore emits no false pairs.
+      const writer = makeWriter("WRITER", [
+        "EXEC SQL INSERT INTO ORDERS (ID)",
+        "         VALUES (:WR-ID) END-EXEC.",
+      ]);
+      // Reader's SELECT mentions both ORDERS (FROM) and CUSTOMERS
+      // (in a subquery). extractSqlTableNames returns both tables.
+      const reader = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. READER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  RD-ID              PIC X(10).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           EXEC SQL SELECT ID INTO :RD-ID FROM CUSTOMERS
+                    WHERE ID IN (SELECT CUST_ID FROM ORDERS) END-EXEC.
+           STOP RUN.
+`;
+      const lineage = buildDb2TableLineage([
+        model(writer, "WRITER.cbl"),
+        model(reader, "READER.cbl"),
+      ]);
+      // ORDERS is the shared table → entry exists.
+      const ordersEntry = lineage!.entries.find((e) => e.table === "ORDERS");
+      expect(ordersEntry).toBeDefined();
+      // Reader's :RD-ID has NO column binding because the multi-table
+      // ref triggered the guard. So no false pair through ORDERS.ID.
+      const rdId = ordersEntry!.reader.hostVars.find((hv) => hv.name === "RD-ID");
+      expect(rdId?.columns).toEqual([]);
+      expect(ordersEntry!.columnPairs).toEqual([]);
+    });
+
     it("summary.columnPairs sums across multiple writer-reader entries", () => {
       // One writer, two readers — produces two entries (one per writer-
       // reader pair). Each entry contributes its own columnPairs; the

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -96,14 +96,23 @@ export interface HostVarRef {
   /** In-program declaration; undefined if lookup failed. */
   dataItem?: HostVarDataItemRef;
   /**
-   * The SQL column the host var binds to, when `parseSqlColumnBindings`
-   * could resolve it (#41 Phase A). Present for three patterns:
-   *   - INSERT INTO T (col-list) VALUES (host-list) — positional pair
-   *   - SELECT col-list INTO host-list FROM ... — positional pair
-   *   - UPDATE T SET col = :host pairs — explicit
-   * Absent for INSERT without column list, arity mismatch, predicate
-   * (WHERE) host vars, FETCH (column list lives on the DECLARE CURSOR),
-   * and any SQL the Phase A regexes can't structure.
+   * Canonical column-binding list (#41 Phase B). The full set of SQL
+   * columns this host var binds to, across every SQL ref in the
+   * program. Empty when the SQL shape carried no parseable column
+   * info (INSERT without column list, FETCH, etc.).
+   *
+   * Multi-binding is uncommon-but-real: `INSERT INTO T (ID, ALT_ID)
+   * VALUES (:WR-ID, :WR-ID)` binds `:WR-ID` to both `ID` and `ALT_ID`,
+   * and a later SELECT reading `ALT_ID INTO :RD-ALT-ID` should still
+   * pair the WR-ID write through `ALT_ID`. Storing only the first
+   * column (the pre-Phase-B shape) silently dropped that flow.
+   * Sorted ascending for byte-stable artifact output.
+   */
+  columns: string[];
+  /**
+   * Convenience alias for `columns[0]` — preserved as the public
+   * single-binding handle from #41 Phase A so external consumers
+   * reading `column` keep working. Absent when `columns` is empty.
    */
   column?: string;
 }
@@ -459,9 +468,15 @@ function resolveHostVar(
 function toHostVarRef(
   name: string,
   resolved: ResolvedHostVar | undefined,
-  column?: string,
+  columns: string[],
 ): HostVarRef {
-  const columnFields = column ? { column } : {};
+  // `column` is a convenience alias for `columns[0]` — present whenever
+  // any column is bound, so external consumers from #41 Phase A keep
+  // working with the singular handle.
+  const sortedColumns = [...columns].sort((a, b) => a.localeCompare(b));
+  const columnFields = sortedColumns.length > 0
+    ? { columns: sortedColumns, column: sortedColumns[0]! }
+    : { columns: sortedColumns };
   if (!resolved) return { name, ...columnFields };
   const { dataItem, originCopybook, replacingSubstitution } = resolved;
   return {
@@ -546,18 +561,19 @@ function bump(
       continue;
     }
     // Field-by-field merge so a later SQL block can fill in info the
-    // first one didn't have, without ever clobbering info we already
-    // collected. Typical cases:
-    //   - First ref unresolved, second resolved → upgrade `dataItem`.
-    //   - First ref had no column binding (SELECT-without-INTO), second
-    //     had one (INSERT col-list, #41 Phase A) → attach `column`.
-    // Pre-#41 this was a whole-entry replace gated on the dataItem
-    // upgrade; that pattern silently dropped a later `column` when the
-    // first ref was already resolved.
+    // first one didn't have. `dataItem` keeps first-resolved (refs
+    // typically agree); `columns` UNIONS across refs so a host var
+    // bound to ID in one SQL and ALT_ID in another carries both
+    // (#41 Phase B fix — pre-merge versions only kept the first
+    // column, silently dropping later bindings and the Phase B
+    // intersection along with them).
+    const mergedColumns = [...new Set([...existing.columns, ...hv.columns])]
+      .sort((a, b) => a.localeCompare(b));
     const merged: HostVarRef = {
       name: hv.name,
       dataItem: existing.dataItem ?? hv.dataItem,
-      column: existing.column ?? hv.column,
+      columns: mergedColumns,
+      ...(mergedColumns.length > 0 ? { column: mergedColumns[0]! } : {}),
     };
     usage.hostVars.set(hv.name, merged);
   }
@@ -596,24 +612,32 @@ function computeColumnPairs(
   writer: Db2LineageParticipant,
   reader: Db2LineageParticipant,
 ): Db2ColumnPair[] {
+  // Index readers by every column they bind, not just `column` — a single
+  // SELECT INTO might land the same host var into multiple columns of a
+  // joined result. The Codex review on #43 caught the symmetric writer-
+  // side case (`INSERT INTO T (ID, ALT_ID) VALUES (:WR-ID, :WR-ID)`);
+  // honoring multi-binding on the reader side too keeps the data model
+  // symmetric.
   const readersByColumn = new Map<string, HostVarRef[]>();
   for (const rhv of reader.hostVars) {
-    if (!rhv.column) continue;
-    const list = readersByColumn.get(rhv.column) ?? [];
-    list.push(rhv);
-    readersByColumn.set(rhv.column, list);
+    for (const col of rhv.columns) {
+      const list = readersByColumn.get(col) ?? [];
+      list.push(rhv);
+      readersByColumn.set(col, list);
+    }
   }
   const pairs: Db2ColumnPair[] = [];
   for (const whv of writer.hostVars) {
-    if (!whv.column) continue;
-    const readers = readersByColumn.get(whv.column);
-    if (!readers) continue;
-    for (const rhv of readers) {
-      pairs.push({
-        column: whv.column,
-        writerHostVar: whv.name,
-        readerHostVar: rhv.name,
-      });
+    for (const col of whv.columns) {
+      const readers = readersByColumn.get(col);
+      if (!readers) continue;
+      for (const rhv of readers) {
+        pairs.push({
+          column: col,
+          writerHostVar: whv.name,
+          readerHostVar: rhv.name,
+        });
+      }
     }
   }
   return pairs.sort((a, b) =>
@@ -679,17 +703,18 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
         continue;
       }
       const hostVarNames = extractHostVars(ref.rawText);
-      // #41 Phase A — parse column bindings once per SQL ref. Empty when the
-      // ref's shape isn't one of the three handled patterns; per-name lookup
-      // below silently leaves `column` unset on those host vars.
+      // #41 Phase A/B — parse column bindings once per SQL ref. Empty when
+      // the ref's shape isn't one of the three handled patterns. Multi-
+      // binding (one host var bound to multiple columns in the same SQL,
+      // e.g. `INSERT INTO T (ID, ALT_ID) VALUES (:WR-ID, :WR-ID)`) is
+      // captured as a list per host var — the bump-merge below unions
+      // these across all of the program's refs.
       const bindings = parseSqlColumnBindings(ref.rawText, op);
-      const columnByHostVar = new Map<string, string>();
+      const columnsByHostVar = new Map<string, string[]>();
       for (const b of bindings) {
-        // First binding wins — if the same host var appears in both the
-        // SET clause and the WHERE clause of an UPDATE, the SET-clause
-        // column was extracted first by parseSqlColumnBindings, so this
-        // map preserves the column-write association.
-        if (!columnByHostVar.has(b.hostVar)) columnByHostVar.set(b.hostVar, b.column);
+        const list = columnsByHostVar.get(b.hostVar) ?? [];
+        if (!list.includes(b.column)) list.push(b.column);
+        columnsByHostVar.set(b.hostVar, list);
       }
       const hostVars: HostVarRef[] = hostVarNames.map((name) => {
         const resolved = resolveHostVar(program, name, copybooksByLogicalName);
@@ -727,7 +752,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
             });
           }
         }
-        return toHostVarRef(name, resolved, columnByHostVar.get(name));
+        return toHostVarRef(name, resolved, columnsByHostVar.get(name) ?? []);
       });
       for (const table of ref.tables) {
         bump(tableState, table, kind, programId, sourceFile, op, hostVars, ref.loc);

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -709,7 +709,18 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
       // e.g. `INSERT INTO T (ID, ALT_ID) VALUES (:WR-ID, :WR-ID)`) is
       // captured as a list per host var — the bump-merge below unions
       // these across all of the program's refs.
-      const bindings = parseSqlColumnBindings(ref.rawText, op);
+      //
+      // **Multi-table guard** (Codex review on #43): when the ref touches
+      // more than one table (subqueries, JOINs, UPDATE … WHERE EXISTS …),
+      // we can't safely attribute a parsed column to one specific table —
+      // attaching the same column to every table would let the Phase B
+      // intersection emit false pairs (e.g., a SELECT FROM T1 picking up
+      // T2 via a WHERE EXISTS subquery would also mark host vars as
+      // reading T2's column). Skip column binding entirely on those refs;
+      // table-scoping the bindings is bigger Phase C work.
+      const bindings = ref.tables.length === 1
+        ? parseSqlColumnBindings(ref.rawText, op)
+        : [];
       const columnsByHostVar = new Map<string, string[]>();
       for (const b of bindings) {
         const list = columnsByHostVar.get(b.hostVar) ?? [];

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -134,6 +134,25 @@ export interface Db2LineageEvidence {
   readerOps: string[];
 }
 
+/**
+ * Cross-program column-level pairing (#41 Phase B). When both the writer
+ * and the reader carry a column binding (from Phase A) for the *same*
+ * SQL column, this triple asserts that the value flows
+ * `writerHostVar → column → readerHostVar` across the program pair.
+ *
+ * Asymmetric host-var directionality is implicit in the operations on
+ * each side: the writer's `column = :HV` in INSERT/UPDATE writes the
+ * host var into the column; the reader's `column INTO :HV` in
+ * SELECT/FETCH reads the column into the host var. The structural
+ * intersection of the two `column` fields proves the through-flow
+ * without needing a SQL parser to argue about it.
+ */
+export interface Db2ColumnPair {
+  column: string;
+  writerHostVar: string;
+  readerHostVar: string;
+}
+
 export interface SerializedDb2LineageEntry {
   confidence: Db2LineageConfidence;
   table: string;
@@ -143,6 +162,15 @@ export interface SerializedDb2LineageEntry {
   evidence: Db2LineageEvidence;
   /** Language-agnostic envelope; consumers branch on `confidence` / `abstain`. */
   envelope: EvidenceEnvelope;
+  /**
+   * Cross-program column-level pairings (#41 Phase B). Computed by
+   * intersecting writer and reader host vars on their `column` field
+   * (both sides have to carry a Phase-A column binding for a pair to
+   * emit). Empty when one or both sides have no column bindings —
+   * common for INSERT-without-column-list, cursor-based FETCH, and any
+   * SQL the Phase A regexes can't structure.
+   */
+  columnPairs: Db2ColumnPair[];
   rationale: string;
 }
 
@@ -150,6 +178,13 @@ export interface Db2Lineage {
   summary: {
     sharedTables: number;
     pairs: number;
+    /**
+     * Total cross-program column pairings across all entries (#41 Phase B).
+     * Sum of `entries[i].columnPairs.length`. Surfaced separately so the
+     * Coverage block / evidence dashboard can show write-read column depth
+     * without walking entries.
+     */
+    columnPairs: number;
     diagnosticsByKind: Record<Db2LineageDiagnosticKind, number>;
   };
   entries: SerializedDb2LineageEntry[];
@@ -539,6 +574,55 @@ function toParticipant(usage: ProgramTableUsage): Db2LineageParticipant {
   };
 }
 
+/**
+ * Intersect writer and reader host vars on their `column` field to emit
+ * cross-program column-level pairings (#41 Phase B). Only host vars that
+ * carry a Phase-A `column` binding participate; bare host vars (unbound)
+ * never produce a pair.
+ *
+ * Output is deterministically sorted by column, then writer host var,
+ * then reader host var — keeps the artifact byte-stable across rebuilds
+ * regardless of the order writer/reader hostVars were merged into the
+ * usage map.
+ *
+ * The Cartesian intersection per column captures the (rare-but-real)
+ * case where one side binds the same column from multiple host vars —
+ * e.g., an UPDATE that writes the column then re-reads it via a
+ * SELECT...INTO in the same program. We emit every legitimate pair so
+ * the reviewer sees the full graph; downstream dedup is the consumer's
+ * call.
+ */
+function computeColumnPairs(
+  writer: Db2LineageParticipant,
+  reader: Db2LineageParticipant,
+): Db2ColumnPair[] {
+  const readersByColumn = new Map<string, HostVarRef[]>();
+  for (const rhv of reader.hostVars) {
+    if (!rhv.column) continue;
+    const list = readersByColumn.get(rhv.column) ?? [];
+    list.push(rhv);
+    readersByColumn.set(rhv.column, list);
+  }
+  const pairs: Db2ColumnPair[] = [];
+  for (const whv of writer.hostVars) {
+    if (!whv.column) continue;
+    const readers = readersByColumn.get(whv.column);
+    if (!readers) continue;
+    for (const rhv of readers) {
+      pairs.push({
+        column: whv.column,
+        writerHostVar: whv.name,
+        readerHostVar: rhv.name,
+      });
+    }
+  }
+  return pairs.sort((a, b) =>
+    a.column.localeCompare(b.column)
+    || a.writerHostVar.localeCompare(b.writerHostVar)
+    || a.readerHostVar.localeCompare(b.readerHostVar),
+  );
+}
+
 export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | null {
   const programs = models.filter((m) => !isCopybook(m.sourceFile));
   if (programs.length < 2) return null;
@@ -694,6 +778,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
         }
         const writerParticipant = toParticipant(writer);
         const readerParticipant = toParticipant(reader);
+        const columnPairs = computeColumnPairs(writerParticipant, readerParticipant);
         const rationale =
           `${writerParticipant.programId.replace("program:", "")} writes to ${table} via ${writerParticipant.operations.join(",")}; `
           + `${readerParticipant.programId.replace("program:", "")} reads from ${table} via ${readerParticipant.operations.join(",")}.`;
@@ -718,6 +803,7 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
               { raw: readerParticipant.sourceFile },
             ],
           },
+          columnPairs,
           rationale,
         });
       }
@@ -742,7 +828,12 @@ export function buildDb2TableLineage(models: CobolCodeModel[]): Db2Lineage | nul
   for (const d of diagnostics) diagnosticsByKind[d.kind]++;
 
   return {
-    summary: { sharedTables, pairs: entries.length, diagnosticsByKind },
+    summary: {
+      sharedTables,
+      pairs: entries.length,
+      columnPairs: entries.reduce((sum, e) => sum + e.columnPairs.length, 0),
+      diagnosticsByKind,
+    },
     entries,
     diagnostics,
   };

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -626,8 +626,16 @@ function computeColumnPairs(
   // side case (`INSERT INTO T (ID, ALT_ID) VALUES (:WR-ID, :WR-ID)`);
   // honoring multi-binding on the reader side too keeps the data model
   // symmetric.
+  //
+  // Skip host vars whose program-side `dataItem` lookup failed — they're
+  // already in the `host-var-unresolved` diagnostic stream and emitting
+  // a confident-looking column flow alongside contradicts the signal
+  // (Codex review #3 on #43). A reviewer seeing `WS-MISSING → NAME →
+  // WS-NAME` would assume the trace is solid; the matching `(?)` in the
+  // host-var cell is a weaker contradiction than dropping the pair.
   const readersByColumn = new Map<string, HostVarRef[]>();
   for (const rhv of reader.hostVars) {
+    if (!rhv.dataItem) continue;
     for (const col of rhv.columns) {
       const list = readersByColumn.get(col) ?? [];
       list.push(rhv);
@@ -636,6 +644,7 @@ function computeColumnPairs(
   }
   const pairs: Db2ColumnPair[] = [];
   for (const whv of writer.hostVars) {
+    if (!whv.dataItem) continue;
     for (const col of whv.columns) {
       const readers = readersByColumn.get(col);
       if (!readers) continue;

--- a/src/cobol/db2-table-lineage.ts
+++ b/src/cobol/db2-table-lineage.ts
@@ -470,12 +470,17 @@ function toHostVarRef(
   resolved: ResolvedHostVar | undefined,
   columns: string[],
 ): HostVarRef {
-  // `column` is a convenience alias for `columns[0]` — present whenever
-  // any column is bound, so external consumers from #41 Phase A keep
-  // working with the singular handle.
+  // `columns` is sorted for byte-stable artifact output, but `column`
+  // (the #41 Phase A back-compat alias) MUST be the first-observed
+  // binding to match Phase A's "first column from the SQL" semantics.
+  // For `INSERT INTO T (ID, ALT_ID) VALUES (:H, :H)` Phase A read
+  // `column === "ID"`; sorting flipped that to `"ALT_ID"` and silently
+  // broke external consumers reading the singular handle. Decouple the
+  // two: insertion-order [0] for `column`, sorted for `columns`.
   const sortedColumns = [...columns].sort((a, b) => a.localeCompare(b));
-  const columnFields = sortedColumns.length > 0
-    ? { columns: sortedColumns, column: sortedColumns[0]! }
+  const firstObserved = columns[0];
+  const columnFields = columns.length > 0 && firstObserved
+    ? { columns: sortedColumns, column: firstObserved }
     : { columns: sortedColumns };
   if (!resolved) return { name, ...columnFields };
   const { dataItem, originCopybook, replacingSubstitution } = resolved;
@@ -566,14 +571,17 @@ function bump(
     // bound to ID in one SQL and ALT_ID in another carries both
     // (#41 Phase B fix — pre-merge versions only kept the first
     // column, silently dropping later bindings and the Phase B
-    // intersection along with them).
+    // intersection along with them). `column` follows first-observed
+    // (existing wins over hv) to preserve the #41 Phase A back-compat
+    // alias semantics across cross-ref merges.
     const mergedColumns = [...new Set([...existing.columns, ...hv.columns])]
       .sort((a, b) => a.localeCompare(b));
+    const firstObservedColumn = existing.column ?? hv.column;
     const merged: HostVarRef = {
       name: hv.name,
       dataItem: existing.dataItem ?? hv.dataItem,
       columns: mergedColumns,
-      ...(mergedColumns.length > 0 ? { column: mergedColumns[0]! } : {}),
+      ...(firstObservedColumn ? { column: firstObservedColumn } : {}),
     };
     usage.hostVars.set(hv.name, merged);
   }

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -597,10 +597,16 @@ function formatColumnPairs(pairs: Db2ColumnPair[]): string {
 function formatHostVars(hostVars: HostVarRef[]): string {
   if (hostVars.length === 0) return "—";
   return hostVars.map((hv) => {
-    // `HV → COLUMN` prefix when we parsed a column binding (#41 Phase A);
-    // bare `HV` otherwise. Keeps backwards-compatible rendering for SQL
-    // shapes parseSqlColumnBindings can't structure.
-    const head = hv.column ? `\`${hv.name}\` → \`${hv.column}\`` : `\`${hv.name}\``;
+    // `HV → COLUMN[, COL2...]` prefix when we parsed column binding(s)
+    // (#41 Phase A/B). Multi-column binding renders comma-separated so
+    // the cell stays single-line even when one host var feeds several
+    // columns (`INSERT INTO T (ID, ALT_ID) VALUES (:WR-ID, :WR-ID)`).
+    // Bare `HV` when columns is empty — keeps backwards-compatible
+    // rendering for SQL shapes parseSqlColumnBindings can't structure.
+    const cols = hv.columns ?? (hv.column ? [hv.column] : []);
+    const head = cols.length > 0
+      ? `\`${hv.name}\` → ${cols.map((c) => `\`${c}\``).join(", ")}`
+      : `\`${hv.name}\``;
     if (!hv.dataItem) return `${head} (?)`;
     const shape = hv.dataItem.picture ?? "group";
     // Substitution wins over plain origin: the user needs to see the rename

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -2,7 +2,7 @@ import type { CobolCodeModel } from "./extractors.js";
 import type { DataItemNode, SourceLocation } from "./types.js";
 import { resolveCanonicalId, displayLabel, normalizeCopybookName } from "./graph.js";
 import type { CallBoundLineage, SerializedCallBoundLineageEntry } from "./call-boundary-lineage.js";
-import { parseReplacingPairs, type Db2Lineage, type HostVarRef } from "./db2-table-lineage.js";
+import { parseReplacingPairs, type Db2ColumnPair, type Db2Lineage, type HostVarRef } from "./db2-table-lineage.js";
 
 /**
  * Linkage tier on a deterministic shared-copybook entry.
@@ -582,6 +582,18 @@ function formatInferredStructure(
  * touches. `<br>` separates entries so a many-host-var cell stays
  * readable.
  */
+/**
+ * Render the Column Flow cell of the DB2 lineage table (#41 Phase B).
+ * One line per cross-program column pair, format
+ * `:writer-host → COLUMN → :reader-host`. Cell renders `—` when no
+ * pairs — preserves the visual spacing of pre-Phase-B output for any
+ * row where one or both sides have no column bindings.
+ */
+function formatColumnPairs(pairs: Db2ColumnPair[]): string {
+  if (pairs.length === 0) return "—";
+  return pairs.map((p) => `\`${p.writerHostVar}\` → \`${p.column}\` → \`${p.readerHostVar}\``).join("<br>");
+}
+
 function formatHostVars(hostVars: HostVarRef[]): string {
   if (hostVars.length === 0) return "—";
   return hostVars.map((hv) => {
@@ -1328,22 +1340,30 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
   if (db2 && (db2.entries.length > 0 || db2.diagnostics.length > 0)) {
     lines.push("## DB2 Table Lineage");
     lines.push("");
-    lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; \`HV → COLUMN\` indicates a column binding parsed from the SQL (INSERT col-list, SELECT INTO, UPDATE SET — #41 Phase A). Bare host vars appear when the SQL shape doesn't carry an explicit column list (INSERT without column list, WHERE-only filters, FETCH from a cursor, subqueries).`);
+    lines.push(`Cross-program field flow inferred from shared DB2 tables. A pair appears when one program writes to a table (\`INSERT\` / \`UPDATE\` / \`DELETE\` / \`MERGE\`) and another reads from it (\`SELECT\` / \`FETCH\`). Host variables on each side are listed; \`HV → COLUMN\` indicates a column binding parsed from the SQL (INSERT col-list, SELECT INTO, UPDATE SET — #41 Phase A). When the writer and the reader both bind the *same* column, the "Column Flow" cell shows the through-flow \`:writer-host → COLUMN → :reader-host\` (#41 Phase B). Bare host vars appear when the SQL shape doesn't carry an explicit column list (INSERT without column list, WHERE-only filters, FETCH from a cursor, subqueries).`);
     lines.push("");
     const totalDb2Diag = db2.diagnostics.length;
+    // Coverage line extended with column-pair depth (#41 Phase B). The
+    // suffix is conditional so byte-identical output is preserved for
+    // pre-Phase-B fixtures where no column bindings exist on either side.
+    const totalColumnPairs = db2.summary.columnPairs ?? 0;
+    const columnSuffix = totalColumnPairs > 0
+      ? `, ${totalColumnPairs} column pair(s)`
+      : "";
     const db2Coverage = totalDb2Diag > 0
-      ? `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s); ${totalDb2Diag} excluded — see below.`
-      : `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s).`;
+      ? `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s)${columnSuffix}; ${totalDb2Diag} excluded — see below.`
+      : `Coverage: ${db2.summary.sharedTables} shared table(s), ${db2.entries.length} writer→reader pair(s)${columnSuffix}.`;
     lines.push(db2Coverage);
     lines.push("");
     if (db2.entries.length > 0) {
-      lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars |");
-      lines.push("|-------|--------|------------|------------------|--------|------------|------------------|");
+      lines.push("| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars | Column Flow |");
+      lines.push("|-------|--------|------------|------------------|--------|------------|------------------|-------------|");
       for (const entry of db2.entries) {
         const writerVars = formatHostVars(entry.writer.hostVars);
         const readerVars = formatHostVars(entry.reader.hostVars);
+        const columnFlow = formatColumnPairs(entry.columnPairs ?? []);
         lines.push(
-          `| ${entry.table} | ${displayLabel(entry.writer.programId)} | ${entry.writer.operations.join(", ")} | ${writerVars} | ${displayLabel(entry.reader.programId)} | ${entry.reader.operations.join(", ")} | ${readerVars} |`
+          `| ${entry.table} | ${displayLabel(entry.writer.programId)} | ${entry.writer.operations.join(", ")} | ${writerVars} | ${displayLabel(entry.reader.programId)} | ${entry.reader.operations.join(", ")} | ${readerVars} | ${columnFlow} |`
         );
       }
       lines.push("");


### PR DESCRIPTION
## Summary

Phase B follow-up to #41. Closes the loop on DB2 column-level lineage: when the writer and the reader **both** carry a Phase-A column binding for the **same** SQL column, the artifact + wiki now emit a cross-program pair `writerHostVar → column → readerHostVar`. The user reading the wiki sees end-to-end column flow without manually correlating both sides' cells.

## How

1. New `Db2ColumnPair { column, writerHostVar, readerHostVar }` type.
2. `SerializedDb2LineageEntry.columnPairs: Db2ColumnPair[]` — sorted by column → writerHostVar → readerHostVar.
3. `Db2Lineage.summary.columnPairs` — total pair count across all entries; surfaced in the DB2 Coverage line.
4. `computeColumnPairs(writer, reader)` intersects `hostVars` on the `column` field. Bare host vars (no Phase-A column) never enter the intersection. Cartesian-on-collision is intentional: when two writer host vars legitimately bind the same column (`INSERT NAME=:A` plus `UPDATE SET NAME=:B`), the intersection emits one pair per (writer-side, reader-side) host var.
5. Renderer: new **Column Flow** column on the DB2 table; cell renders `` `:WHV` → `COL` → `:RHV` `` per pair, `<br>`-separated. Empty pairs collapse to `—`. DB2 Coverage line gains `, N column pair(s)` suffix when N > 0.

## Sample render

```
Coverage: 1 shared table(s), 2 writer→reader pair(s), 3 column pair(s).

| Table | Writer | Writer Ops | Writer Host Vars | Reader | Reader Ops | Reader Host Vars | Column Flow |
|-------|--------|------------|------------------|--------|------------|------------------|-------------|
| CUSTOMERS | UPDATER | UPDATE | `WS-ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | READER | SELECT | `WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | `WS-NAME` → `NAME` → `WS-NAME` |
| CUSTOMERS | WRITER | INSERT | `WS-EMAIL` → `EMAIL` (X(50))<br>`WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | READER | SELECT | `WS-ID` → `ID` (X(10))<br>`WS-NAME` → `NAME` (X(30)) | `WS-ID` → `ID` → `WS-ID`<br>`WS-NAME` → `NAME` → `WS-NAME` |
```

Note how the **UPDATER** row only shows `:WS-NAME → NAME → :WS-NAME` (the UPDATER's `:WS-ID` is a WHERE filter, not a column write, so it has no Phase-A column binding and never enters the intersection). The **WRITER** row shows two pairs — but not EMAIL, since the reader doesn't bind that column.

## Backwards-compat

- `columnPairs` is always present (defaults to `[]`) on entries — type-mandatory, but renders cleanly as `—` when empty. No artifact-shape break beyond the new fields.
- Existing 77 db2-table-lineage tests pass unchanged. Full suite 3796/3796.
- Coverage line suffix is conditional on `columnPairs > 0`, so output stays byte-identical for any corpus where neither side has Phase-A bindings.

## Tests

7 new under `DB2 cross-program column-level pairing (#41 Phase B)`:

1. Positive intersection — writer + reader both bind the same columns → pairs emitted in sorted order.
2. One side unbound (INSERT-without-col-list writer) → `columnPairs === []`.
3. Disjoint columns (writer binds ID, reader binds NAME) → `[]`.
4. UPDATE writer with WHERE filter — WHERE-clause host vars stay out of pairs; SET-clause columns pair.
5. Cartesian-on-collision — two writer host vars bind the same column → both pair with the reader's host var.
6. Deterministic sort — column → writerHostVar → readerHostVar.
7. `summary.columnPairs` sums across multiple writer-reader entries.

## Out of scope

- INSERT…SELECT or MERGE column flow (Phase A doesn't bind those, so they fall through here too).
- "Same field flows through multiple shared tables" — table-graph pathfinding (much bigger).
- Renaming `summary.columnPairs` to something more specific (e.g. `crossProgramColumnPairs`). Keeping it concise to mirror `pairs`.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/db2-table-lineage.test.ts` — 84/84 (77 existing + 7 new)
- [x] `npx vitest run` — 3796/3796
- [x] `npx tsc --noEmit` — clean
- [x] Rendered fixture eyeballed: Coverage line shows column pair count; Column Flow cell renders correctly with/without pairs.
