### PR TITLE
feat(evidence): Phase 2b readiness gates + rebuild auto-regen flag

### DIFF
--- a/docs/evidence-envelope.md
+++ b/docs/evidence-envelope.md
@@ -152,7 +152,7 @@ Without this hook in Phase 2a, Phase 2b is guesswork. Including it now means the
 
 ## Phase 2b flip criteria
 
-Phase 2b ships disabled. The decision to flip `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true` (or set `evidence.rejectUnsupportedWrites: true` in `.agent-wiki.yaml`) is gated on telemetry rather than vibe. The evidence report exposes a **Phase 2b readiness** section that evaluates the gates below against the rolling windows already populated by Phases 1–4. Status is one of `ready` / `not-ready` / `insufficient-data`.
+Phase 2b ships disabled. The decision to flip `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true` (or set `evidence.reject_unsupported_writes: true` in `.agent-wiki.yaml`) is gated on telemetry rather than vibe. The evidence report exposes a **Phase 2b readiness** section that evaluates the gates below against the rolling windows already populated by Phases 1–4. Status is one of `ready` / `not-ready` / `insufficient-data`.
 
 | Gate | Threshold | Window | Why this number |
 |------|-----------|--------|-----------------|

--- a/docs/evidence-envelope.md
+++ b/docs/evidence-envelope.md
@@ -1,6 +1,6 @@
 # Evidence Envelope
 
-**Status: Phases 1–4 delivered. Phase 2b (hard reject) ships disabled and is operator-toggleable via `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED` once the would-reject ratio settles. Section "Phase 0 — design" below is preserved as the original contract; downstream sections describe what shipped.**
+**Status: Phases 1–4 delivered. Phase 2b (hard reject) ships disabled and is operator-toggleable via `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED` once the [Phase 2b flip criteria](#phase-2b-flip-criteria) (concrete numeric gates: 4 weeks under 5% wouldRejectRatio + ≥ 50 writes + search abstain ≤ 30%) are met. The `Phase 2b readiness` section in `wiki/evidence-report.md` is the live verdict. Section "Phase 0 — design" below is preserved as the original contract; downstream sections describe what shipped.**
 
 agent-wiki has accumulated many evidence-like features (raw provenance, frontmatter `sources`, COBOL lineage confidence tiers, graph edge evidence, lint, `raw_coverage`), but each tool exposes them differently. Agents using one tool's output have no reliable way to ask "is this match strong enough to act on?" The envelope is a unified contract every retrieval / query tool will adopt across the evidence-first program (#78).
 
@@ -149,6 +149,26 @@ The headline ratio is `(unsupportedWrites + rejectedWrites) / totalWrites` — *
 The ratio is omitted when the counter file is empty (early deployments would otherwise read as 0%).
 
 Without this hook in Phase 2a, Phase 2b is guesswork. Including it now means the data is collected from day one.
+
+## Phase 2b flip criteria
+
+Phase 2b ships disabled. The decision to flip `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true` (or set `evidence.rejectUnsupportedWrites: true` in `.agent-wiki.yaml`) is gated on telemetry rather than vibe. The evidence report exposes a **Phase 2b readiness** section that evaluates the gates below against the rolling windows already populated by Phases 1–4. Status is one of `ready` / `not-ready` / `insufficient-data`.
+
+| Gate | Threshold | Window | Why this number |
+|------|-----------|--------|-----------------|
+| Total writes | ≥ 50 | last 4 weeks | Below 50 the ratio is too thin — one or two unsupported writes can flip a 0% week into 50%. Caught as `insufficient-data` rather than `not-ready`. |
+| Weekly `wouldRejectRatio` | < 5% per week | each of the last 4 weeks (weeks with 0 writes carry no signal and pass by default) | Per-week (not pooled) so a single bad week blocks the flip. Captures whether the unsupported rate is **sustained** low rather than averaged-low across a spike. |
+| Search abstain ratio | ≤ 30% | last 30 days, requires ≥ 10 searches | Phase 2b tightens the **supply** side of grounding (rejects unsupported writes). If search is already abstaining heavily, the corpus has retrieval problems too; flipping 2b in that state compounds the squeeze. Skipped when there isn't enough search activity to be meaningful. |
+
+The thresholds are conservative — false-positive `ready` would block legitimate writes, which is worse than waiting another week.
+
+**Workflow**:
+
+1. Operators run `wiki_admin --action evidence-report --write=true` (or pass `evidence_report=true` to `wiki_admin --action rebuild` to fold report regeneration into the rebuild) periodically — daily for active corpora, weekly otherwise.
+2. The rendered `wiki/evidence-report.md` shows the Phase 2b readiness verdict and per-gate pass/fail at the bottom. When `status: ready` and `currentlyEnabled: no`, the report includes the explicit `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true` knob to flip.
+3. After flipping, the same gates keep monitoring — `currentlyEnabled: yes` plus continued passing gates is the steady state. If a regression pushes a gate back over its threshold while 2b is on, the report still shows the regression and operators decide whether to flip back to warn mode.
+
+These numbers can be revised once production data accumulates, but a revision is itself a deliberate change documented in this file rather than a silent constant change.
 
 ## Corpus-level evidence report (Phase 4)
 

--- a/src/evidence-report.test.ts
+++ b/src/evidence-report.test.ts
@@ -561,9 +561,10 @@ describe("renderEvidenceReport — Phase 2b readiness section", () => {
     }
     const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
     expect(md).toMatch(/READY/);
-    // Per-week table is the inset 2-space-indented table; check the most
-    // recent week row appears with its ratio shown.
-    expect(md).toMatch(/2026-05-01 \| 60 \| 0 \| 0\.0% \| ✓/);
+    // Per-week table is inset under the gate bullet; the 2-space indent is
+    // load-bearing for Markdown nested-table rendering, so anchor the full
+    // line shape (leading indent + trailing pipe).
+    expect(md).toMatch(/^ {2}\| 2026-05-01 \| 60 \| 0 \| 0\.0% \| ✓ \|$/m);
   });
 
   it("includes the flip-instruction tip only when ready and not yet enabled", () => {
@@ -573,6 +574,11 @@ describe("renderEvidenceReport — Phase 2b readiness section", () => {
     }
     const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
     expect(md).toContain("AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true");
+    // YAML loader uses snake_case (src/wiki.ts: evidenceData.reject_unsupported_writes).
+    // The flip tip must show that exact key so operators copy-pasting it land
+    // on a recognised setting rather than a silently-ignored typo.
+    expect(md).toContain("evidence.reject_unsupported_writes: true");
+    expect(md).not.toContain("evidence.rejectUnsupportedWrites");
   });
 
   it("omits the flip tip when Phase 2b is already enabled", () => {

--- a/src/evidence-report.test.ts
+++ b/src/evidence-report.test.ts
@@ -422,3 +422,169 @@ describe("runEvidenceReport — write flag", () => {
     );
   });
 });
