### PR TITLE
feat(cobol): resolve dynamic CALL via VALUE / single-MOVE constant propagation (#46 Phase A)

### DIFF
--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -1285,6 +1285,41 @@ describe("buildCallBoundLineage", () => {
       expect(lineage!.entries).toEqual([]);
     });
 
+    it("qualified MOVE (`MOVE X OF Y TO Z`) is conservatively skipped — no false propagation", () => {
+      // Self-review concern: a naive `operands[0] = source, [1..] = targets`
+      // approach would mis-parse `MOVE A OF GROUP TO TARGET` as
+      // (source=A, targets=[GROUP, TARGET]) because OF is a keyword and
+      // gets stripped from operands. The token-based extractor refuses
+      // qualified sources/targets entirely — qualified MOVEs simply
+      // don't feed the resolver.
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  GROUP-A.
+           05  PGM-NAME       PIC X(8) VALUE "CUSTBILL".
+       01  WS-PGM             PIC X(8).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE PGM-NAME OF GROUP-A TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      // WS-PGM has no literal MOVE recorded (the qualified MOVE was
+      // skipped) and no VALUE clause → resolver returns null →
+      // dynamic-call. The PGM-NAME field's VALUE doesn't propagate
+      // (we'd need full data-flow tracking — Phase B).
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
     it("resolved-but-not-in-corpus: emits unresolved-callee with resolution trail in rationale", () => {
       const caller = `
        IDENTIFICATION DIVISION.

--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -1115,11 +1115,223 @@ describe("buildCallBoundLineage", () => {
     expect(findChildName(lineage2)).toBe("FIELD-V1");
   });
 
-  it("dynamic CALL <var> resolving to an IBM API name does NOT match the whitelist (#26 phase 1)", () => {
-    // The whitelist is gated behind targetKind === "literal" — a runtime-
-    // resolved CALL <variable> stays a dynamic-call diagnostic regardless
-    // of whether the value at the call site happens to match an IBM API
-    // name. Static lineage can't see the variable's runtime value.
+  describe("Dynamic CALL constant propagation (#46 Phase A)", () => {
+    function calleeFixture(programId: string): string {
+      return `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. ${programId}.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-A               PIC X(8).
+       PROCEDURE DIVISION USING LK-A.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+    }
+
+    it("VALUE clause: CALL <var> where var has only a VALUE literal resolves to the literal", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "CUSTBILL".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      expect(lineage).not.toBeNull();
+      // The resolved call produces entries (callee CUSTBILL is in the corpus).
+      expect(lineage!.entries.length).toBeGreaterThan(0);
+      const entry = lineage!.entries[0]!;
+      expect(entry.dynamicCallResolution).toEqual({
+        identifier: "WS-PGM",
+        literal: "CUSTBILL",
+        source: "VALUE",
+      });
+      // No dynamic-call diagnostic — we resolved the target.
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(false);
+    });
+
+    it("single literal MOVE: CALL <var> after exactly one MOVE literal resolves", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE "CUSTBILL" TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      const entry = lineage!.entries[0]!;
+      expect(entry.dynamicCallResolution).toEqual({
+        identifier: "WS-PGM",
+        literal: "CUSTBILL",
+        source: "MOVE",
+      });
+    });
+
+    it("VALUE + MOVE agreeing: still resolves (source = MOVE — most recent observation wins)", () => {
+      // The Phase A rule is "the identifier holds exactly one literal value".
+      // A VALUE clause and a MOVE both giving the same literal still satisfy
+      // the uniqueness gate; the MOVE branch fires first, so source = "MOVE".
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "CUSTBILL".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE "CUSTBILL" TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      expect(lineage!.entries[0]!.dynamicCallResolution?.literal).toBe("CUSTBILL");
+    });
+
+    it("VALUE + MOVE DISAGREEING: stays dynamic-call (two distinct candidate values)", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "PROG-A".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE "PROG-B" TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("PROG-A"), "PROG-A.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
+    it("two distinct literal MOVEs: stays dynamic-call (ambiguous)", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE "PROG-A" TO WS-PGM.
+           MOVE "PROG-B" TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("PROG-A"), "PROG-A.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+    });
+
+    it("non-literal MOVE source: stays dynamic-call (unknown runtime value)", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "CUSTBILL".
+       01  WS-OTHER           PIC X(8).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           MOVE WS-OTHER TO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      // VALUE says "CUSTBILL" but the non-literal MOVE makes runtime
+      // value unknowable. Conservative: drop.
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
+    it("resolved-but-not-in-corpus: emits unresolved-callee with resolution trail in rationale", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "MISSING".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      // No callee program in the corpus for "MISSING".
+      const otherCaller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. OTHER.
+       DATA DIVISION.
+       LINKAGE SECTION.
+       01  LK-X       PIC X(8).
+       PROCEDURE DIVISION USING LK-X.
+       A000-MAIN SECTION.
+       A100-START.
+           GOBACK.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(otherCaller, "OTHER.cbl"),
+      ]);
+      // Resolved target is "MISSING" — not in corpus, and not on the IBM
+      // whitelist. Classifies as unresolved-callee, not dynamic-call.
+      expect(lineage!.diagnostics.some((d) => d.kind === "unresolved-callee")).toBe(true);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(false);
+      const unresolved = lineage!.diagnostics.find((d) => d.kind === "unresolved-callee");
+      expect(unresolved?.rationale).toContain("resolved to \"MISSING\"");
+      expect(unresolved?.rationale).toContain("via VALUE");
+    });
+  });
+
+  it("dynamic CALL <var> resolving to an IBM API name VIA CONSTANT PROPAGATION matches the whitelist (#46 Phase A)", () => {
+    // Pre-#46 this case stayed a `dynamic-call` diagnostic because static
+    // lineage refused to look through the variable. #46 Phase A adds
+    // VALUE / single-MOVE constant propagation, and the resolved literal
+    // is then checked against the IBM whitelist — so a CALL to a
+    // variable holding "MQCONN" via exactly one literal MOVE now
+    // correctly classifies as `system-call`.
     const caller = `
        IDENTIFICATION DIVISION.
        PROGRAM-ID. CALLER.
@@ -1151,7 +1363,12 @@ describe("buildCallBoundLineage", () => {
     ]);
 
     expect(lineage).not.toBeNull();
-    expect(lineage!.diagnostics.some((d) => d.kind === "system-call")).toBe(false);
-    expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+    // Resolved via single-MOVE constant propagation, target "MQCONN" is on
+    // the IBM whitelist → system-call diagnostic, no dynamic-call.
+    expect(lineage!.diagnostics.some((d) => d.kind === "system-call")).toBe(true);
+    expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(false);
+    // The system-call diagnostic carries the resolution trail.
+    const sysCall = lineage!.diagnostics.find((d) => d.kind === "system-call");
+    expect(sysCall?.rationale).toContain("Resolved from CALL `WS-PROG-NAME` via MOVE");
   });
 });

--- a/src/cobol/__tests__/code-analysis.test.ts
+++ b/src/cobol/__tests__/code-analysis.test.ts
@@ -466,6 +466,8 @@ describe("code-analysis plugin system", () => {
       expect(migrated.db2References).toEqual([]);
       expect(migrated.cicsReferences).toEqual([]);
       expect(migrated.fileAccesses).toEqual([]);
+      // #46 Phase A added moveAssignments — backfill to [] for legacy.
+      expect(migrated.moveAssignments).toEqual([]);
       expect(migrated.calls[0].usingArgs).toEqual([]);
     });
 

--- a/src/cobol/call-boundary-lineage.ts
+++ b/src/cobol/call-boundary-lineage.ts
@@ -104,6 +104,19 @@ export interface SerializedCallBoundLineageEntry {
    * on without parsing domain detail.
    */
   envelope: EvidenceEnvelope;
+  /**
+   * #46 Phase A — present when the CALL site target was an identifier
+   * (dynamic call) that the resolver proved holds exactly one literal
+   * program name (via VALUE clause OR exactly-one literal MOVE with no
+   * non-literal writes). Lets the consumer distinguish "true literal
+   * CALL" from "dynamic CALL resolved via constant propagation",
+   * carrying the rename trail (identifier → literal, by which source).
+   */
+  dynamicCallResolution?: {
+    identifier: string;
+    literal: string;
+    source: "VALUE" | "MOVE";
+  };
   rationale: string;
 }
 
@@ -125,6 +138,90 @@ function isCopybook(filename: string): boolean {
 function findTopLevelDataItem(items: DataItemNode[], name: string): DataItemNode | undefined {
   const upper = name.toUpperCase();
   return items.find((item) => item.name.toUpperCase() === upper);
+}
+
+/**
+ * Recursive data-item lookup over a program's WS + LINKAGE trees. Used by
+ * `resolveDynamicCallTarget` to check VALUE clauses on identifiers that
+ * might live nested in a record. Different from `findTopLevelDataItem`
+ * (used by USING-arg resolution which only accepts 01-level records) —
+ * a program-name variable is just as likely to be `05 WS-PGM` inside
+ * `01 WS-VARS` as `01 WS-PGM` at top level.
+ */
+function findDataItemAnywhere(items: DataItemNode[], name: string): DataItemNode | undefined {
+  const upper = name.toUpperCase();
+  for (const item of items) {
+    if (item.name.toUpperCase() === upper) return item;
+    const inner = findDataItemAnywhere(item.children, name);
+    if (inner) return inner;
+  }
+  return undefined;
+}
+
+/**
+ * Extract a string-literal value from a `DataItemNode.value` field. The
+ * parser preserves quotes for LITERAL tokens (`VALUE "FOO"` lands as
+ * `value === '"FOO"'`), so we recognise literals by the leading quote
+ * and strip both ends. NUMERIC values and figurative-constant IDENTIFIER
+ * values (`SPACES`, `ZEROES`, ...) return undefined — those aren't
+ * usable program names for static CALL resolution.
+ */
+function extractStringLiteralValue(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  if (!/^["']/.test(raw)) return undefined;
+  return raw.replace(/^["']|["']$/g, "");
+}
+
+/**
+ * Resolve a `CALL <identifier>` target to a literal program name via
+ * conservative constant propagation (#46 Phase A). Returns `null`
+ * whenever the identifier doesn't uniquely hold a single literal value —
+ * fail-safe to the existing `dynamic-call` diagnostic. Two patterns
+ * succeed:
+ *
+ *   1. **Exactly one literal MOVE** to the identifier, with no
+ *      non-literal MOVE to the same identifier anywhere in the program.
+ *      Source classified as `"MOVE"`. If a VALUE clause also exists on
+ *      the data item, it must agree with the MOVE literal — disagreement
+ *      means two distinct possible values, so we abstain.
+ *   2. **VALUE clause** initializer with a string literal, and no MOVE
+ *      to the identifier at all. Source classified as `"VALUE"`.
+ *
+ * Anything else — multiple distinct literals, any non-literal MOVE,
+ * disagreement between VALUE and MOVE, no value at all — returns null.
+ * Multi-branch dispatch (`IF X MOVE "A" TO P ELSE MOVE "B"`) is Phase B
+ * scope; it currently lands as "two distinct literals" and falls
+ * through to the diagnostic.
+ */
+function resolveDynamicCallTarget(
+  caller: CobolCodeModel,
+  identifier: string,
+): { literal: string; source: "VALUE" | "MOVE" } | null {
+  const upper = identifier.toUpperCase();
+  const assignments = caller.moveAssignments.filter(
+    (a) => a.target.toUpperCase() === upper,
+  );
+  const dataItem = findDataItemAnywhere(caller.dataItems, identifier)
+    ?? findDataItemAnywhere(caller.linkageItems, identifier);
+  const valueLit = extractStringLiteralValue(dataItem?.value);
+
+  if (assignments.length > 0) {
+    // Any non-literal write disqualifies — we don't know what the
+    // identifier holds at the call site.
+    if (assignments.some((a) => a.literal === undefined)) return null;
+    const uniqueLiterals = new Set(assignments.map((a) => a.literal!));
+    if (uniqueLiterals.size !== 1) return null;
+    const literal = [...uniqueLiterals][0]!;
+    // A VALUE clause may coexist with MOVEs as long as it agrees with
+    // the literal MOVE value. Disagreement = two distinct candidates.
+    if (valueLit !== undefined && valueLit !== literal) return null;
+    return { literal, source: "MOVE" };
+  }
+
+  if (valueLit !== undefined) {
+    return { literal: valueLit, source: "VALUE" };
+  }
+  return null;
 }
 
 /**
@@ -242,6 +339,7 @@ function emitPair(
   calleeName: string,
   entries: SerializedCallBoundLineageEntry[],
   diagnostics: CallBoundDiagnostic[],
+  dynamicCallResolution?: { identifier: string; literal: string; source: "VALUE" | "MOVE" },
 ): void {
   const callerShape = shapeOf(callerItem, callerQualified);
   const calleeShape = shapeOf(calleeItem, calleeQualified);
@@ -284,6 +382,7 @@ function emitPair(
     callSite,
     evidence,
     envelope: buildEnvelope(confidence, callerSourceFile, calleeSourceFile, callSite.line),
+    ...(dynamicCallResolution ? { dynamicCallResolution } : {}),
     rationale: buildRationale(evidence, position, isTopLevel),
   });
 
@@ -307,6 +406,7 @@ function emitPair(
         calleeName,
         entries,
         diagnostics,
+        dynamicCallResolution,
       );
     }
   }
@@ -399,35 +499,63 @@ export function buildCallBoundLineage(
       // diagnostic, just an empty trace.
       if (call.usingArgs.length === 0) continue;
 
-      const callee = byProgramId.get(call.target.toUpperCase());
+      // #46 Phase A — try to resolve a dynamic `CALL <identifier>` to a
+      // literal program name via VALUE / single-MOVE constant propagation
+      // BEFORE the byProgramId lookup. On success, the downstream code
+      // treats this site like a literal CALL with `effectiveTarget` and
+      // attaches a `dynamicCallResolution` evidence dimension to entries.
+      // On failure, behavior is unchanged (still falls through to
+      // `dynamic-call` diagnostic at the lookup).
+      let effectiveTarget = call.target;
+      let dynamicCallResolution:
+        | { identifier: string; literal: string; source: "VALUE" | "MOVE" }
+        | undefined;
+      if (call.targetKind === "identifier") {
+        const resolved = resolveDynamicCallTarget(caller, call.target);
+        if (resolved) {
+          effectiveTarget = resolved.literal;
+          dynamicCallResolution = {
+            identifier: call.target,
+            literal: resolved.literal,
+            source: resolved.source,
+          };
+        }
+      }
+
+      const callee = byProgramId.get(effectiveTarget.toUpperCase());
       if (!callee) {
-        // Distinguish three cases:
-        //   1. CALL <var>             → dynamic-call
-        //   2. CALL "IBM-runtime"     → system-call (#26 phase 1)
-        //   3. CALL "user-program"    → unresolved-callee (real gap)
-        // Order matters: literal targets that match the IBM whitelist
-        // are documented runtime APIs, not missing user programs. The
-        // identifier-vs-literal check stays first so a dynamically
-        // resolved name doesn't accidentally match a system call.
+        // Distinguish four cases (#46 Phase A added the dynamic-resolved
+        // branches; resolved dynamic calls go through the literal-call
+        // diagnostic paths because we know the target name now):
+        //   1. CALL <var>             unresolved → dynamic-call
+        //   2. CALL <var> → "IBM"     resolved   → system-call (whitelist)
+        //   3. CALL "IBM"             literal    → system-call (whitelist)
+        //   4. CALL "user"            literal    → unresolved-callee
         let kind: CallBoundDiagnosticKind;
         let rationale: string;
-        if (call.targetKind === "identifier") {
+        if (call.targetKind === "identifier" && !dynamicCallResolution) {
           kind = "dynamic-call";
-          rationale = `CALL via identifier \`${call.target}\` is resolved at runtime; static lineage cannot determine the callee.`;
-        } else if (SYSTEM_CALLEES.has(call.target.toUpperCase())) {
+          rationale = `CALL via identifier \`${call.target}\` is resolved at runtime; static lineage cannot determine the callee. (No exactly-one literal MOVE or VALUE clause found for the identifier.)`;
+        } else if (SYSTEM_CALLEES.has(effectiveTarget.toUpperCase())
+          || extraSystemCalleesNorm.has(effectiveTarget.toUpperCase())) {
           kind = "system-call";
-          rationale = `CALL "${call.target}" targets a documented IBM runtime API (MQ / Language Environment / CICS-batch family); excluded from user-program lineage.`;
-        } else if (extraSystemCalleesNorm.has(call.target.toUpperCase())) {
-          kind = "system-call";
-          rationale = `CALL "${call.target}" matches the project-local system-call extension (\`extraSystemCallees\`); excluded from user-program lineage.`;
+          const isExtra = !SYSTEM_CALLEES.has(effectiveTarget.toUpperCase());
+          const baseRationale = isExtra
+            ? `CALL "${effectiveTarget}" matches the project-local system-call extension (\`extraSystemCallees\`); excluded from user-program lineage.`
+            : `CALL "${effectiveTarget}" targets a documented IBM runtime API (MQ / Language Environment / CICS-batch family); excluded from user-program lineage.`;
+          rationale = dynamicCallResolution
+            ? `${baseRationale} (Resolved from CALL \`${dynamicCallResolution.identifier}\` via ${dynamicCallResolution.source}.)`
+            : baseRationale;
         } else {
           kind = "unresolved-callee";
-          rationale = `CALL "${call.target}" has no matching program in the corpus.`;
+          rationale = dynamicCallResolution
+            ? `CALL via identifier \`${dynamicCallResolution.identifier}\` resolved to "${effectiveTarget}" (via ${dynamicCallResolution.source}) but no matching program in the corpus.`
+            : `CALL "${effectiveTarget}" has no matching program in the corpus.`;
         }
         diagnostics.push({
           kind,
           callerProgramId,
-          target: call.target,
+          target: effectiveTarget,
           callSite: call.loc,
           rationale,
         });
@@ -465,11 +593,11 @@ export function buildCallBoundLineage(
         diagnostics.push({
           kind: "arity-mismatch",
           callerProgramId,
-          target: call.target,
+          target: effectiveTarget,
           callSite: call.loc,
           rationale:
             `CALL passes ${call.usingArgs.length} arg(s) but callee `
-            + `\`${call.target}\` declares ${callee.linkageItems.length} `
+            + `\`${effectiveTarget}\` declares ${callee.linkageItems.length} `
             + `LINKAGE record(s).`,
         });
         continue;
@@ -495,7 +623,7 @@ export function buildCallBoundLineage(
           diagnostics.push({
             kind: "caller-arg-not-top-level",
             callerProgramId,
-            target: call.target,
+            target: effectiveTarget,
             callSite: call.loc,
             rationale:
               `Position ${i}: USING arg \`${callerArgName}\` is not a top-level `
@@ -517,9 +645,10 @@ export function buildCallBoundLineage(
           caller.sourceFile,
           callee.sourceFile,
           call.loc,
-          call.target,
+          effectiveTarget,
           entries,
           diagnostics,
+          dynamicCallResolution,
         );
       }
     }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -348,26 +348,47 @@ function extractStatementRelations(
   }
 
   if (verb === "MOVE") {
-    // `MOVE <source> TO <target>...`. Parser strips the TO keyword from
-    // operands (TO has its own token type, not pushed to operands), so
-    // ops[0] is the source and ops[1..] are targets. Literal-source MOVEs
-    // feed the dynamic-CALL constant-propagation resolver (#46 Phase A);
-    // non-literal sources are still recorded (with `literal` undefined)
-    // so the resolver can see "this variable has a non-literal write"
-    // and conservatively abstain.
-    const ops = stmt.operands;
-    if (ops.length >= 2) {
-      const source = ops[0]!;
-      const isLiteral = /^["']/.test(source);
-      const literal = isLiteral ? source.replace(/^["']|["']$/g, "") : undefined;
-      for (let i = 1; i < ops.length; i++) {
-        const target = ops[i];
-        if (!target) continue;
-        model.moveAssignments.push({
-          target,
-          ...(literal !== undefined ? { literal } : {}),
-          loc: stmt.loc,
-        });
+    // `MOVE <source> TO <target>...`. Use the typed token stream rather
+    // than `stmt.operands`: operands silently drops OF/IN qualifier
+    // keywords, so `MOVE A OF B TO C` would arrive as `[A, B, C]` and
+    // produce a wrong `(source=A, targets=[B, C])` record. Walking
+    // tokens lets us locate the `TO` boundary and refuse qualified
+    // operands.
+    //
+    // Phase A conservative: only emit when each side is a single
+    // unqualified identifier (or single literal on the source). Group
+    // moves (`MOVE A TO B C D`) emit one record per target. Qualified
+    // forms (`A OF B`, `A IN B`) are skipped entirely — they're
+    // uncommon for program-name variables and Phase A's constant-
+    // propagation resolver doesn't need them.
+    const tokens = stmt.tokens;
+    const toIdx = tokens.findIndex((t) => t.type === "TO");
+    if (toIdx > 1) {
+      // Slice off the leading MOVE verb token; collect source and
+      // target token windows separated by TO.
+      const sourceTokens = tokens.slice(1, toIdx);
+      const targetTokens = tokens.slice(toIdx + 1);
+      const hasQualifier = (ts: typeof sourceTokens): boolean =>
+        ts.some((t) => t.type === "OF" || t.type === "IN");
+      const sourceIsSingleScalar = sourceTokens.length === 1
+        && (sourceTokens[0]!.type === "IDENTIFIER"
+          || sourceTokens[0]!.type === "LITERAL"
+          || sourceTokens[0]!.type === "NUMERIC");
+      // Targets: each must be one IDENTIFIER token (multi-target MOVE
+      // is space-separated, no OF/IN expected for the simple cases we
+      // care about). Reject if ANY target is qualified.
+      if (sourceIsSingleScalar && !hasQualifier(sourceTokens) && !hasQualifier(targetTokens)) {
+        const source = sourceTokens[0]!.value;
+        const isLiteral = /^["']/.test(source);
+        const literal = isLiteral ? source.replace(/^["']|["']$/g, "") : undefined;
+        for (const tt of targetTokens) {
+          if (tt.type !== "IDENTIFIER") continue;
+          model.moveAssignments.push({
+            target: tt.value,
+            ...(literal !== undefined ? { literal } : {}),
+            loc: stmt.loc,
+          });
+        }
       }
     }
   }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -62,6 +62,20 @@ export interface CobolCodeModel {
     rawText: string;
     loc: SourceLocation;
   }[];
+  /**
+   * `MOVE <source> TO <target>...` records (#46 Phase A). Each target
+   * receives its own entry; multi-target `MOVE X TO A B` produces two
+   * entries with the same source. `literal` is set when the source is a
+   * quoted string literal — surrogate evidence for constant propagation
+   * in the call-bound lineage builder. Non-literal sources (identifiers,
+   * numerics) populate the entry too so the resolver can detect "this
+   * variable has a non-literal write" and abstain conservatively.
+   */
+  moveAssignments: {
+    target: string;
+    literal?: string;
+    loc: SourceLocation;
+  }[];
 }
 
 export interface CodeSummary {
@@ -97,6 +111,7 @@ export function extractModel(ast: CobolAST): CobolCodeModel {
     db2References: [],
     cicsReferences: [],
     fileAccesses: [],
+    moveAssignments: [],
   };
 
   for (const div of ast.divisions) {
@@ -329,6 +344,31 @@ function extractStatementRelations(
         usingArgs: extractUsingArgs(stmt.rawText),
         loc: stmt.loc,
       });
+    }
+  }
+
+  if (verb === "MOVE") {
+    // `MOVE <source> TO <target>...`. Parser strips the TO keyword from
+    // operands (TO has its own token type, not pushed to operands), so
+    // ops[0] is the source and ops[1..] are targets. Literal-source MOVEs
+    // feed the dynamic-CALL constant-propagation resolver (#46 Phase A);
+    // non-literal sources are still recorded (with `literal` undefined)
+    // so the resolver can see "this variable has a non-literal write"
+    // and conservatively abstain.
+    const ops = stmt.operands;
+    if (ops.length >= 2) {
+      const source = ops[0]!;
+      const isLiteral = /^["']/.test(source);
+      const literal = isLiteral ? source.replace(/^["']|["']$/g, "") : undefined;
+      for (let i = 1; i < ops.length; i++) {
+        const target = ops[i];
+        if (!target) continue;
+        model.moveAssignments.push({
+          target,
+          ...(literal !== undefined ? { literal } : {}),
+          loc: stmt.loc,
+        });
+      }
     }
   }
 

--- a/src/cobol/field-lineage.ts
+++ b/src/cobol/field-lineage.ts
@@ -1318,10 +1318,26 @@ export function generateFieldLineagePage(lineage: SerializedFieldLineage): { pat
         const highCount = group.entries.filter((e) => e.confidence === "high").length;
         lines.push(`### ${displayLabel(group.callerProgramId)} → ${displayLabel(group.calleeProgramId)}`);
         lines.push("");
+        // #46 Phase A — surface the dynamic-call resolution trail in the
+        // group summary when one or more entries was resolved via VALUE
+        // or single-MOVE constant propagation. Dedup the trails: a
+        // group can include multiple CALL sites and the trails might
+        // differ; show each unique `identifier → literal (source)`
+        // exactly once so the summary stays compact.
+        const resolutionTrails = new Set<string>();
+        for (const entry of group.entries) {
+          if (entry.dynamicCallResolution) {
+            const r = entry.dynamicCallResolution;
+            resolutionTrails.add(`\`${r.identifier}\` → "${r.literal}" via ${r.source}`);
+          }
+        }
         const summary = highCount > 0
           ? `${group.entries.length} pair(s): ${detCount} deterministic, ${highCount} high-confidence (name divergence — review below).`
           : `${group.entries.length} pair(s), all deterministic.`;
-        lines.push(`*${summary}*`);
+        const resolved = resolutionTrails.size > 0
+          ? ` Resolved from dynamic CALL: ${[...resolutionTrails].join("; ")}.`
+          : "";
+        lines.push(`*${summary}${resolved}*`);
         lines.push("");
         lines.push("| Pos | Caller | Callee | Confidence | Evidence |");
         lines.push("|-----|--------|--------|------------|----------|");

--- a/src/cobol/plugin.ts
+++ b/src/cobol/plugin.ts
@@ -91,6 +91,10 @@ export function migrateLoadedModel(raw: unknown): CobolCodeModel {
   if (!Array.isArray(m.db2References)) m.db2References = [];
   if (!Array.isArray(m.cicsReferences)) m.cicsReferences = [];
   if (!Array.isArray(m.fileAccesses)) m.fileAccesses = [];
+  // #46 Phase A — moveAssignments is new; pre-#46 artifacts on disk
+  // don't carry it. The call-bound builder iterates this list when
+  // resolving dynamic CALL targets, so a missing field would throw.
+  if (!Array.isArray(m.moveAssignments)) m.moveAssignments = [];
   for (const call of m.calls) {
     if (!Array.isArray((call as { usingArgs?: unknown }).usingArgs)) {
       (call as { usingArgs: string[] }).usingArgs = [];


### PR DESCRIPTION
## Summary

Closes #46. Resolve `CALL <identifier>` to a literal program name when the identifier provably holds exactly one literal value, via VALUE clause or exactly-one literal MOVE. Treats resolved sites as literal CALLs (full pair-entry emission + IBM whitelist check applies to the resolved name), with a `dynamicCallResolution` evidence dimension on entries so the rename trail (`identifier → literal (source)`) is visible.

## Two patterns succeed (conservative, fail-safe)

1. **VALUE clause** initializer with a string literal AND no MOVE to the identifier → resolve, source `"VALUE"`.
2. **Exactly one literal MOVE** to the identifier AND no non-literal MOVE anywhere → resolve, source `"MOVE"`. A coexisting VALUE clause must agree with the literal; disagreement = two distinct candidates → abstain.

Anything else stays `dynamic-call`:
- Multiple distinct literal MOVEs (ambiguous)
- Any non-literal MOVE source (runtime value unknowable)
- VALUE clause disagreeing with the MOVE literal
- No VALUE and no MOVE

Multi-branch dispatch (`IF X MOVE "A" ELSE MOVE "B"`) lands as "two distinct literals" → diagnostic. Phase B scope.

## Output additions

- `CobolCodeModel.moveAssignments: Array<{ target, literal?, loc }>` — extracted from every MOVE statement. Non-literal sources still recorded (with `literal` undefined) so the resolver can see "this variable has a non-literal write" and abstain.
- `SerializedCallBoundLineageEntry.dynamicCallResolution?: { identifier, literal, source }` — present on entries whose CALL site was resolved from a dynamic identifier.
- Renderer: per-pair group summary gains a `Resolved from dynamic CALL: \`WS-PGM\` → "CUSTBILL" via VALUE.` suffix.

## Diagnostic semantics

The byProgramId lookup now runs against `effectiveTarget` (the resolved literal). Three downstream paths:

- **Resolved + in-corpus** → entries emit with `dynamicCallResolution` attached.
- **Resolved + on IBM whitelist** → `system-call` diagnostic (issue acceptance #6).
- **Resolved + not-in-corpus + not-IBM** → `unresolved-callee` with trail in rationale, not `dynamic-call`. We now know the target name; the "static lineage can't see" framing doesn't fit.
- **Not resolved + still identifier** → `dynamic-call` diagnostic (today's behavior).

## Sample render

```
### CALLER → CUSTBILL

*3 pair(s), all deterministic. Resolved from dynamic CALL: `WS-PGM` → "CUSTBILL" via VALUE.*

| Pos | Caller | Callee | Confidence | Evidence |
|-----|--------|--------|------------|----------|
| 0 | WS-REC | LK-REC | deterministic | both-group, name-aligned, same-level |
| 0 | WS-REC.WS-FIELD-A | LK-REC.LK-FIELD-A | deterministic | scalar-match, name-aligned, same-level |
| 0 | WS-REC.WS-FIELD-B | LK-REC.LK-FIELD-B | deterministic | scalar-match, name-aligned, same-level |
```

## Backwards-compat

- `moveAssignments` is a new array on `CobolCodeModel`; existing consumers ignore unknown fields.
- `dynamicCallResolution` on entries is optional; entries without it render exactly as before.
- One pre-existing test (`dynamic CALL <var> resolving to an IBM API name does NOT match the whitelist`) was updated — its premise (whitelist gated on literal-only) is exactly the bug Phase A fixes. The fixture now correctly classifies as `system-call` with the resolution trail in the rationale.
- Full suite 3823/3823.

## Tests (7 new)

Under `Dynamic CALL constant propagation (#46 Phase A)`:

1. VALUE clause positive — `CALL WS-PGM` where `WS-PGM PIC X(8) VALUE "CUSTBILL"` resolves.
2. Single-MOVE positive — exactly one `MOVE "CUSTBILL" TO WS-PGM` then `CALL WS-PGM` resolves.
3. VALUE + MOVE agreeing — both say `"CUSTBILL"` → resolves, source `"MOVE"`.
4. VALUE + MOVE disagreeing — VALUE `"PROG-A"`, MOVE `"PROG-B"` → abstain.
5. Two distinct literal MOVEs — abstain.
6. Non-literal MOVE source (`MOVE WS-OTHER TO WS-PGM`) — abstain even with a matching VALUE.
7. Resolved-but-not-in-corpus — emits `unresolved-callee` with `via VALUE` trail in the rationale.

Plus the updated whitelist test that asserts `system-call` after resolution.

## Out of scope (Phase B candidates)

- Multi-branch dispatch (`IF X MOVE "A" ELSE MOVE "B"`) emitting one entry per candidate.
- Configuration / database-driven program names. Static can't know these.
- `EXEC CICS LINK PROGRAM(...)` — separate surface.
- Path-sensitive analysis (assignments inside one PERFORM branch vs another). Phase A treats the procedure division as flat.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/call-boundary-lineage.test.ts` — 69/69 (62 existing + 7 new, 1 test updated)
- [x] `npx vitest run` — 3823/3823
- [x] `npx tsc --noEmit` — clean
- [x] Render eyeball: group summary cleanly shows `Resolved from dynamic CALL: ...`
