### PR TITLE
fix(cobol): dynamic CALL resolver abstains on STRING / UNSTRING / INITIALIZE writes (#48 Phase A.1)

### DIFF
--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -1320,6 +1320,113 @@ describe("buildCallBoundLineage", () => {
       expect(lineage!.entries).toEqual([]);
     });
 
+    it("STRING ... INTO clobbers VALUE clause: resolver abstains (#48 Phase A.1)", () => {
+      // VALUE "FALLBACK" then STRING into WS-PGM means the variable
+      // value at the CALL site is computed, not constant. Pre-#48 the
+      // resolver saw no MOVE, fell back to VALUE, and falsely resolved
+      // the call to "FALLBACK". Now: the STRING write is tracked as a
+      // non-literal assignment and the resolver abstains.
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "FALLBACK".
+       01  WS-PREFIX          PIC X(4).
+       01  WS-SUFFIX          PIC X(4).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           STRING WS-PREFIX WS-SUFFIX INTO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("FALLBACK"), "FALLBACK.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
+    it("INITIALIZE clobbers VALUE clause: resolver abstains (#48 Phase A.1)", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "FALLBACK".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           INITIALIZE WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("FALLBACK"), "FALLBACK.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
+    it("UNSTRING ... INTO clobbers VALUE clause: resolver abstains (#48 Phase A.1)", () => {
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-INPUT           PIC X(20).
+       01  WS-PGM             PIC X(8) VALUE "FALLBACK".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           UNSTRING WS-INPUT INTO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("FALLBACK"), "FALLBACK.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
+    it("non-MOVE write on a DIFFERENT identifier doesn't disqualify resolution (#48 Phase A.1)", () => {
+      // Verify the abstain gate is precise to the queried identifier —
+      // INITIALIZE of WS-OTHER doesn't affect resolution of WS-PGM.
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "CUSTBILL".
+       01  WS-OTHER           PIC X(8).
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           INITIALIZE WS-OTHER.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("CUSTBILL"), "CUSTBILL.cbl"),
+      ]);
+      expect(lineage!.entries.length).toBeGreaterThan(0);
+      expect(lineage!.entries[0]!.dynamicCallResolution).toEqual({
+        identifier: "WS-PGM",
+        literal: "CUSTBILL",
+        source: "VALUE",
+      });
+    });
+
     it("resolved-but-not-in-corpus: emits unresolved-callee with resolution trail in rationale", () => {
       const caller = `
        IDENTIFICATION DIVISION.

--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -1423,6 +1423,39 @@ describe("buildCallBoundLineage", () => {
       expect(lineage!.entries).toEqual([]);
     });
 
+    it("READ ... INTO clobbers VALUE clause: resolver abstains (#48 Phase A.1)", () => {
+      // Reading a record from a file overwrites the target with file
+      // data — runtime-computed, not constant. Same precision class as
+      // ACCEPT / STRING.
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+           SELECT PGM-FILE ASSIGN TO "PGMFILE".
+       DATA DIVISION.
+       FILE SECTION.
+       FD  PGM-FILE.
+       01  PGM-RECORD         PIC X(80).
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "FALLBACK".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           READ PGM-FILE INTO WS-PGM.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("FALLBACK"), "FALLBACK.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
     it("non-MOVE write on a DIFFERENT identifier doesn't disqualify resolution (#48 Phase A.1)", () => {
       // Verify the abstain gate is precise to the queried identifier —
       // INITIALIZE of WS-OTHER doesn't affect resolution of WS-PGM.

--- a/src/cobol/__tests__/call-boundary-lineage.test.ts
+++ b/src/cobol/__tests__/call-boundary-lineage.test.ts
@@ -1397,6 +1397,32 @@ describe("buildCallBoundLineage", () => {
       expect(lineage!.entries).toEqual([]);
     });
 
+    it("ACCEPT clobbers VALUE clause: resolver abstains (#48 Phase A.1)", () => {
+      // ACCEPT reads runtime input (env/console/date), so the variable
+      // is by definition not constant. Same precision class as
+      // STRING/INITIALIZE/UNSTRING.
+      const caller = `
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. CALLER.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-PGM             PIC X(8) VALUE "FALLBACK".
+       01  WS-A               PIC X(8).
+       PROCEDURE DIVISION.
+       A000-MAIN SECTION.
+       A100-START.
+           ACCEPT WS-PGM FROM ENVIRONMENT.
+           CALL WS-PGM USING WS-A.
+           STOP RUN.
+`;
+      const lineage = buildCallBoundLineage([
+        model(caller, "CALLER.cbl"),
+        model(calleeFixture("FALLBACK"), "FALLBACK.cbl"),
+      ]);
+      expect(lineage!.diagnostics.some((d) => d.kind === "dynamic-call")).toBe(true);
+      expect(lineage!.entries).toEqual([]);
+    });
+
     it("non-MOVE write on a DIFFERENT identifier doesn't disqualify resolution (#48 Phase A.1)", () => {
       // Verify the abstain gate is precise to the queried identifier —
       // INITIALIZE of WS-OTHER doesn't affect resolution of WS-PGM.

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -72,14 +72,21 @@ export interface CobolCodeModel {
    *     The only write shape that produces a resolvable literal.
    *   - `verb: "MOVE"` without `literal` — non-literal MOVE source
    *     (identifier or numeric). Disqualifies resolution.
-   *   - `verb: "INITIALIZE" | "STRING" | "UNSTRING"` (always no
-   *     `literal`) — non-MOVE writes that clobber the target with a
-   *     value the resolver can't statically determine. Same effect
-   *     as a non-literal MOVE: abstain.
+   *   - `verb: "INITIALIZE" | "STRING" | "UNSTRING" | "ACCEPT" | "READ"`
+   *     (always no `literal`) — non-MOVE write verbs that clobber the
+   *     target with a runtime-computed value the resolver can't
+   *     statically determine. Same effect as a non-literal MOVE:
+   *     abstain. ACCEPT covers env/console/date input; READ covers the
+   *     optional `READ <file> INTO <ident>` clause.
    *
    * Multi-target `MOVE X TO A B` produces two entries with the same
    * source. Qualified targets (`A OF B`, `A IN B`) are skipped at
    * extraction time — Phase A doesn't handle them.
+   *
+   * Out of scope (Phase B+): SET, INSPECT, CALL ... RETURNING, and the
+   * arithmetic verbs (ADD/SUBTRACT/MULTIPLY/DIVIDE/COMPUTE — those
+   * write numeric variables, not the alphanumeric ones used as
+   * program-name aliases).
    *
    * `verb` is optional for back-compat with pre-#48 artifacts where
    * every entry was implicitly a MOVE; missing values default to

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -88,7 +88,7 @@ export interface CobolCodeModel {
   moveAssignments: {
     target: string;
     literal?: string;
-    verb?: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING" | "ACCEPT";
+    verb?: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING" | "ACCEPT" | "READ";
     loc: SourceLocation;
   }[];
 }
@@ -510,6 +510,29 @@ function extractStatementRelations(
       const qualified = next && (next.type === "OF" || next.type === "IN");
       if (t.type === "IDENTIFIER" && !qualified) {
         model.moveAssignments.push({ target: t.value, verb: "ACCEPT", loc: stmt.loc });
+      }
+    }
+  }
+
+  if (verb === "READ") {
+    // `READ <file> [NEXT RECORD] INTO <ident>` — the optional INTO
+    // clause copies the read record into <ident>, clobbering whatever
+    // was there. Without INTO, READ writes only the FD/record area
+    // (handled by fileAccesses for file-lineage purposes, not relevant
+    // to dynamic-CALL resolution). Same INTO-then-IDENTIFIER pattern
+    // as STRING.
+    const tokens = stmt.tokens;
+    const intoIdx = tokens.findIndex((t) => t.type === "INTO");
+    if (intoIdx > 0) {
+      for (let i = intoIdx + 1; i < tokens.length; i++) {
+        const t = tokens[i]!;
+        if (t.type === "IDENTIFIER") {
+          const next = tokens[i + 1];
+          if (next && (next.type === "OF" || next.type === "IN")) break;
+          model.moveAssignments.push({ target: t.value, verb: "READ", loc: stmt.loc });
+          break;
+        }
+        if (t.type === "OF" || t.type === "IN") break;
       }
     }
   }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -465,30 +465,33 @@ function extractStatementRelations(
     //   [COUNT IN <c>] [target-2 ...] [WITH POINTER <ptr>] [TALLYING IN <t>]
     //   END-UNSTRING`. After INTO, IDENTIFIER tokens are targets until
     // the next non-IDENTIFIER keyword (DELIMITER/COUNT/POINTER/TALLYING/etc.).
-    // Phase A.1 simplification: capture up to the FIRST qualifier or
-    // keyword boundary; rare edge cases (qualified targets, multiple
-    // delimiter clauses) fall through unhandled.
+    //
+    // Phase A.1 conservative rule: if ANY OF/IN qualifier appears in the
+    // target run, skip the whole statement. Nested-qualifier handling
+    // (`A OF B OF C`) is too brittle without proper grammar tracking;
+    // false-negative (we miss the abstain) is preferred over false-
+    // positive (we capture a non-target as a target).
     const tokens = stmt.tokens;
     const intoIdx = tokens.findIndex((t) => t.type === "INTO");
     if (intoIdx > 0) {
+      const candidates: string[] = [];
+      let qualified = false;
       for (let i = intoIdx + 1; i < tokens.length; i++) {
         const t = tokens[i]!;
         if (t.type === "IDENTIFIER") {
-          const next = tokens[i + 1];
-          if (next && (next.type === "OF" || next.type === "IN")) {
-            // Skip past the qualified target (don't capture it).
-            i += 2;
-            continue;
-          }
-          model.moveAssignments.push({ target: t.value, verb: "UNSTRING", loc: stmt.loc });
+          candidates.push(t.value);
         } else if (t.type === "OF" || t.type === "IN") {
-          // Mid-stream OF/IN shouldn't happen if we skipped correctly above.
-          continue;
+          qualified = true;
+          break;
         } else {
           // Stop at the first non-IDENTIFIER/non-OF/IN token (DELIMITER /
-          // COUNT / WITH / etc.). UNSTRING's grammar has more clauses we
-          // don't track for now.
+          // COUNT / WITH / etc.).
           break;
+        }
+      }
+      if (!qualified) {
+        for (const target of candidates) {
+          model.moveAssignments.push({ target, verb: "UNSTRING", loc: stmt.loc });
         }
       }
     }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -88,7 +88,7 @@ export interface CobolCodeModel {
   moveAssignments: {
     target: string;
     literal?: string;
-    verb?: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING";
+    verb?: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING" | "ACCEPT";
     loc: SourceLocation;
   }[];
 }
@@ -493,6 +493,23 @@ function extractStatementRelations(
         for (const target of candidates) {
           model.moveAssignments.push({ target, verb: "UNSTRING", loc: stmt.loc });
         }
+      }
+    }
+  }
+
+  if (verb === "ACCEPT") {
+    // `ACCEPT <ident> [FROM <source>]`. The target is the FIRST
+    // unqualified IDENTIFIER after the verb. ACCEPT reads runtime
+    // input (date/time/env/console), so the resulting value is by
+    // definition not constant — same precision risk as STRING.
+    // Skip qualified targets for consistency with the other verbs.
+    const tokens = stmt.tokens;
+    if (tokens.length >= 2) {
+      const t = tokens[1]!;
+      const next = tokens[2];
+      const qualified = next && (next.type === "OF" || next.type === "IN");
+      if (t.type === "IDENTIFIER" && !qualified) {
+        model.moveAssignments.push({ target: t.value, verb: "ACCEPT", loc: stmt.loc });
       }
     }
   }

--- a/src/cobol/extractors.ts
+++ b/src/cobol/extractors.ts
@@ -63,17 +63,32 @@ export interface CobolCodeModel {
     loc: SourceLocation;
   }[];
   /**
-   * `MOVE <source> TO <target>...` records (#46 Phase A). Each target
-   * receives its own entry; multi-target `MOVE X TO A B` produces two
-   * entries with the same source. `literal` is set when the source is a
-   * quoted string literal — surrogate evidence for constant propagation
-   * in the call-bound lineage builder. Non-literal sources (identifiers,
-   * numerics) populate the entry too so the resolver can detect "this
-   * variable has a non-literal write" and abstain conservatively.
+   * Write-like assignment records used by the dynamic-CALL constant-
+   * propagation resolver (#46 Phase A; extended in #48 Phase A.1 to
+   * cover non-MOVE write verbs). Each entry names a target identifier
+   * and the verb that wrote it:
+   *
+   *   - `verb: "MOVE"` with a `literal` — `MOVE "FOO" TO target`.
+   *     The only write shape that produces a resolvable literal.
+   *   - `verb: "MOVE"` without `literal` — non-literal MOVE source
+   *     (identifier or numeric). Disqualifies resolution.
+   *   - `verb: "INITIALIZE" | "STRING" | "UNSTRING"` (always no
+   *     `literal`) — non-MOVE writes that clobber the target with a
+   *     value the resolver can't statically determine. Same effect
+   *     as a non-literal MOVE: abstain.
+   *
+   * Multi-target `MOVE X TO A B` produces two entries with the same
+   * source. Qualified targets (`A OF B`, `A IN B`) are skipped at
+   * extraction time — Phase A doesn't handle them.
+   *
+   * `verb` is optional for back-compat with pre-#48 artifacts where
+   * every entry was implicitly a MOVE; missing values default to
+   * "MOVE" at consumer time.
    */
   moveAssignments: {
     target: string;
     literal?: string;
+    verb?: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING";
     loc: SourceLocation;
   }[];
 }
@@ -364,8 +379,6 @@ function extractStatementRelations(
     const tokens = stmt.tokens;
     const toIdx = tokens.findIndex((t) => t.type === "TO");
     if (toIdx > 1) {
-      // Slice off the leading MOVE verb token; collect source and
-      // target token windows separated by TO.
       const sourceTokens = tokens.slice(1, toIdx);
       const targetTokens = tokens.slice(toIdx + 1);
       const hasQualifier = (ts: typeof sourceTokens): boolean =>
@@ -374,9 +387,6 @@ function extractStatementRelations(
         && (sourceTokens[0]!.type === "IDENTIFIER"
           || sourceTokens[0]!.type === "LITERAL"
           || sourceTokens[0]!.type === "NUMERIC");
-      // Targets: each must be one IDENTIFIER token (multi-target MOVE
-      // is space-separated, no OF/IN expected for the simple cases we
-      // care about). Reject if ANY target is qualified.
       if (sourceIsSingleScalar && !hasQualifier(sourceTokens) && !hasQualifier(targetTokens)) {
         const source = sourceTokens[0]!.value;
         const isLiteral = /^["']/.test(source);
@@ -386,8 +396,99 @@ function extractStatementRelations(
           model.moveAssignments.push({
             target: tt.value,
             ...(literal !== undefined ? { literal } : {}),
+            verb: "MOVE",
             loc: stmt.loc,
           });
+        }
+      }
+    }
+  }
+
+  // #48 Phase A.1 — non-MOVE write verbs that can clobber a variable.
+  // These never produce a resolvable literal (the written value is
+  // computed at runtime), so they're emitted with `literal: undefined`
+  // and the resolver's existing "any non-literal write disqualifies"
+  // gate catches them. Each verb has a distinct target-extraction
+  // shape — see comments per verb. Qualified targets (`A OF B`) are
+  // skipped at the per-token level for the same reason as MOVE.
+  if (verb === "INITIALIZE") {
+    // `INITIALIZE <ident>... [REPLACING ...] [DEFAULT TO ...]`. Every
+    // unqualified IDENTIFIER token after the verb is a target, until
+    // the first OF/IN qualifier (skip the whole statement) or any
+    // other keyword (REPLACING/DEFAULT/etc., stop).
+    const tokens = stmt.tokens;
+    const candidates: string[] = [];
+    let qualified = false;
+    for (let i = 1; i < tokens.length; i++) {
+      const t = tokens[i]!;
+      if (t.type === "IDENTIFIER") {
+        candidates.push(t.value);
+      } else if (t.type === "OF" || t.type === "IN") {
+        qualified = true;
+        break;
+      } else {
+        break;
+      }
+    }
+    if (!qualified) {
+      for (const target of candidates) {
+        model.moveAssignments.push({ target, verb: "INITIALIZE", loc: stmt.loc });
+      }
+    }
+  }
+
+  if (verb === "STRING") {
+    // `STRING <source-list> INTO <target> [WITH POINTER <ptr>] ... END-STRING`.
+    // The first IDENTIFIER after `INTO` is the destination target.
+    // A `WITH POINTER` operand is also a write target but rare for
+    // program-name vars; track only the primary INTO target for now.
+    const tokens = stmt.tokens;
+    const intoIdx = tokens.findIndex((t) => t.type === "INTO");
+    if (intoIdx > 0) {
+      for (let i = intoIdx + 1; i < tokens.length; i++) {
+        const t = tokens[i]!;
+        if (t.type === "IDENTIFIER") {
+          // Reject if the very next token is OF/IN (qualified target).
+          const next = tokens[i + 1];
+          if (next && (next.type === "OF" || next.type === "IN")) break;
+          model.moveAssignments.push({ target: t.value, verb: "STRING", loc: stmt.loc });
+          break;
+        }
+        // Skip any leading keyword tokens between INTO and the target.
+        if (t.type === "OF" || t.type === "IN") break;
+      }
+    }
+  }
+
+  if (verb === "UNSTRING") {
+    // `UNSTRING <source> [DELIMITED BY ...] INTO <target-1> [DELIMITER IN <d>]
+    //   [COUNT IN <c>] [target-2 ...] [WITH POINTER <ptr>] [TALLYING IN <t>]
+    //   END-UNSTRING`. After INTO, IDENTIFIER tokens are targets until
+    // the next non-IDENTIFIER keyword (DELIMITER/COUNT/POINTER/TALLYING/etc.).
+    // Phase A.1 simplification: capture up to the FIRST qualifier or
+    // keyword boundary; rare edge cases (qualified targets, multiple
+    // delimiter clauses) fall through unhandled.
+    const tokens = stmt.tokens;
+    const intoIdx = tokens.findIndex((t) => t.type === "INTO");
+    if (intoIdx > 0) {
+      for (let i = intoIdx + 1; i < tokens.length; i++) {
+        const t = tokens[i]!;
+        if (t.type === "IDENTIFIER") {
+          const next = tokens[i + 1];
+          if (next && (next.type === "OF" || next.type === "IN")) {
+            // Skip past the qualified target (don't capture it).
+            i += 2;
+            continue;
+          }
+          model.moveAssignments.push({ target: t.value, verb: "UNSTRING", loc: stmt.loc });
+        } else if (t.type === "OF" || t.type === "IN") {
+          // Mid-stream OF/IN shouldn't happen if we skipped correctly above.
+          continue;
+        } else {
+          // Stop at the first non-IDENTIFIER/non-OF/IN token (DELIMITER /
+          // COUNT / WITH / etc.). UNSTRING's grammar has more clauses we
+          // don't track for now.
+          break;
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes #48. Follow-up to #46 / #47 caught in post-merge self-review.

#46 Phase A's resolver only inspected MOVE writes. Real-world COBOL has other write verbs that clobber a variable: `STRING ... INTO`, `UNSTRING ... INTO`, `INITIALIZE`. With a `VALUE` clause initializer and a STRING/INITIALIZE/UNSTRING write before the CALL, the merged resolver would falsely resolve the call to the VALUE literal — the actual program name is the runtime-computed result.

```cobol
01  WS-PGM   PIC X(8)  VALUE "FALLBACK".
STRING WS-PREFIX WS-SUFFIX INTO WS-PGM.
CALL WS-PGM USING WS-DATA.
```

Pre-#48: resolves to `"FALLBACK"` (wrong). Post-#48: `dynamic-call` diagnostic (correct).

## How

`moveAssignments` field is extended to track non-MOVE write verbs. Each entry carries `verb: "MOVE" | "INITIALIZE" | "STRING" | "UNSTRING"`. The non-MOVE verbs always produce `literal: undefined`, so the resolver's existing gate (`assignments.some(a => a.literal === undefined) → abstain`) catches them automatically — no resolver code change needed.

Per-verb target extraction:

- `INITIALIZE <ident-list>` — every unqualified IDENTIFIER until OF/IN/keyword is a target.
- `STRING ... INTO <target>` — first IDENTIFIER after INTO.
- `UNSTRING source INTO <target-list>` — IDENTIFIERs after INTO, until next non-IDENTIFIER keyword (DELIMITER/COUNT/POINTER/etc.).

Qualified targets (`A OF B`) are skipped at extraction time, consistent with MOVE.

## Out of scope (Phase B candidates)

- Arithmetic verbs (ADD/SUBTRACT/MULTIPLY/DIVIDE/COMPUTE) — these write numeric variables; program-name vars are alphanumeric. Unlikely culprit.
- SET (pointers/indices/conditions) — uncommon for strings.
- INSPECT — modifies in-place; uncommon for program-name vars.
- READ INTO — uncommon for program names.

If real-corpus data shows any of these as a source of false positives, they can be added in a later phase.

## Backwards-compat

- `verb` field on `moveAssignments` entries is **optional** for back-compat with pre-#48 `.model.json` artifacts (every pre-#48 entry was implicitly a MOVE).
- Existing 70 call-bound tests pass unchanged.
- `migrateLoadedModel` continues to backfill `moveAssignments` to `[]` for pre-#46 artifacts (already in place).

## Tests

4 new under `Dynamic CALL constant propagation`:

1. `STRING ... INTO WS-PGM` clobbers VALUE → dynamic-call.
2. `INITIALIZE WS-PGM` clobbers VALUE → dynamic-call.
3. `UNSTRING ... INTO WS-PGM` clobbers VALUE → dynamic-call.
4. **Isolation** — INITIALIZE of a DIFFERENT identifier doesn't abstain the resolution of the queried identifier.

Full suite 3842/3842.

## Test plan

- [x] `npx vitest run src/cobol/__tests__/call-boundary-lineage.test.ts` — 74/74 (70 existing + 4 new)
- [x] `npx vitest run` — 3842/3842
- [x] `npx tsc --noEmit` — clean