+
+describe("buildEvidenceReport — Phase 2b readiness", () => {
+  const NOW = new Date("2026-05-08T00:00:00.000Z");
+
+  function fillWeek(workspace: string, weekStartISO: string, grounded: number, unsupported: number) {
+    const start = new Date(weekStartISO).getTime();
+    for (let i = 0; i < grounded; i++) {
+      appendWriteEvent(workspace, "grounded", new Date(start + 1000 * (i + 1)).toISOString());
+    }
+    for (let i = 0; i < unsupported; i++) {
+      appendWriteEvent(workspace, "unsupported", new Date(start + 1000 * (grounded + i + 1)).toISOString());
+    }
+  }
+
+  it("returns insufficient-data when total writes < 50", () => {
+    const wiki = freshWiki();
+    fillWeek(wiki.config.workspace, "2026-05-01", 5, 0);
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.status).toBe("insufficient-data");
+    expect(r.gates.totalWrites.passing).toBe(false);
+    expect(r.gates.totalWrites.value).toBe(5);
+    expect(r.gates.totalWrites.threshold).toBe(50);
+    expect(r.reasons.join(" ")).toMatch(/below threshold/);
+  });
+
+  it("returns ready when total writes ≥ 50 and all weekly ratios < 5%", () => {
+    const wiki = freshWiki();
+    // 4 × 31 grounded + 4 × 1 unsupported = 128 writes; per-week ratio 1/32 = 3.1% < 5%
+    fillWeek(wiki.config.workspace, "2026-04-10", 31, 1);
+    fillWeek(wiki.config.workspace, "2026-04-17", 31, 1);
+    fillWeek(wiki.config.workspace, "2026-04-24", 31, 1);
+    fillWeek(wiki.config.workspace, "2026-05-01", 31, 1);
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.status).toBe("ready");
+    expect(r.gates.totalWrites.passing).toBe(true);
+    expect(r.gates.weeklyRatio.passing).toBe(true);
+    expect(r.gates.weeklyRatio.perWeek.every((w) => w.passing)).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+
+  it("returns not-ready when a single week exceeds the 5% threshold", () => {
+    const wiki = freshWiki();
+    fillWeek(wiki.config.workspace, "2026-04-10", 20, 0);
+    fillWeek(wiki.config.workspace, "2026-04-17", 20, 0);
+    fillWeek(wiki.config.workspace, "2026-04-24", 20, 0);
+    fillWeek(wiki.config.workspace, "2026-05-01", 20, 5); // 5/25 = 20%
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.status).toBe("not-ready");
+    expect(r.gates.totalWrites.passing).toBe(true);
+    expect(r.gates.weeklyRatio.passing).toBe(false);
+    const failing = r.gates.weeklyRatio.perWeek.filter((w) => !w.passing);
+    expect(failing).toHaveLength(1);
+    expect(failing[0]!.weekStart).toBe("2026-05-01");
+    expect(r.reasons.join(" ")).toMatch(/above 5%/);
+  });
+
+  it("passes weeks with 0 writes (no signal) — they don't block the gate", () => {
+    const wiki = freshWiki();
+    // Only the most recent week has activity; older weeks are empty.
+    fillWeek(wiki.config.workspace, "2026-05-01", 60, 1);
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.status).toBe("ready");
+    expect(r.gates.weeklyRatio.passing).toBe(true);
+    const empty = r.gates.weeklyRatio.perWeek.filter((w) => w.totalWrites === 0);
+    expect(empty.every((w) => w.passing)).toBe(true);
+    expect(empty.every((w) => w.ratio === null)).toBe(true);
+  });
+
+  it("skips the search abstain gate when fewer than 10 searches in window", () => {
+    const wiki = freshWiki();
+    fillWeek(wiki.config.workspace, "2026-04-10", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-04-17", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-04-24", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-05-01", 15, 0);
+    // 5 searches, half abstaining — would be 50% if applied, but gate skips.
+    for (let i = 0; i < 5; i++) {
+      appendSearchEvent(wiki.config.workspace, {
+        timestamp: new Date(2026, 4, 1 + i).toISOString(),
+        abstainReason: i < 3 ? "below-floor" : null,
+        top1Score: 2.0, top1Top2Ratio: 1.5, confidence: "weak",
+      });
+    }
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.gates.searchAbstain.applicable).toBe(false);
+    expect(r.status).toBe("ready"); // skipped gate doesn't block readiness
+  });
+
+  it("returns not-ready when search abstain ratio > 30% (with enough searches)", () => {
+    const wiki = freshWiki();
+    fillWeek(wiki.config.workspace, "2026-04-10", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-04-17", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-04-24", 15, 0);
+    fillWeek(wiki.config.workspace, "2026-05-01", 15, 0);
+    // 20 searches, 12 abstaining = 60% > 30%
+    for (let i = 0; i < 20; i++) {
+      appendSearchEvent(wiki.config.workspace, {
+        timestamp: new Date(2026, 4, 1 + (i % 7)).toISOString(),
+        abstainReason: i < 12 ? "below-floor" : null,
+        top1Score: 2.0, top1Top2Ratio: 1.5, confidence: "weak",
+      });
+    }
+    const r = buildEvidenceReport(wiki, NOW).phase2bReadiness;
+    expect(r.status).toBe("not-ready");
+    expect(r.gates.searchAbstain.applicable).toBe(true);
+    if (r.gates.searchAbstain.applicable) {
+      expect(r.gates.searchAbstain.passing).toBe(false);
+      expect(r.gates.searchAbstain.value).toBeCloseTo(0.6);
+    }
+    expect(r.reasons.join(" ")).toMatch(/Search abstain ratio/);
+  });
+
+  it("currentlyEnabled mirrors wiki.config.evidence.rejectUnsupportedWrites", () => {
+    const wiki = freshWiki();
+    // Default config: Phase 2b off.
+    expect(buildEvidenceReport(wiki, NOW).phase2bReadiness.currentlyEnabled).toBe(false);
+    // Flip the config directly — this is what the env var resolves to at startup.
+    wiki.config.evidence.rejectUnsupportedWrites = true;
+    expect(buildEvidenceReport(wiki, NOW).phase2bReadiness.currentlyEnabled).toBe(true);
+  });
+});
+
+describe("renderEvidenceReport — Phase 2b readiness section", () => {
+  const NOW = new Date("2026-05-08T00:00:00.000Z");
+
+  it("emits the section header and current-state line in every report", () => {
+    const wiki = freshWiki();
+    const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
+    expect(md).toContain("## Phase 2b readiness");
+    expect(md).toContain("Currently enabled: no");
+    expect(md).toMatch(/INSUFFICIENT DATA/);
+  });
+
+  it("renders per-week gate rows with pass/fail markers", () => {
+    const wiki = freshWiki();
+    for (let i = 0; i < 60; i++) {
+      appendWriteEvent(wiki.config.workspace, "grounded", "2026-05-02T00:00:00.000Z");
+    }
+    const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
+    expect(md).toMatch(/READY/);
+    // Per-week table is the inset 2-space-indented table; check the most
+    // recent week row appears with its ratio shown.
+    expect(md).toMatch(/2026-05-01 \| 60 \| 0 \| 0\.0% \| ✓/);
+  });
+
+  it("includes the flip-instruction tip only when ready and not yet enabled", () => {
+    const wiki = freshWiki();
+    for (let i = 0; i < 60; i++) {
+      appendWriteEvent(wiki.config.workspace, "grounded", "2026-05-02T00:00:00.000Z");
+    }
+    const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
+    expect(md).toContain("AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true");
+  });
+
+  it("omits the flip tip when Phase 2b is already enabled", () => {
+    const wiki = freshWiki();
+    wiki.config.evidence.rejectUnsupportedWrites = true;
+    for (let i = 0; i < 60; i++) {
+      appendWriteEvent(wiki.config.workspace, "grounded", "2026-05-02T00:00:00.000Z");
+    }
+    const md = renderEvidenceReport(buildEvidenceReport(wiki, NOW));
+    expect(md).toContain("Currently enabled: yes");
+    // The flip tip is a "> blockquote ... To flip Phase 2b on, set ..." — the
+    // section header always shows, but the tip should be absent.
+    expect(md).not.toMatch(/To flip Phase 2b on, set/);
+  });
+});

--- a/src/evidence-report.test.ts
+++ b/src/evidence-report.test.ts
@@ -579,6 +579,11 @@ describe("renderEvidenceReport — Phase 2b readiness section", () => {
     // on a recognised setting rather than a silently-ignored typo.
     expect(md).toContain("evidence.reject_unsupported_writes: true");
     expect(md).not.toContain("evidence.rejectUnsupportedWrites");
+    // The flip-criteria link must be an absolute URL — `../docs/...` would
+    // dead-link when wiki/evidence-report.md ships under a user-supplied
+    // wiki/ dir (docs/ is not in the npm package).
+    expect(md).toContain("https://github.com/xinhuagu/agent-wiki/blob/main/docs/evidence-envelope.md");
+    expect(md).not.toMatch(/\(\.\.\/docs\//);
   });
 
   it("omits the flip tip when Phase 2b is already enabled", () => {

--- a/src/evidence-report.test.ts
+++ b/src/evidence-report.test.ts
@@ -15,15 +15,27 @@ import {
 } from "./evidence-report.js";
 
 let testRoot: string;
+let savedRejectEnv: string | undefined;
 function freshWiki(): Wiki {
   return Wiki.init(testRoot);
 }
 
 beforeEach(() => {
   testRoot = mkdtempSync(join(tmpdir(), "evidence-report-"));
+  // Isolate from any developer/CI shell that has set the env var (this
+  // PR explicitly documents it as an operator knob). Otherwise tests
+  // asserting `currentlyEnabled: false` or render output without the
+  // "Currently enabled: yes" line fail spuriously.
+  savedRejectEnv = process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+  delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
 });
 afterEach(() => {
   rmSync(testRoot, { recursive: true, force: true });
+  if (savedRejectEnv === undefined) {
+    delete process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED;
+  } else {
+    process.env.AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED = savedRejectEnv;
+  }
 });
 
 describe("buildEvidenceReport — source coverage", () => {

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -78,12 +78,33 @@ export interface SearchTrust {
  * if the display window is widened. The min-writes threshold below is
  * calibrated to exactly this many weeks; any change here should be
  * paired with a re-calibration of `PHASE2B_MIN_TOTAL_WRITES`.
+ *
+ * Invariant (enforced by `pickGateBuckets`): must be ≤ WEEKS_OF_TREND,
+ * otherwise the gate's `slice(-N)` silently returns fewer buckets than
+ * intended and the threshold would become incorrectly easier to pass.
  */
 const PHASE2B_GATE_WEEKS = 4;
 const PHASE2B_MIN_TOTAL_WRITES = 50;
 const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
 const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
 const PHASE2B_MIN_SEARCHES_FOR_GATE = 10;
+
+/**
+ * Canonical GitHub URL of the flip-criteria section, surfaced in the
+ * rendered report's "ready" tip. Lifted to module scope so a repo
+ * rename or fork only requires updating one literal. The test at
+ * `evidence-report.test.ts` pins this constant indirectly via the
+ * rendered output.
+ *
+ * Why absolute (not `../docs/...`): when `wiki/evidence-report.md`
+ * is rendered under a user-supplied wiki/ dir, the wiki dir's
+ * position relative to docs/ in `node_modules/@agent-wiki/mcp/` is
+ * not stable — there is no guaranteed sibling path the operator
+ * could click. (The npm package does ship `docs/` per package.json
+ * `files`, but at an unrelated location.)
+ */
+const FLIP_CRITERIA_URL =
+  "https://github.com/xinhuagu/agent-wiki/blob/main/docs/evidence-envelope.md#phase-2b-flip-criteria";
 
 /**
  * Phase 2b readiness — operationalises the "once the would-reject ratio
@@ -158,6 +179,26 @@ export function buildEvidenceReport(
   };
 }
 
+/**
+ * Take the most recent PHASE2B_GATE_WEEKS buckets, asserting the trend
+ * is wide enough to satisfy the gate. If `PHASE2B_GATE_WEEKS` is ever
+ * raised above `WEEKS_OF_TREND`, `slice(-N)` would silently return
+ * fewer buckets than the gate expects — failing loud here surfaces the
+ * calibration mismatch rather than letting the min-writes gate become
+ * incorrectly easier.
+ */
+function pickGateBuckets(trend: TrendBucket[]): TrendBucket[] {
+  if (PHASE2B_GATE_WEEKS > trend.length) {
+    throw new Error(
+      `PHASE2B_GATE_WEEKS (${PHASE2B_GATE_WEEKS}) exceeds the available ` +
+        `trend window (${trend.length}). aggregateTrend must return at ` +
+        `least PHASE2B_GATE_WEEKS buckets; widen WEEKS_OF_TREND or lower ` +
+        `the gate.`,
+    );
+  }
+  return trend.slice(-PHASE2B_GATE_WEEKS);
+}
+
 function assessPhase2bReadiness(
   wiki: Wiki,
   trend: TrendBucket[],
@@ -166,9 +207,7 @@ function assessPhase2bReadiness(
   const currentlyEnabled = wiki.config.evidence.rejectUnsupportedWrites;
   const reasons: string[] = [];
 
-  // Take the most recent PHASE2B_GATE_WEEKS buckets explicitly so the gate
-  // logic is independent of `aggregateTrend`'s display window.
-  const gateBuckets = trend.slice(-PHASE2B_GATE_WEEKS);
+  const gateBuckets = pickGateBuckets(trend);
 
   const totalWritesValue = gateBuckets.reduce((acc, b) => acc + b.totalWrites, 0);
   const totalWritesGate = {
@@ -220,16 +259,14 @@ function assessPhase2bReadiness(
         `Wait for more activity before flipping — the ratio is statistically thin.`,
     );
   }
-  // Typed predicate: weeks that fail the gate provably have a non-null
-  // ratio (a null ratio means totalWrites === 0, which passes by default).
-  // The narrowing removes the need for `w.ratio ?? 0` defensiveness below.
-  type FailingWeek = (typeof perWeek)[number] & { ratio: number };
-  const failingWeeks: FailingWeek[] = perWeek.filter(
-    (w): w is FailingWeek => !w.passing && w.ratio !== null,
-  );
+  // Invariant: `passing = ratio === null || ratio < threshold`, so `!passing`
+  // mathematically implies `ratio !== null`. The bang below documents the
+  // invariant at the use site; a discriminated union on passing would be
+  // more elaborate than this small block warrants.
+  const failingWeeks = perWeek.filter((w) => !w.passing);
   if (failingWeeks.length > 0) {
     const list = failingWeeks
-      .map((w) => `${w.weekStart} (${(w.ratio * 100).toFixed(1)}%)`)
+      .map((w) => `${w.weekStart} (${(w.ratio! * 100).toFixed(1)}%)`)
       .join(", ");
     reasons.push(
       `${failingWeeks.length} week(s) above ${(PHASE2B_MAX_WEEKLY_RATIO * 100).toFixed(0)}% wouldRejectRatio: ${list}.`,
@@ -687,16 +724,11 @@ export function renderEvidenceReport(report: EvidenceReport): string {
   }
 
   if (r.status === "ready" && !r.currentlyEnabled) {
-    // Absolute URL: this report is written under a user-supplied wiki/
-    // directory, and the rendered string also goes back to MCP clients
-    // inline; either way a `../docs/...` relative path dead-links because
-    // `docs/` doesn't ship with the npm package. Keep the link layer-
-    // agnostic by pointing at the canonical GitHub source.
     lines.push(
       `> All gates pass. To flip Phase 2b on, set ` +
         `\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\` (env var) or ` +
         `\`evidence.reject_unsupported_writes: true\` in \`.agent-wiki.yaml\`. ` +
-        `See [Phase 2b flip criteria](https://github.com/xinhuagu/agent-wiki/blob/main/docs/evidence-envelope.md#phase-2b-flip-criteria) ` +
+        `See [Phase 2b flip criteria](${FLIP_CRITERIA_URL}) ` +
         `for the rationale.`,
     );
     lines.push("");
@@ -708,7 +740,19 @@ export function renderEvidenceReport(report: EvidenceReport): string {
 /**
  * Generate the report and optionally persist it. Returns the rendered
  * markdown so the MCP caller can also surface it inline.
+ *
+ * Overloads narrow `writtenTo` to `string` when `write: true` so callers
+ * (e.g. `regenerateEvidenceReport` in server.ts) can use the path without
+ * an unreachable fallback.
  */
+export function runEvidenceReport(
+  wiki: Wiki,
+  opts: { write: true; now?: Date },
+): { report: EvidenceReport; markdown: string; writtenTo: string };
+export function runEvidenceReport(
+  wiki: Wiki,
+  opts?: { write?: false; now?: Date },
+): { report: EvidenceReport; markdown: string; writtenTo?: undefined };
 export function runEvidenceReport(
   wiki: Wiki,
   opts: { write?: boolean; now?: Date } = {},

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -81,6 +81,15 @@ export interface SearchTrust {
  * block legitimate writes. See docs/evidence-envelope.md "Phase 2b flip
  * criteria" for the rationale.
  */
+/**
+ * The number of weekly buckets the gates evaluate. Decoupled from the
+ * `WEEKS_OF_TREND` constant that drives the cosmetic "Trend (last N
+ * weeks)" sparkline so the gate's calibration doesn't silently change
+ * if the display window is widened. The min-writes threshold below is
+ * calibrated to exactly this many weeks; any change here should be
+ * paired with a re-calibration of `PHASE2B_MIN_TOTAL_WRITES`.
+ */
+const PHASE2B_GATE_WEEKS = 4;
 const PHASE2B_MIN_TOTAL_WRITES = 50;
 const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
 const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
@@ -157,14 +166,18 @@ function assessPhase2bReadiness(
   const currentlyEnabled = wiki.config.evidence.rejectUnsupportedWrites;
   const reasons: string[] = [];
 
-  const totalWritesValue = trend.reduce((acc, b) => acc + b.totalWrites, 0);
+  // Take the most recent PHASE2B_GATE_WEEKS buckets explicitly so the gate
+  // logic is independent of `aggregateTrend`'s display window.
+  const gateBuckets = trend.slice(-PHASE2B_GATE_WEEKS);
+
+  const totalWritesValue = gateBuckets.reduce((acc, b) => acc + b.totalWrites, 0);
   const totalWritesGate = {
     value: totalWritesValue,
     threshold: PHASE2B_MIN_TOTAL_WRITES,
     passing: totalWritesValue >= PHASE2B_MIN_TOTAL_WRITES,
   };
 
-  const perWeek = trend.map((b) => {
+  const perWeek = gateBuckets.map((b) => {
     const ratio = b.totalWrites === 0 ? null : b.unsupportedOrRejected / b.totalWrites;
     // A week with no writes carries no signal — it neither confirms nor refutes
     // readiness, so it passes by default. The totalWrites gate catches the
@@ -207,10 +220,16 @@ function assessPhase2bReadiness(
         `Wait for more activity before flipping — the ratio is statistically thin.`,
     );
   }
-  const failingWeeks = perWeek.filter((w) => !w.passing);
+  // Typed predicate: weeks that fail the gate provably have a non-null
+  // ratio (a null ratio means totalWrites === 0, which passes by default).
+  // The narrowing removes the need for `w.ratio ?? 0` defensiveness below.
+  type FailingWeek = (typeof perWeek)[number] & { ratio: number };
+  const failingWeeks: FailingWeek[] = perWeek.filter(
+    (w): w is FailingWeek => !w.passing && w.ratio !== null,
+  );
   if (failingWeeks.length > 0) {
     const list = failingWeeks
-      .map((w) => `${w.weekStart} (${((w.ratio ?? 0) * 100).toFixed(1)}%)`)
+      .map((w) => `${w.weekStart} (${(w.ratio * 100).toFixed(1)}%)`)
       .join(", ");
     reasons.push(
       `${failingWeeks.length} week(s) above ${(PHASE2B_MAX_WEEKLY_RATIO * 100).toFixed(0)}% wouldRejectRatio: ${list}.`,
@@ -668,11 +687,16 @@ export function renderEvidenceReport(report: EvidenceReport): string {
   }
 
   if (r.status === "ready" && !r.currentlyEnabled) {
+    // Absolute URL: this report is written under a user-supplied wiki/
+    // directory, and the rendered string also goes back to MCP clients
+    // inline; either way a `../docs/...` relative path dead-links because
+    // `docs/` doesn't ship with the npm package. Keep the link layer-
+    // agnostic by pointing at the canonical GitHub source.
     lines.push(
       `> All gates pass. To flip Phase 2b on, set ` +
         `\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\` (env var) or ` +
         `\`evidence.reject_unsupported_writes: true\` in \`.agent-wiki.yaml\`. ` +
-        `See [Phase 2b flip criteria](../docs/evidence-envelope.md#phase-2b-flip-criteria) ` +
+        `See [Phase 2b flip criteria](https://github.com/xinhuagu/agent-wiki/blob/main/docs/evidence-envelope.md#phase-2b-flip-criteria) ` +
         `for the rationale.`,
     );
     lines.push("");

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -72,16 +72,6 @@ export interface SearchTrust {
 }
 
 /**
- * Phase 2b readiness — operationalises the "once the would-reject ratio
- * settles" decision point in docs/evidence-envelope.md by checking the
- * already-aggregated telemetry against fixed numeric thresholds.
- *
- * Thresholds are intentionally conservative: Phase 2b makes wiki_write
- * hard-fail on unsupported pages, so a false-positive ready signal would
- * block legitimate writes. See docs/evidence-envelope.md "Phase 2b flip
- * criteria" for the rationale.
- */
-/**
  * The number of weekly buckets the gates evaluate. Decoupled from the
  * `WEEKS_OF_TREND` constant that drives the cosmetic "Trend (last N
  * weeks)" sparkline so the gate's calibration doesn't silently change
@@ -95,6 +85,16 @@ const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
 const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
 const PHASE2B_MIN_SEARCHES_FOR_GATE = 10;
 
+/**
+ * Phase 2b readiness — operationalises the "once the would-reject ratio
+ * settles" decision point in docs/evidence-envelope.md by checking the
+ * already-aggregated telemetry against fixed numeric thresholds.
+ *
+ * Thresholds are intentionally conservative: Phase 2b makes wiki_write
+ * hard-fail on unsupported pages, so a false-positive ready signal would
+ * block legitimate writes. See docs/evidence-envelope.md "Phase 2b flip
+ * criteria" for the rationale.
+ */
 export interface Phase2bReadiness {
   status: "ready" | "not-ready" | "insufficient-data";
   /** Already-enabled state from `wiki.config.evidence.rejectUnsupportedWrites`. */
@@ -216,7 +216,7 @@ function assessPhase2bReadiness(
   // week is over the ratio, both show up rather than only the first.
   if (!totalWritesGate.passing) {
     reasons.push(
-      `Total writes over 4 weeks (${totalWritesValue}) below threshold (${PHASE2B_MIN_TOTAL_WRITES}). ` +
+      `Total writes over ${PHASE2B_GATE_WEEKS} weeks (${totalWritesValue}) below threshold (${PHASE2B_MIN_TOTAL_WRITES}). ` +
         `Wait for more activity before flipping — the ratio is statistically thin.`,
     );
   }
@@ -648,7 +648,7 @@ export function renderEvidenceReport(report: EvidenceReport): string {
 
   const tw = r.gates.totalWrites;
   lines.push(
-    `- **Total writes (4-week window)**: ${tw.value} / ${tw.threshold} ${checkmark(tw.passing)}`,
+    `- **Total writes (${PHASE2B_GATE_WEEKS}-week window)**: ${tw.value} / ${tw.threshold} ${checkmark(tw.passing)}`,
   );
 
   const wr = r.gates.weeklyRatio;

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -179,26 +179,6 @@ export function buildEvidenceReport(
   };
 }
 
-/**
- * Take the most recent PHASE2B_GATE_WEEKS buckets, asserting the trend
- * is wide enough to satisfy the gate. If `PHASE2B_GATE_WEEKS` is ever
- * raised above `WEEKS_OF_TREND`, `slice(-N)` would silently return
- * fewer buckets than the gate expects — failing loud here surfaces the
- * calibration mismatch rather than letting the min-writes gate become
- * incorrectly easier.
- */
-function pickGateBuckets(trend: TrendBucket[]): TrendBucket[] {
-  if (PHASE2B_GATE_WEEKS > trend.length) {
-    throw new Error(
-      `PHASE2B_GATE_WEEKS (${PHASE2B_GATE_WEEKS}) exceeds the available ` +
-        `trend window (${trend.length}). aggregateTrend must return at ` +
-        `least PHASE2B_GATE_WEEKS buckets; widen WEEKS_OF_TREND or lower ` +
-        `the gate.`,
-    );
-  }
-  return trend.slice(-PHASE2B_GATE_WEEKS);
-}
-
 function assessPhase2bReadiness(
   wiki: Wiki,
   trend: TrendBucket[],
@@ -207,7 +187,14 @@ function assessPhase2bReadiness(
   const currentlyEnabled = wiki.config.evidence.rejectUnsupportedWrites;
   const reasons: string[] = [];
 
-  const gateBuckets = pickGateBuckets(trend);
+  // Inline guard so a future bump of PHASE2B_GATE_WEEKS past WEEKS_OF_TREND
+  // fails loud instead of silently making the gate easier to pass.
+  if (trend.length < PHASE2B_GATE_WEEKS) {
+    throw new Error(
+      `Trend window (${trend.length}) shorter than PHASE2B_GATE_WEEKS (${PHASE2B_GATE_WEEKS}); widen WEEKS_OF_TREND.`,
+    );
+  }
+  const gateBuckets = trend.slice(-PHASE2B_GATE_WEEKS);
 
   const totalWritesValue = gateBuckets.reduce((acc, b) => acc + b.totalWrites, 0);
   const totalWritesGate = {
@@ -739,20 +726,10 @@ export function renderEvidenceReport(report: EvidenceReport): string {
 
 /**
  * Generate the report and optionally persist it. Returns the rendered
- * markdown so the MCP caller can also surface it inline.
- *
- * Overloads narrow `writtenTo` to `string` when `write: true` so callers
- * (e.g. `regenerateEvidenceReport` in server.ts) can use the path without
- * an unreachable fallback.
+ * markdown so the MCP caller can also surface it inline. `writtenTo` is
+ * set when `write: true`; callers that need it as a non-optional string
+ * should null-check at the use site.
  */
-export function runEvidenceReport(
-  wiki: Wiki,
-  opts: { write: true; now?: Date },
-): { report: EvidenceReport; markdown: string; writtenTo: string };
-export function runEvidenceReport(
-  wiki: Wiki,
-  opts?: { write?: false; now?: Date },
-): { report: EvidenceReport; markdown: string; writtenTo?: undefined };
 export function runEvidenceReport(
   wiki: Wiki,
   opts: { write?: boolean; now?: Date } = {},

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -79,9 +79,11 @@ export interface SearchTrust {
  * calibrated to exactly this many weeks; any change here should be
  * paired with a re-calibration of `PHASE2B_MIN_TOTAL_WRITES`.
  *
- * Invariant (enforced by `pickGateBuckets`): must be ≤ WEEKS_OF_TREND,
- * otherwise the gate's `slice(-N)` silently returns fewer buckets than
- * intended and the threshold would become incorrectly easier to pass.
+ * Invariant (enforced inline in `assessPhase2bReadiness` by the
+ * `trend.length < PHASE2B_GATE_WEEKS` guard before the `slice(-N)`):
+ * must be ≤ `WEEKS_OF_TREND`, otherwise the slice silently returns
+ * fewer buckets than intended and the threshold would become
+ * incorrectly easier to pass.
  */
 const PHASE2B_GATE_WEEKS = 4;
 const PHASE2B_MIN_TOTAL_WRITES = 50;

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -71,6 +71,53 @@ export interface SearchTrust {
   ratioHistogram: { lt15: number; lt20: number; lt30: number; ge30: number };
 }
 
+/**
+ * Phase 2b readiness — operationalises the "once the would-reject ratio
+ * settles" decision point in docs/evidence-envelope.md by checking the
+ * already-aggregated telemetry against fixed numeric thresholds.
+ *
+ * Thresholds are intentionally conservative: Phase 2b makes wiki_write
+ * hard-fail on unsupported pages, so a false-positive ready signal would
+ * block legitimate writes. See docs/evidence-envelope.md "Phase 2b flip
+ * criteria" for the rationale.
+ */
+export const PHASE2B_MIN_TOTAL_WRITES = 50;
+export const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
+export const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
+export const PHASE2B_MIN_SEARCHES_FOR_GATE = 10;
+
+export interface Phase2bReadiness {
+  status: "ready" | "not-ready" | "insufficient-data";
+  /** Already-enabled state from `wiki.config.evidence.rejectUnsupportedWrites`. */
+  currentlyEnabled: boolean;
+  /** Per-gate verdicts. A gate with `applicable: false` is skipped from the status decision. */
+  gates: {
+    totalWrites: {
+      applicable: true;
+      value: number;
+      threshold: number;
+      passing: boolean;
+    };
+    weeklyRatio: {
+      applicable: true;
+      threshold: number;
+      perWeek: Array<{
+        weekStart: string;
+        totalWrites: number;
+        unsupportedOrRejected: number;
+        ratio: number | null;       // null when totalWrites === 0
+        passing: boolean;            // true when ratio is null (no signal) or < threshold
+      }>;
+      passing: boolean;             // every week with data passes
+    };
+    searchAbstain:
+      | { applicable: true; value: number; threshold: number; passing: boolean }
+      | { applicable: false; reason: string };
+  };
+  /** Plain-English summary of what is blocking readiness, if anything. */
+  reasons: string[];
+}
+
 export interface EvidenceReport {
   generatedAt: string;
   source: SourceCoverage;
@@ -81,18 +128,120 @@ export interface EvidenceReport {
     fieldLineage?: FieldLineageDiagnosticsSection;
   };
   trend: TrendBucket[];
+  phase2bReadiness: Phase2bReadiness;
 }
 
 export function buildEvidenceReport(
   wiki: Wiki,
   now: Date = new Date(),
 ): EvidenceReport {
+  const searchTrust = aggregateSearchTrust(wiki, now);
+  const trend = aggregateTrend(wiki, now);
   return {
     generatedAt: now.toISOString(),
     source: aggregateSourceCoverage(wiki),
-    searchTrust: aggregateSearchTrust(wiki, now),
+    searchTrust,
     lineage: aggregateCobolLineage(wiki),
-    trend: aggregateTrend(wiki, now),
+    trend,
+    phase2bReadiness: assessPhase2bReadiness(wiki, trend, searchTrust),
+  };
+}
+
+function assessPhase2bReadiness(
+  wiki: Wiki,
+  trend: TrendBucket[],
+  searchTrust: SearchTrust,
+): Phase2bReadiness {
+  const currentlyEnabled = wiki.config.evidence.rejectUnsupportedWrites;
+  const reasons: string[] = [];
+
+  const totalWritesValue = trend.reduce((acc, b) => acc + b.totalWrites, 0);
+  const totalWritesGate = {
+    applicable: true as const,
+    value: totalWritesValue,
+    threshold: PHASE2B_MIN_TOTAL_WRITES,
+    passing: totalWritesValue >= PHASE2B_MIN_TOTAL_WRITES,
+  };
+
+  const perWeek = trend.map((b) => {
+    const ratio = b.totalWrites === 0 ? null : b.unsupportedOrRejected / b.totalWrites;
+    // A week with no writes carries no signal — it neither confirms nor refutes
+    // readiness, so it passes by default. The totalWrites gate catches the
+    // case where all four weeks are empty.
+    const passing = ratio === null || ratio < PHASE2B_MAX_WEEKLY_RATIO;
+    return {
+      weekStart: b.weekStart,
+      totalWrites: b.totalWrites,
+      unsupportedOrRejected: b.unsupportedOrRejected,
+      ratio,
+      passing,
+    };
+  });
+  const weeklyRatioGate = {
+    applicable: true as const,
+    threshold: PHASE2B_MAX_WEEKLY_RATIO,
+    perWeek,
+    passing: perWeek.every((w) => w.passing),
+  };
+
+  const searchAbstainGate: Phase2bReadiness["gates"]["searchAbstain"] =
+    searchTrust.totalSearches >= PHASE2B_MIN_SEARCHES_FOR_GATE &&
+    searchTrust.abstainRatio !== null
+      ? {
+          applicable: true,
+          value: searchTrust.abstainRatio,
+          threshold: PHASE2B_MAX_SEARCH_ABSTAIN_RATIO,
+          passing: searchTrust.abstainRatio <= PHASE2B_MAX_SEARCH_ABSTAIN_RATIO,
+        }
+      : {
+          applicable: false,
+          reason: `fewer than ${PHASE2B_MIN_SEARCHES_FOR_GATE} searches in the last 30 days — not enough signal to gate on`,
+        };
+
+  // Collect reasons for every failing gate, regardless of status. This keeps
+  // the operator-visible "why" complete: if total writes are too thin AND a
+  // week is over the ratio, both show up rather than only the first.
+  if (!totalWritesGate.passing) {
+    reasons.push(
+      `Total writes over 4 weeks (${totalWritesValue}) below threshold (${PHASE2B_MIN_TOTAL_WRITES}). ` +
+        `Wait for more activity before flipping — the ratio is statistically thin.`,
+    );
+  }
+  const failingWeeks = perWeek.filter((w) => !w.passing);
+  if (failingWeeks.length > 0) {
+    const list = failingWeeks
+      .map((w) => `${w.weekStart} (${((w.ratio ?? 0) * 100).toFixed(1)}%)`)
+      .join(", ");
+    reasons.push(
+      `${failingWeeks.length} week(s) above ${(PHASE2B_MAX_WEEKLY_RATIO * 100).toFixed(0)}% wouldRejectRatio: ${list}.`,
+    );
+  }
+  if (searchAbstainGate.applicable && !searchAbstainGate.passing) {
+    reasons.push(
+      `Search abstain ratio (${(searchAbstainGate.value * 100).toFixed(1)}%) above ` +
+        `${(PHASE2B_MAX_SEARCH_ABSTAIN_RATIO * 100).toFixed(0)}% — many queries are returning weak matches; ` +
+        `Phase 2b would also tighten the supply side, compounding the problem.`,
+    );
+  }
+
+  // Status: insufficient-data takes precedence (we can't make a real call yet
+  // — a single bad week against 5 writes is noise, not signal). Otherwise,
+  // every applicable gate must pass.
+  let status: Phase2bReadiness["status"];
+  if (!totalWritesGate.passing) {
+    status = "insufficient-data";
+  } else {
+    const allGatesPass =
+      weeklyRatioGate.passing &&
+      (!searchAbstainGate.applicable || searchAbstainGate.passing);
+    status = allGatesPass ? "ready" : "not-ready";
+  }
+
+  return {
+    status,
+    currentlyEnabled,
+    gates: { totalWrites: totalWritesGate, weeklyRatio: weeklyRatioGate, searchAbstain: searchAbstainGate },
+    reasons,
   };
 }
 
@@ -459,6 +608,73 @@ export function renderEvidenceReport(report: EvidenceReport): string {
     }
   }
   lines.push("");
+
+  // ── Section 5: Phase 2b readiness ──────────────────────────────────
+  const r = report.phase2bReadiness;
+  lines.push(`## Phase 2b readiness`);
+  lines.push("");
+  const statusLabel =
+    r.status === "ready" ? "READY — gates pass; safe to consider flipping"
+    : r.status === "not-ready" ? "NOT READY — see reasons below"
+    : "INSUFFICIENT DATA — too few writes to judge yet";
+  lines.push(`- Status: **${statusLabel}**`);
+  lines.push(`- Currently enabled: ${r.currentlyEnabled ? "yes (\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\`)" : "no"}`);
+  lines.push("");
+
+  lines.push(`### Gates`);
+  lines.push("");
+  const checkmark = (p: boolean) => (p ? "✓" : "✗");
+
+  const tw = r.gates.totalWrites;
+  lines.push(
+    `- **Total writes (4-week window)**: ${tw.value} / ${tw.threshold} ${checkmark(tw.passing)}`,
+  );
+
+  const wr = r.gates.weeklyRatio;
+  lines.push(
+    `- **Weekly wouldRejectRatio < ${(wr.threshold * 100).toFixed(0)}%**: ${checkmark(wr.passing)}`,
+  );
+  lines.push("");
+  lines.push(`  | Week start | Writes | Unsupp/Rej | Ratio | Pass |`);
+  lines.push(`  |------------|--------|------------|-------|------|`);
+  for (const w of wr.perWeek) {
+    const ratioStr = w.ratio === null ? "—" : `${(w.ratio * 100).toFixed(1)}%`;
+    lines.push(
+      `  | ${w.weekStart} | ${w.totalWrites} | ${w.unsupportedOrRejected} | ${ratioStr} | ${checkmark(w.passing)} |`,
+    );
+  }
+  lines.push("");
+
+  const sa = r.gates.searchAbstain;
+  if (sa.applicable) {
+    lines.push(
+      `- **Search abstain ratio (30d) ≤ ${(sa.threshold * 100).toFixed(0)}%**: ` +
+        `${(sa.value * 100).toFixed(1)}% ${checkmark(sa.passing)}`,
+    );
+  } else {
+    lines.push(`- **Search abstain ratio (30d)**: skipped — ${sa.reason}`);
+  }
+  lines.push("");
+
+  if (r.reasons.length > 0) {
+    lines.push(`### Reasons`);
+    lines.push("");
+    for (const reason of r.reasons) {
+      lines.push(`- ${reason}`);
+    }
+    lines.push("");
+  }
+
+  if (r.status === "ready" && !r.currentlyEnabled) {
+    lines.push(
+      `> All gates pass. To flip Phase 2b on, set ` +
+        `\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\` (env var) or ` +
+        `\`evidence.rejectUnsupportedWrites: true\` in \`.agent-wiki.yaml\`. ` +
+        `See [Phase 2b flip criteria](../docs/evidence-envelope.md#phase-2b-flip-criteria) ` +
+        `for the rationale.`,
+    );
+    lines.push("");
+  }
 
   return lines.join("\n");
 }

--- a/src/evidence-report.ts
+++ b/src/evidence-report.ts
@@ -81,25 +81,27 @@ export interface SearchTrust {
  * block legitimate writes. See docs/evidence-envelope.md "Phase 2b flip
  * criteria" for the rationale.
  */
-export const PHASE2B_MIN_TOTAL_WRITES = 50;
-export const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
-export const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
-export const PHASE2B_MIN_SEARCHES_FOR_GATE = 10;
+const PHASE2B_MIN_TOTAL_WRITES = 50;
+const PHASE2B_MAX_WEEKLY_RATIO = 0.05;
+const PHASE2B_MAX_SEARCH_ABSTAIN_RATIO = 0.30;
+const PHASE2B_MIN_SEARCHES_FOR_GATE = 10;
 
 export interface Phase2bReadiness {
   status: "ready" | "not-ready" | "insufficient-data";
   /** Already-enabled state from `wiki.config.evidence.rejectUnsupportedWrites`. */
   currentlyEnabled: boolean;
-  /** Per-gate verdicts. A gate with `applicable: false` is skipped from the status decision. */
+  /**
+   * Per-gate verdicts. `totalWrites` and `weeklyRatio` always evaluate;
+   * `searchAbstain` may report `applicable: false` when the 30-day search
+   * volume is too low for the gate to be meaningful.
+   */
   gates: {
     totalWrites: {
-      applicable: true;
       value: number;
       threshold: number;
       passing: boolean;
     };
     weeklyRatio: {
-      applicable: true;
       threshold: number;
       perWeek: Array<{
         weekStart: string;
@@ -157,7 +159,6 @@ function assessPhase2bReadiness(
 
   const totalWritesValue = trend.reduce((acc, b) => acc + b.totalWrites, 0);
   const totalWritesGate = {
-    applicable: true as const,
     value: totalWritesValue,
     threshold: PHASE2B_MIN_TOTAL_WRITES,
     passing: totalWritesValue >= PHASE2B_MIN_TOTAL_WRITES,
@@ -178,7 +179,6 @@ function assessPhase2bReadiness(
     };
   });
   const weeklyRatioGate = {
-    applicable: true as const,
     threshold: PHASE2B_MAX_WEEKLY_RATIO,
     perWeek,
     passing: perWeek.every((w) => w.passing),
@@ -618,7 +618,9 @@ export function renderEvidenceReport(report: EvidenceReport): string {
     : r.status === "not-ready" ? "NOT READY — see reasons below"
     : "INSUFFICIENT DATA — too few writes to judge yet";
   lines.push(`- Status: **${statusLabel}**`);
-  lines.push(`- Currently enabled: ${r.currentlyEnabled ? "yes (\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\`)" : "no"}`);
+  // `currentlyEnabled` resolves from env var OR YAML config; don't attribute
+  // to one specific knob since the operator may have flipped either.
+  lines.push(`- Currently enabled: ${r.currentlyEnabled ? "yes" : "no"}`);
   lines.push("");
 
   lines.push(`### Gates`);
@@ -669,7 +671,7 @@ export function renderEvidenceReport(report: EvidenceReport): string {
     lines.push(
       `> All gates pass. To flip Phase 2b on, set ` +
         `\`AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true\` (env var) or ` +
-        `\`evidence.rejectUnsupportedWrites: true\` in \`.agent-wiki.yaml\`. ` +
+        `\`evidence.reject_unsupported_writes: true\` in \`.agent-wiki.yaml\`. ` +
         `See [Phase 2b flip criteria](../docs/evidence-envelope.md#phase-2b-flip-criteria) ` +
         `for the rationale.`,
     );

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2348,6 +2348,10 @@ describe("consolidated tool: wiki_admin", () => {
     // The Phase 2b readiness section should appear in the persisted report.
     const content = readFileSync(reportPath, "utf-8");
     expect(content).toContain("## Phase 2b readiness");
+    // On success, no structured failure field is emitted — the field
+    // exists only when regen failed (parity with the batch path's
+    // deferred-entry mutation shape).
+    expect(parsed.evidenceReport).toBeUndefined();
   });
 
   it("action:rebuild without evidence_report leaves the report file untouched", async () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3038,4 +3038,31 @@ Extra content.` } },
     const rebuildResult = parsed.results.find((r: any) => r.tool === "wiki_admin");
     expect(rebuildResult?.result?.deferred).toMatch(/rebuild/);
   });
+
+  it("batch preserves evidence_report:true on deduped wiki_admin rebuild", async () => {
+    // Regression: dedup originally stripped the flag and the end-of-batch
+    // path only ran rebuildIndex+rebuildTimeline, so wiki/evidence-report.md
+    // never appeared even though the standalone call did write it.
+    const wiki = freshWiki();
+    const reportPath = join(wiki.config.wikiDir, "evidence-report.md");
+    expect(existsSync(reportPath)).toBe(false);
+    await handleTool(wiki, "batch", {
+      operations: [
+        { tool: "wiki_admin", args: { action: "rebuild", evidence_report: true } },
+      ],
+    });
+    expect(existsSync(reportPath)).toBe(true);
+    expect(readFileSync(reportPath, "utf-8")).toContain("## Phase 2b readiness");
+  });
+
+  it("batch leaves report untouched when evidence_report flag is absent on rebuild", async () => {
+    const wiki = freshWiki();
+    const reportPath = join(wiki.config.wikiDir, "evidence-report.md");
+    await handleTool(wiki, "batch", {
+      operations: [
+        { tool: "wiki_admin", args: { action: "rebuild" } },
+      ],
+    });
+    expect(existsSync(reportPath)).toBe(false);
+  });
 });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2332,6 +2332,31 @@ describe("consolidated tool: wiki_admin", () => {
     expect(parsed.writtenTo).toBeDefined();
     expect(existsSync(join(wiki.config.wikiDir, "evidence-report.md"))).toBe(true);
   });
+
+  it("action:rebuild with evidence_report:true also writes the evidence report", async () => {
+    const wiki = freshWiki();
+    const reportPath = join(wiki.config.wikiDir, "evidence-report.md");
+    expect(existsSync(reportPath)).toBe(false);
+    const result = await handleTool(wiki, "wiki_admin", {
+      action: "rebuild",
+      evidence_report: true,
+    });
+    const parsed = JSON.parse(result as string);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.message).toMatch(/Evidence report written/);
+    expect(existsSync(reportPath)).toBe(true);
+    // The Phase 2b readiness section should appear in the persisted report.
+    const content = readFileSync(reportPath, "utf-8");
+    expect(content).toContain("## Phase 2b readiness");
+  });
+
+  it("action:rebuild without evidence_report leaves the report file untouched", async () => {
+    const wiki = freshWiki();
+    const reportPath = join(wiki.config.wikiDir, "evidence-report.md");
+    expect(existsSync(reportPath)).toBe(false);
+    await handleTool(wiki, "wiki_admin", { action: "rebuild" });
+    expect(existsSync(reportPath)).toBe(false);
+  });
 });
 
 describe("consolidated tool: code_query", () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -3046,13 +3046,21 @@ Extra content.` } },
     const wiki = freshWiki();
     const reportPath = join(wiki.config.wikiDir, "evidence-report.md");
     expect(existsSync(reportPath)).toBe(false);
-    await handleTool(wiki, "batch", {
+    const result = await handleTool(wiki, "batch", {
       operations: [
         { tool: "wiki_admin", args: { action: "rebuild", evidence_report: true } },
       ],
     });
     expect(existsSync(reportPath)).toBe(true);
     expect(readFileSync(reportPath, "utf-8")).toContain("## Phase 2b readiness");
+    // Invariant: 1 op → 1 result entry. The evidence-report regen lives
+    // inside the deferred rebuild's entry, never as a sibling that would
+    // inflate `count` and break op→result alignment for callers.
+    const parsed = JSON.parse(result as string);
+    expect(parsed.count).toBe(1);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].tool).toBe("wiki_admin");
+    expect(parsed.results[0].result?.deferred).toMatch(/rebuild/);
   });
 
   it("batch leaves report untouched when evidence_report flag is absent on rebuild", async () => {
@@ -3064,5 +3072,22 @@ Extra content.` } },
       ],
     });
     expect(existsSync(reportPath)).toBe(false);
+  });
+
+  it("batch rebuild runs evidence migration so legacy pages classify equivalently to inline rebuild", async () => {
+    // Without batch-side migration, the report's Source coverage would
+    // bucket pre-migration legacy pages as `other` instead of
+    // `legacyUnsupported` — divergence from the inline rebuild path.
+    // Marker file presence under .agent-wiki/ is the canonical signal that
+    // migration ran.
+    const wiki = freshWiki();
+    const marker = join(wiki.config.workspace, ".agent-wiki", "evidence-migrated");
+    expect(existsSync(marker)).toBe(false);
+    await handleTool(wiki, "batch", {
+      operations: [
+        { tool: "wiki_admin", args: { action: "rebuild", evidence_report: true } },
+      ],
+    });
+    expect(existsSync(marker)).toBe(true);
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -3116,6 +3116,11 @@ export async function handleTool(
       // op from this batch — the end-of-batch rebuild block below regenerates
       // the report once so the opt-in flag survives dedup.
       let needsEvidenceReport = false;
+      // Deferred entries from rebuild ops that asked for evidence_report:true.
+      // Held by reference so we can mutate them in place on regen failure —
+      // keeps the 1-op→1-result invariant and the established `{ tool, result }`
+      // shape rather than introducing a sibling entry on failure.
+      const rebuildEntriesAwaitingEvidence: Array<Record<string, unknown>> = [];
 
       const results: Array<Record<string, unknown>> = [];
       for (const op of ops) {
@@ -3129,8 +3134,15 @@ export async function handleTool(
         if (isRebuild) {
           needsRebuild = true;
           needsTimeline = true;
-          if (op.args?.evidence_report === true) needsEvidenceReport = true;
-          results.push({ tool: op.tool, result: { ok: true, deferred: "merged into end-of-batch rebuild" } });
+          const entry: Record<string, unknown> = {
+            tool: op.tool,
+            result: { ok: true, deferred: "merged into end-of-batch rebuild" },
+          };
+          results.push(entry);
+          if (op.args?.evidence_report === true) {
+            needsEvidenceReport = true;
+            rebuildEntriesAwaitingEvidence.push(entry);
+          }
           continue;
         }
         try {
@@ -3186,19 +3198,29 @@ export async function handleTool(
         const pageCache = wiki.buildPageCache();
         wiki.rebuildIndex(pageCache);
         if (needsTimeline) wiki.rebuildTimeline(pageCache);
+        // Mirror inline rebuild's evidence migration step. Without this,
+        // batch-generated evidence reports misclassify pre-migration legacy
+        // pages as `other` instead of `legacyUnsupported`. Migration is
+        // marker-file-gated and one-shot, so the call is a no-op after the
+        // first run on any given workspace.
+        try {
+          const pluginIds = listPlugins().map((p) => p.id);
+          migrateExistingPagesForEvidence(wiki, pluginIds);
+        } catch { /* never fails the rebuild */ }
       }
       if (needsEvidenceReport) {
-        // Surface failure as a follow-up result entry so the batch caller
-        // sees the partial-success state. Mirrors the inline rebuild path,
-        // which pushes the same string into `parts` (see
-        // regenerateEvidenceReport's docblock). On success the report
-        // file presence is the operator's signal — no extra entry needed.
         const evResult = regenerateEvidenceReport(wiki);
         if (!evResult.ok) {
-          results.push({
-            tool: "wiki_admin",
-            warning: `Evidence report regeneration failed: ${evResult.error}`,
-          });
+          // Surface failure in-place on the deferred entry so the caller
+          // gets one result per op, keeping `count: results.length` honest
+          // and the shape uniform with the rest of this handler.
+          for (const entry of rebuildEntriesAwaitingEvidence) {
+            const prior = entry.result as Record<string, unknown>;
+            entry.result = {
+              ...prior,
+              evidenceReport: { ok: false, error: evResult.error },
+            };
+          }
         }
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1803,6 +1803,25 @@ function readPagesContent(
   return pages;
 }
 
+/**
+ * Best-effort regeneration of `wiki/evidence-report.md`, used by the
+ * `wiki_admin action:rebuild evidence_report:true` flag on both the
+ * inline and batched code paths. The rebuild itself never fails on
+ * evidence bookkeeping, but the flag is operator-requested — both
+ * callers surface success or failure into their visible response so
+ * `ok:true` never implies the regen happened when it didn't.
+ */
+function regenerateEvidenceReport(
+  wiki: Wiki,
+): { ok: true; writtenTo: string } | { ok: false; error: string } {
+  try {
+    const er = runEvidenceReport(wiki, { write: true });
+    return { ok: true, writtenTo: er.writtenTo ?? "wiki/evidence-report.md" };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export async function handleTool(
   wiki: Wiki,
   name: string,
@@ -2316,7 +2335,10 @@ export async function handleTool(
     }
 
     case "wiki_evidence_report": {
-      const write = (args.write as boolean) ?? false;
+      // Strict boolean match — mirrors the batch-handler coercion at the
+      // wiki_admin rebuild evidence_report:true sniff so the two flags
+      // agree on what "true" means for direct (non-MCP) callers too.
+      const write = args.write === true;
       const result = runEvidenceReport(wiki, { write });
       return JSON.stringify({
         report: result.report,
@@ -2468,19 +2490,13 @@ export async function handleTool(
 
       // Opt-in: regenerate the evidence report alongside the rebuild so the
       // dashboard stays fresh without a separate wiki_admin evidence-report
-      // call. The rebuild itself never fails on evidence bookkeeping, but
-      // since this flag is operator-requested (vs. silent telemetry), we
-      // surface the failure in `parts` instead of swallowing it — otherwise
-      // ok:true would imply the regen happened when it didn't.
-      const wantEvidenceReport = (args.evidence_report as boolean) ?? false;
-      if (wantEvidenceReport) {
-        try {
-          const er = runEvidenceReport(wiki, { write: true });
-          parts.push(`Evidence report written to ${er.writtenTo}`);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          parts.push(`Evidence report regeneration failed: ${msg}`);
-        }
+      // call. See regenerateEvidenceReport's docblock for the operator-
+      // surface-failure contract; the batch path mirrors this exact shape.
+      if (args.evidence_report === true) {
+        const evResult = regenerateEvidenceReport(wiki);
+        parts.push(evResult.ok
+          ? `Evidence report written to ${evResult.writtenTo}`
+          : `Evidence report regeneration failed: ${evResult.error}`);
       }
 
       return JSON.stringify({ ok: true, message: parts.join(". ") + "." });
@@ -3172,9 +3188,18 @@ export async function handleTool(
         if (needsTimeline) wiki.rebuildTimeline(pageCache);
       }
       if (needsEvidenceReport) {
-        try {
-          runEvidenceReport(wiki, { write: true });
-        } catch { /* best-effort, mirrors the inline rebuild path's tolerance */ }
+        // Surface failure as a follow-up result entry so the batch caller
+        // sees the partial-success state. Mirrors the inline rebuild path,
+        // which pushes the same string into `parts` (see
+        // regenerateEvidenceReport's docblock). On success the report
+        // file presence is the operator's signal — no extra entry needed.
+        const evResult = regenerateEvidenceReport(wiki);
+        if (!evResult.ok) {
+          results.push({
+            tool: "wiki_admin",
+            warning: `Evidence report regeneration failed: ${evResult.error}`,
+          });
+        }
       }
 
       return JSON.stringify({ results, count: results.length }, null, 2);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2468,16 +2468,19 @@ export async function handleTool(
 
       // Opt-in: regenerate the evidence report alongside the rebuild so the
       // dashboard stays fresh without a separate wiki_admin evidence-report
-      // call. Best-effort — never fails the rebuild.
-      let evidenceReportWritten: string | undefined;
-      if ((args.evidence_report as boolean) === true) {
+      // call. The rebuild itself never fails on evidence bookkeeping, but
+      // since this flag is operator-requested (vs. silent telemetry), we
+      // surface the failure in `parts` instead of swallowing it — otherwise
+      // ok:true would imply the regen happened when it didn't.
+      const wantEvidenceReport = (args.evidence_report as boolean) ?? false;
+      if (wantEvidenceReport) {
         try {
           const er = runEvidenceReport(wiki, { write: true });
-          evidenceReportWritten = er.writtenTo;
-        } catch { /* ignore — evidence bookkeeping never fails a rebuild */ }
-      }
-      if (evidenceReportWritten) {
-        parts.push(`Evidence report written to ${evidenceReportWritten}`);
+          parts.push(`Evidence report written to ${er.writtenTo}`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          parts.push(`Evidence report regeneration failed: ${msg}`);
+        }
       }
 
       return JSON.stringify({ ok: true, message: parts.join(". ") + "." });
@@ -3093,6 +3096,10 @@ export async function handleTool(
       let needsRebuild = false;
       let needsTimeline = false;
       let needsGraphRebuild = false;
+      // Carries through any `wiki_admin action:rebuild evidence_report:true`
+      // op from this batch — the end-of-batch rebuild block below regenerates
+      // the report once so the opt-in flag survives dedup.
+      let needsEvidenceReport = false;
 
       const results: Array<Record<string, unknown>> = [];
       for (const op of ops) {
@@ -3106,6 +3113,7 @@ export async function handleTool(
         if (isRebuild) {
           needsRebuild = true;
           needsTimeline = true;
+          if (op.args?.evidence_report === true) needsEvidenceReport = true;
           results.push({ tool: op.tool, result: { ok: true, deferred: "merged into end-of-batch rebuild" } });
           continue;
         }
@@ -3162,6 +3170,11 @@ export async function handleTool(
         const pageCache = wiki.buildPageCache();
         wiki.rebuildIndex(pageCache);
         if (needsTimeline) wiki.rebuildTimeline(pageCache);
+      }
+      if (needsEvidenceReport) {
+        try {
+          runEvidenceReport(wiki, { write: true });
+        } catch { /* best-effort, mirrors the inline rebuild path's tolerance */ }
       }
 
       return JSON.stringify({ results, count: results.length }, null, 2);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1804,22 +1804,85 @@ function readPagesContent(
 }
 
 /**
- * Best-effort regeneration of `wiki/evidence-report.md`, used by the
- * `wiki_admin action:rebuild evidence_report:true` flag on both the
- * inline and batched code paths. The rebuild itself never fails on
- * evidence bookkeeping, but the flag is operator-requested — both
- * callers surface success or failure into their visible response so
- * `ok:true` never implies the regen happened when it didn't.
+ * Best-effort regeneration of `wiki/evidence-report.md`. Called from
+ * `runPostRebuildEvidence` below, which both the inline and batched
+ * rebuild paths invoke. The rebuild never fails on evidence
+ * bookkeeping, but the flag is operator-requested — both callers
+ * surface success or failure into their visible response so `ok:true`
+ * never implies the regen happened when it didn't.
  */
 function regenerateEvidenceReport(
   wiki: Wiki,
 ): { ok: true; writtenTo: string } | { ok: false; error: string } {
   try {
+    // The `write: true` overload narrows `writtenTo` to `string`, so no
+    // unreachable fallback is needed here.
     const er = runEvidenceReport(wiki, { write: true });
-    return { ok: true, writtenTo: er.writtenTo ?? "wiki/evidence-report.md" };
+    return { ok: true, writtenTo: er.writtenTo };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
+}
+
+/**
+ * Single source of truth for the post-rebuild evidence bookkeeping that
+ * both `wiki_admin action:rebuild` (inline) and the end-of-batch rebuild
+ * path execute: (1) one-shot migration of pre-existing pages, (2) weekly
+ * digest line into wiki/log.md, (3) optional opt-in evidence-report regen.
+ *
+ * Returns:
+ *   - `parts`: message fragments for the inline handler to append to its
+ *     ok-message. The batch handler does not surface these and may
+ *     discard them — current behavior is to omit migration / digest
+ *     messages from batch responses (they remain in log.md).
+ *   - `evidence`: the regen result when `regenerateReport` was true,
+ *     `null` otherwise. Both call sites consume this to surface failure
+ *     into their visible response shape.
+ */
+function runPostRebuildEvidence(
+  wiki: Wiki,
+  opts: { regenerateReport: boolean },
+): {
+  parts: string[];
+  evidence: { ok: true; writtenTo: string } | { ok: false; error: string } | null;
+} {
+  const parts: string[] = [];
+
+  let migration: ReturnType<typeof migrateExistingPagesForEvidence> | null = null;
+  try {
+    const pluginIds = listPlugins().map((p) => p.id);
+    migration = migrateExistingPagesForEvidence(wiki, pluginIds);
+  } catch { /* never fails the rebuild */ }
+  if (migration && !migration.alreadyMigrated && migration.totalPages > 0) {
+    parts.push(
+      `Evidence migration: ${migration.totalPages} pages — ` +
+        `${migration.grounded} grounded, ` +
+        `${migration.syntheses + migration.preExistingSynthesis} synthesis, ` +
+        `${migration.legacy} legacy-unsupported`,
+    );
+  }
+
+  try {
+    const week = summarizeLastWeek(wiki.config.workspace);
+    if (week.totalWrites > 0 || week.unsupportedTransitions > 0) {
+      const ratioStr =
+        week.wouldRejectRatio === null
+          ? ""
+          : ` — ${(week.wouldRejectRatio * 100).toFixed(1)}% blocked-or-would-block under Phase 2b`;
+      wiki.log(
+        "evidence",
+        "log.md",
+        `Last 7 days: ${week.unsupportedWrites} unsupported `
+          + `+ ${week.rejectedWrites} rejected `
+          + `/ ${week.totalWrites} wiki_write(s) `
+          + `(${week.unsupportedTransitions} new unsupported pages)`
+          + `${ratioStr}.`,
+      );
+    }
+  } catch { /* never fails the rebuild */ }
+
+  const evidence = opts.regenerateReport ? regenerateEvidenceReport(wiki) : null;
+  return { parts, evidence };
 }
 
 export async function handleTool(
@@ -2335,11 +2398,12 @@ export async function handleTool(
     }
 
     case "wiki_evidence_report": {
-      // Strict boolean match — mirrors the batch-handler coercion at the
-      // wiki_admin rebuild evidence_report:true sniff so the two flags
-      // agree on what "true" means for direct (non-MCP) callers too.
-      const write = args.write === true;
-      const result = runEvidenceReport(wiki, { write });
+      const write = (args.write as boolean) ?? false;
+      // Split the branch so the call resolves to one of the narrowed
+      // overloads (write:true narrows writtenTo to string).
+      const result = write
+        ? runEvidenceReport(wiki, { write: true })
+        : runEvidenceReport(wiki, { write: false });
       return JSON.stringify({
         report: result.report,
         markdown: result.markdown,
@@ -2441,18 +2505,6 @@ export async function handleTool(
         vectorStats = await wiki.rebuildVectorIndex().catch(() => undefined);
       }
 
-      // Evidence-first phase 2a: one-shot migration of pre-existing pages
-      // (gated by marker file under .agent-wiki/) so existing compiler
-      // artifacts and user pages don't all flag as "unsupported" the day
-      // phase 2a ships. Also emit a one-line weekly count of unsupported
-      // writes into wiki/log.md so the maintainer has a running signal
-      // ahead of the phase 4 dashboard.
-      let migration: ReturnType<typeof migrateExistingPagesForEvidence> | null = null;
-      try {
-        const pluginIds = listPlugins().map((p) => p.id);
-        migration = migrateExistingPagesForEvidence(wiki, pluginIds);
-      } catch { /* ignore — evidence bookkeeping never fails a rebuild */ }
-
       const parts: string[] = ["Index and timeline rebuilt"];
       if (graphStats) {
         parts.push(`Knowledge graph: ${graphStats.nodes} nodes, ${graphStats.edges} edges`);
@@ -2460,46 +2512,33 @@ export async function handleTool(
       if (vectorStats) {
         parts.push(`Vector index: ${vectorStats.pagesProcessed} pages embedded${vectorStats.errors > 0 ? `, ${vectorStats.errors} errors` : ""}`);
       }
-      if (migration && !migration.alreadyMigrated && migration.totalPages > 0) {
-        parts.push(
-          `Evidence migration: ${migration.totalPages} pages — ` +
-          `${migration.grounded} grounded, ` +
-          `${migration.syntheses + migration.preExistingSynthesis} synthesis, ` +
-          `${migration.legacy} legacy-unsupported`
-        );
+
+      // Single source of truth for post-rebuild evidence bookkeeping;
+      // batch's end-of-batch path invokes the same helper for parity.
+      const regenerateReport = (args.evidence_report as boolean) ?? false;
+      const bookkeeping = runPostRebuildEvidence(wiki, { regenerateReport });
+      parts.push(...bookkeeping.parts);
+      if (bookkeeping.evidence) {
+        parts.push(bookkeeping.evidence.ok
+          ? `Evidence report written to ${bookkeeping.evidence.writtenTo}`
+          : `Evidence report regeneration failed: ${bookkeeping.evidence.error}`);
       }
 
-      try {
-        const week = summarizeLastWeek(wiki.config.workspace);
-        if (week.totalWrites > 0 || week.unsupportedTransitions > 0) {
-          const ratioStr =
-            week.wouldRejectRatio === null
-              ? ""
-              : ` — ${(week.wouldRejectRatio * 100).toFixed(1)}% blocked-or-would-block under Phase 2b`;
-          wiki.log(
-            "evidence",
-            "log.md",
-            `Last 7 days: ${week.unsupportedWrites} unsupported `
-              + `+ ${week.rejectedWrites} rejected `
-              + `/ ${week.totalWrites} wiki_write(s) `
-              + `(${week.unsupportedTransitions} new unsupported pages)`
-              + `${ratioStr}.`,
-          );
-        }
-      } catch { /* ignore */ }
-
-      // Opt-in: regenerate the evidence report alongside the rebuild so the
-      // dashboard stays fresh without a separate wiki_admin evidence-report
-      // call. See regenerateEvidenceReport's docblock for the operator-
-      // surface-failure contract; the batch path mirrors this exact shape.
-      if (args.evidence_report === true) {
-        const evResult = regenerateEvidenceReport(wiki);
-        parts.push(evResult.ok
-          ? `Evidence report written to ${evResult.writtenTo}`
-          : `Evidence report regeneration failed: ${evResult.error}`);
+      // On regen failure, surface a structured field alongside ok:true so
+      // programmatic callers can detect partial-success without sniffing
+      // the message string. Matches the batch handler's deferred-entry
+      // shape (`evidenceReport: { ok: false, error }`).
+      const response: Record<string, unknown> = {
+        ok: true,
+        message: parts.join(". ") + ".",
+      };
+      if (bookkeeping.evidence && !bookkeeping.evidence.ok) {
+        response.evidenceReport = {
+          ok: false,
+          error: bookkeeping.evidence.error,
+        };
       }
-
-      return JSON.stringify({ ok: true, message: parts.join(". ") + "." });
+      return JSON.stringify(response);
     }
 
     // wiki_classify removed — wiki_write auto-classifies
@@ -3139,7 +3178,11 @@ export async function handleTool(
             result: { ok: true, deferred: "merged into end-of-batch rebuild" },
           };
           results.push(entry);
-          if (op.args?.evidence_report === true) {
+          // Match the in-handler `(args.X as boolean) ?? false` convention
+          // (e.g. wiki_lint's apply_fixes) so the same input shape produces
+          // the same behavior across every wiki_admin entry point.
+          const opEvidenceReport = (op.args?.evidence_report as boolean) ?? false;
+          if (opEvidenceReport) {
             needsEvidenceReport = true;
             rebuildEntriesAwaitingEvidence.push(entry);
           }
@@ -3198,19 +3241,13 @@ export async function handleTool(
         const pageCache = wiki.buildPageCache();
         wiki.rebuildIndex(pageCache);
         if (needsTimeline) wiki.rebuildTimeline(pageCache);
-        // Mirror inline rebuild's evidence migration step. Without this,
-        // batch-generated evidence reports misclassify pre-migration legacy
-        // pages as `other` instead of `legacyUnsupported`. Migration is
-        // marker-file-gated and one-shot, so the call is a no-op after the
-        // first run on any given workspace.
-        try {
-          const pluginIds = listPlugins().map((p) => p.id);
-          migrateExistingPagesForEvidence(wiki, pluginIds);
-        } catch { /* never fails the rebuild */ }
-      }
-      if (needsEvidenceReport) {
-        const evResult = regenerateEvidenceReport(wiki);
-        if (!evResult.ok) {
+        // Single source of truth for migration + weekly log + optional
+        // regen — same helper the inline rebuild path uses, so the two
+        // produce equivalent side effects (log.md, .agent-wiki/ marker).
+        const bookkeeping = runPostRebuildEvidence(wiki, {
+          regenerateReport: needsEvidenceReport,
+        });
+        if (bookkeeping.evidence && !bookkeeping.evidence.ok) {
           // Surface failure in-place on the deferred entry so the caller
           // gets one result per op, keeping `count: results.length` honest
           // and the shape uniform with the rest of this handler.
@@ -3218,7 +3255,7 @@ export async function handleTool(
             const prior = entry.result as Record<string, unknown>;
             entry.result = {
               ...prior,
-              evidenceReport: { ok: false, error: evResult.error },
+              evidenceReport: { ok: false, error: bookkeeping.evidence.error },
             };
           }
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -386,9 +386,9 @@ export function createServer(wikiPath?: string, workspace?: string): Server {
           "Wiki administration and maintenance. Select `action` to control behavior:\n" +
           "- `init`: Initialize a new knowledge base — creates wiki/, raw/, schemas/ directories and default templates.\n" +
           "- `config`: Show current workspace configuration: directories, lint settings, search settings, entity templates.\n" +
-          "- `rebuild`: Rebuild index.md, timeline.md, code knowledge graphs, and optionally the vector index (when search.hybrid is enabled).\n" +
+          "- `rebuild`: Rebuild index.md, timeline.md, code knowledge graphs, and optionally the vector index (when search.hybrid is enabled). Set evidence_report=true to also regenerate the evidence report and persist it to wiki/evidence-report.md as part of the rebuild.\n" +
           "- `lint`: Run comprehensive health checks: contradictions, orphan pages, broken links, raw file integrity (SHA-256), synthesis page integrity. Set apply_fixes=true to auto-repair fixable issues.\n" +
-          "- `evidence-report`: Aggregate evidence-first telemetry into a corpus-level Markdown report (source coverage, lineage diagnostics, 4-week write trend). Set write=true to also persist the report to wiki/evidence-report.md.",
+          "- `evidence-report`: Aggregate evidence-first telemetry into a corpus-level Markdown report (source coverage, lineage diagnostics, 4-week write trend, Phase 2b readiness gates). Set write=true to also persist the report to wiki/evidence-report.md.",
         inputSchema: {
           type: "object" as const,
           properties: {
@@ -412,6 +412,10 @@ export function createServer(wikiPath?: string, workspace?: string): Server {
             write: {
               type: "boolean",
               description: "[evidence-report] If true, persist the report to wiki/evidence-report.md in addition to returning it. Default: false.",
+            },
+            evidence_report: {
+              type: "boolean",
+              description: "[rebuild] If true, also regenerate the evidence report and persist it to wiki/evidence-report.md as part of the rebuild. Useful for keeping the dashboard fresh without a separate evidence-report call. Default: false.",
             },
           },
           required: ["action"],
@@ -2461,6 +2465,20 @@ export async function handleTool(
           );
         }
       } catch { /* ignore */ }
+
+      // Opt-in: regenerate the evidence report alongside the rebuild so the
+      // dashboard stays fresh without a separate wiki_admin evidence-report
+      // call. Best-effort — never fails the rebuild.
+      let evidenceReportWritten: string | undefined;
+      if ((args.evidence_report as boolean) === true) {
+        try {
+          const er = runEvidenceReport(wiki, { write: true });
+          evidenceReportWritten = er.writtenTo;
+        } catch { /* ignore — evidence bookkeeping never fails a rebuild */ }
+      }
+      if (evidenceReportWritten) {
+        parts.push(`Evidence report written to ${evidenceReportWritten}`);
+      }
 
       return JSON.stringify({ ok: true, message: parts.join(". ") + "." });
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1815,9 +1815,13 @@ function regenerateEvidenceReport(
   wiki: Wiki,
 ): { ok: true; writtenTo: string } | { ok: false; error: string } {
   try {
-    // The `write: true` overload narrows `writtenTo` to `string`, so no
-    // unreachable fallback is needed here.
     const er = runEvidenceReport(wiki, { write: true });
+    // `write: true` always sets `writtenTo`; the null-check is here only
+    // because the public signature keeps `writtenTo?: string` rather than
+    // paying for overloads to narrow it for a single caller.
+    if (!er.writtenTo) {
+      return { ok: false, error: "runEvidenceReport(write:true) returned no writtenTo path" };
+    }
     return { ok: true, writtenTo: er.writtenTo };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -2399,11 +2403,7 @@ export async function handleTool(
 
     case "wiki_evidence_report": {
       const write = (args.write as boolean) ?? false;
-      // Split the branch so the call resolves to one of the narrowed
-      // overloads (write:true narrows writtenTo to string).
-      const result = write
-        ? runEvidenceReport(wiki, { write: true })
-        : runEvidenceReport(wiki, { write: false });
+      const result = runEvidenceReport(wiki, { write });
       return JSON.stringify({
         report: result.report,
         markdown: result.markdown,
@@ -3240,6 +3240,10 @@ export async function handleTool(
       if (needsRebuild) {
         const pageCache = wiki.buildPageCache();
         wiki.rebuildIndex(pageCache);
+        // Yield to the event loop so the MCP transport can answer client
+        // pings between the two rebuilds. Mirrors the inline rebuild path
+        // (relevant on slow filesystems like OneDrive-synced workspaces).
+        await new Promise((r) => setImmediate(r));
         if (needsTimeline) wiki.rebuildTimeline(pageCache);
         // Single source of truth for migration + weekly log + optional
         // regen — same helper the inline rebuild path uses, so the two


### PR DESCRIPTION
## Summary

- Operationalise the Phase 2b flip decision: the evidence report now publishes a `phase2bReadiness` verdict (`ready` / `not-ready` / `insufficient-data`) against three concrete numeric gates instead of leaving "once the would-reject ratio settles" as a vibe call.
- Connect existing pieces — no new MCP tool, no new agent-visible field. The verdict lives in `wiki_admin evidence-report` output (operator-facing), and `wiki_admin rebuild` gains an opt-in `evidence_report: true` flag so the dashboard can stay fresh as part of a regular rebuild.
- Document the gates and the flip workflow in `docs/evidence-envelope.md` so the numbers are explicit rather than implicit.

### Gates

| Gate | Threshold | Window |
|------|-----------|--------|
| Total writes | ≥ 50 | last 4 weeks |
| Weekly `wouldRejectRatio` | < 5% per week | each of the last 4 weeks (weeks with 0 writes pass by default) |
| Search abstain ratio | ≤ 30% | last 30 days, requires ≥ 10 searches |

Below-50-total flags as `insufficient-data` (statistically thin); a single bad week or a high search abstain rate flags as `not-ready`. Conservative on purpose — a false-positive `ready` would block legitimate writes.

When `status: ready` and `currentlyEnabled: no`, the rendered report includes the exact `AGENT_WIKI_EVIDENCE_REJECT_UNSUPPORTED=true` knob to flip.

## Test plan

- [x] Unit tests for `assessPhase2bReadiness` cover: insufficient-data, ready, not-ready (weekly ratio), zero-write weeks passing by default, search-gate skipping under threshold, search-gate triggering above threshold, `currentlyEnabled` reflecting wiki config
- [x] Render tests cover: section appears in every report, per-week table rows with ✓/✗, flip-tip appears only when ready+not-enabled, flip-tip suppressed when already enabled
- [x] Server tests cover: `wiki_admin --action rebuild evidence_report:true` writes `wiki/evidence-report.md` and includes the Phase 2b section; rebuild without the flag leaves the file untouched
- [x] Full suite green: 55 files / 2159 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
